### PR TITLE
soroban-rpc: Fix bug in OpenSQLiteDB()

### DIFF
--- a/cmd/soroban-rpc/internal/ledgerentry_storage/db.go
+++ b/cmd/soroban-rpc/internal/ledgerentry_storage/db.go
@@ -66,6 +66,7 @@ func OpenSQLiteDB(dbFilePath string) (DB, error) {
 
 	if err = runMigrations(ret.db.DB, "sqlite3"); err != nil {
 		_ = db.Close()
+		return nil, errors.Wrap(err, "could not run migrations")
 	}
 
 	return ret, nil


### PR DESCRIPTION

Currently `OpenSQLiteDB()` swallows any errors caused by running migrations and doesn't propagate migration errors up to the caller. Additionally, this bug also results in returning a closed db connection from `OpenSQLiteDB()`.

