### PR TITLE
soroban-rpc: Fix rollback errors in logs

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledger_test.go
+++ b/cmd/soroban-rpc/internal/db/ledger_test.go
@@ -67,6 +67,8 @@ func TestLedgers(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, tx.LedgerWriter().InsertLedger(createLedger(ledgerSequence)))
 		assert.NoError(t, tx.Commit(ledgerSequence))
+		// rolling back after a commit is a no-op
+		assert.NoError(t, tx.Rollback())
 	}
 
 	assertLedgerRange(t, reader, 1, 10)


### PR DESCRIPTION
### What

During ingestion we can see the following logs:

WARN[2023-02-06T21:16:22.733+01:00] could not rollback ingest write transactions  error="sql: transaction has already been committed or rolled back" pid=78232

This commit will ignore sql.ErrTxDone errors when rolling back a transaction.

