### PR TITLE
Add --console flag when running core during integration tests

### DIFF
--- a/cmd/soroban-rpc/internal/test/core-start.sh
+++ b/cmd/soroban-rpc/internal/test/core-start.sh
@@ -26,4 +26,4 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-exec stellar-core run
+exec stellar-core run --console


### PR DESCRIPTION

### What

Add --console flag when running core during integration tests.

### Why

This flag will make it so the core container will print all its logs to stdout which is very useful for debugging.

### Known limitations

[N/A]
