### PR TITLE
soroban-rpc: Use latest 1.20 go version to build soroban-rpc docker image

### DIFF
--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as build
+FROM golang:1.20 as build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
 


### PR DESCRIPTION
### What

Use latest 1.20 go version to build soroban-rpc docker image.

### Why

So we can benefit from security fixes that are released in patch versions.

### Known limitations

[N/A]
