### PR TITLE
soroban-rpc: Use support/db package to interact with sqlite

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -10,11 +10,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jmoiron/sqlx"
-
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
+	dbsession "github.com/stellar/go/support/db"
 	supportlog "github.com/stellar/go/support/log"
 
 	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal"
@@ -36,7 +35,7 @@ const (
 type Daemon struct {
 	core                *ledgerbackend.CaptiveStellarCore
 	ingestService       *ingest.Service
-	db                  *sqlx.DB
+	db                  dbsession.SessionInterface
 	handler             *internal.Handler
 	logger              *supportlog.Entry
 	preflightWorkerPool *preflight.PreflightWorkerPool
@@ -46,7 +45,7 @@ func (d *Daemon) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	d.handler.ServeHTTP(writer, request)
 }
 
-func (d *Daemon) GetDB() *sqlx.DB {
+func (d *Daemon) GetDB() dbsession.SessionInterface {
 	return d.db
 }
 

--- a/cmd/soroban-rpc/internal/db/db.go
+++ b/cmd/soroban-rpc/internal/db/db.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
 	migrate "github.com/rubenv/sql-migrate"
 
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -38,31 +38,28 @@ type WriteTx interface {
 	Rollback() error
 }
 
-func OpenSQLiteDB(dbFilePath string) (*sqlx.DB, error) {
+func OpenSQLiteDB(dbFilePath string) (db.SessionInterface, error) {
 	// 1. Use Write-Ahead Logging (WAL).
 	// 2. Disable WAL auto-checkpointing (we will do the checkpointing ourselves with wal_checkpoint pragmas
 	//    after every write transaction).
 	// 3. Use synchronous=NORMAL, which is faster and still safe in WAL mode.
-	db, err := sqlx.Open("sqlite3", fmt.Sprintf("file:%s?_journal_mode=WAL&_wal_autocheckpoint=0&_synchronous=NORMAL", dbFilePath))
+	session, err := db.Open("sqlite3", fmt.Sprintf("file:%s?_journal_mode=WAL&_wal_autocheckpoint=0&_synchronous=NORMAL", dbFilePath))
 	if err != nil {
 		return nil, errors.Wrap(err, "open failed")
 	}
 
-	if err = runMigrations(db.DB, "sqlite3"); err != nil {
-		_ = db.Close()
+	if err = runMigrations(session.DB.DB, "sqlite3"); err != nil {
+		_ = session.Close()
 		return nil, errors.Wrap(err, "could not run migrations")
 	}
 
-	return db, nil
+	return session, nil
 }
 
-func getLatestLedgerSequence(ctx context.Context, q sqlx.QueryerContext) (uint32, error) {
-	sqlStr, args, err := sq.Select("value").From(metaTableName).Where(sq.Eq{"key": latestLedgerSequenceMetaKey}).ToSql()
-	if err != nil {
-		return 0, err
-	}
+func getLatestLedgerSequence(ctx context.Context, q db.SessionInterface) (uint32, error) {
+	sql := sq.Select("value").From(metaTableName).Where(sq.Eq{"key": latestLedgerSequenceMetaKey})
 	var results []string
-	if err = sqlx.SelectContext(ctx, q, &results, sqlStr, args...); err != nil {
+	if err := q.Select(ctx, &results, sql); err != nil {
 		return 0, err
 	}
 	switch len(results) {
@@ -82,7 +79,7 @@ func getLatestLedgerSequence(ctx context.Context, q sqlx.QueryerContext) (uint32
 }
 
 type readWriter struct {
-	db                    *sqlx.DB
+	db                    db.SessionInterface
 	maxBatchSize          int
 	ledgerRetentionWindow uint32
 }
@@ -91,7 +88,7 @@ type readWriter struct {
 // the size of ledger entry batches when writing ledger entries
 // and the retention window for how many historical ledgers are
 // recorded in the database.
-func NewReadWriter(db *sqlx.DB, maxBatchSize int, ledgerRetentionWindow uint32) ReadWriter {
+func NewReadWriter(db db.SessionInterface, maxBatchSize int, ledgerRetentionWindow uint32) ReadWriter {
 	return &readWriter{
 		db:                    db,
 		maxBatchSize:          maxBatchSize,
@@ -104,18 +101,18 @@ func (rw *readWriter) GetLatestLedgerSequence(ctx context.Context) (uint32, erro
 }
 
 func (rw *readWriter) NewTx(ctx context.Context) (WriteTx, error) {
-	tx, err := rw.db.BeginTxx(ctx, nil)
-	if err != nil {
+	txSession := rw.db.Clone()
+	if err := txSession.Begin(ctx); err != nil {
 		return nil, err
 	}
-	stmtCache := sq.NewStmtCache(tx)
+	stmtCache := sq.NewStmtCache(txSession.GetTx())
 	db := rw.db
 	return writeTx{
 		postCommit: func() error {
-			_, err = db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
+			_, err := db.ExecRaw(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
 			return err
 		},
-		tx:           tx,
+		tx:           txSession,
 		stmtCache:    stmtCache,
 		ledgerWriter: ledgerWriter{stmtCache: stmtCache},
 		ledgerEntryWriter: ledgerEntryWriter{
@@ -130,7 +127,7 @@ func (rw *readWriter) NewTx(ctx context.Context) (WriteTx, error) {
 
 type writeTx struct {
 	postCommit            func() error
-	tx                    *sqlx.Tx
+	tx                    db.SessionInterface
 	stmtCache             *sq.StmtCache
 	ledgerEntryWriter     ledgerEntryWriter
 	ledgerWriter          ledgerWriter
@@ -168,10 +165,10 @@ func (w writeTx) Commit(ledgerSeq uint32) error {
 }
 
 func (w writeTx) Rollback() error {
-	// sql.ErrTxDone is returned when rolling back a transaction which has
+	// errors.New("not in transaction") is returned when rolling back a transaction which has
 	// already been committed or rolled back. We can ignore those errors
 	// because we allow rolling back after commits in defer statements.
-	if err := w.tx.Rollback(); err == nil || err == sql.ErrTxDone {
+	if err := w.tx.Rollback(); err == nil || err.Error() == "not in transaction" {
 		return nil
 	} else {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20230331111359-53b82066a0f8
+	github.com/stellar/go v0.0.0-20230410132830-a9de2a21d17b
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/mod v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230331111359-53b82066a0f8 h1:nXubIrtf//uIcWX1YRxZwfvCq+2V3hpSMjyaQY+vwaM=
-github.com/stellar/go v0.0.0-20230331111359-53b82066a0f8/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230410132830-a9de2a21d17b h1:dgLmJicMZtOBbuAUZ9ggkmay5fFC4LNmjQXDbBjZmXc=
+github.com/stellar/go v0.0.0-20230410132830-a9de2a21d17b/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

Use the `support/db` package from the go monorepo to interact with sqlite instead of the lower level sqlx package.

### Why

There is a metrics [wrapper](https://github.com/stellar/go/blob/master/support/db/metrics.go#L63) for`db.Session` which can be used by soroban-rpc to get a bunch of useful db metrics out of the box. These metrics are necessary for https://github.com/stellar/soroban-tools/issues/496

### Known limitations

[N/A]
