### PR TITLE
cmd/soroban-rpc/internal/db: fix TestConcurrentReadersAndWriter

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry_test.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry_test.go
@@ -20,6 +20,10 @@ func getLedgerEntryAndLatestLedgerSequenceWithErr(db *sqlx.DB, key xdr.LedgerKey
 	if err != nil {
 		return false, xdr.LedgerEntry{}, 0, err
 	}
+	var doneErr error
+	defer func() {
+		doneErr = tx.Done()
+	}()
 
 	latestSeq, err := tx.GetLatestLedgerSequence()
 	if err != nil {
@@ -31,10 +35,7 @@ func getLedgerEntryAndLatestLedgerSequenceWithErr(db *sqlx.DB, key xdr.LedgerKey
 		return false, xdr.LedgerEntry{}, 0, err
 	}
 
-	if err := tx.Done(); err != nil {
-		return false, xdr.LedgerEntry{}, 0, err
-	}
-	return present, entry, latestSeq, nil
+	return present, entry, latestSeq, doneErr
 }
 
 func getLedgerEntryAndLatestLedgerSequence(db *sqlx.DB, key xdr.LedgerKey) (bool, xdr.LedgerEntry, uint32) {


### PR DESCRIPTION
### What

Remove the code added in https://github.com/stellar/soroban-tools/pull/368 to periodically execute WAL checkpoints instead of executing them after every ingestion transaction.

I thought that the WAL checkpoints were degrading performance but it turns out that was because there were long lived read transactions in TestConcurrentReadersAndWriter that were not getting closed.

Close https://github.com/stellar/soroban-tools/issues/380

