### PR TITLE
fix: switch to stderr directly for when account already exists

### DIFF
--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -213,7 +213,7 @@ impl Network {
         tracing::debug!("{res:#?}");
         if let Some(detail) = res.get("detail").and_then(Value::as_str) {
             if detail.contains("createAccountAlreadyExist") {
-                tracing::warn!("Account already exists");
+                eprintln!("Account already exists");
             }
         } else if res.get("successful").is_none() {
             return Err(Error::InproperResponse(res.to_string()));


### PR DESCRIPTION
### What

Switch from `tracing::warn` to `eprintln`

### Why

It didn't make it into stderr in tests.

### Known limitations

[TODO or N/A]
