### PR TITLE
Fix/stellar asset bindings

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration.rs
+++ b/cmd/crates/soroban-test/tests/it/integration.rs
@@ -3,3 +3,4 @@ mod dotenv;
 mod hello_world;
 mod util;
 mod wrap;
+mod bindings;

--- a/cmd/crates/soroban-test/tests/it/integration.rs
+++ b/cmd/crates/soroban-test/tests/it/integration.rs
@@ -1,6 +1,6 @@
+mod bindings;
 mod custom_types;
 mod dotenv;
 mod hello_world;
 mod util;
 mod wrap;
-mod bindings;

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -29,4 +29,7 @@ async fn invoke_test_generate_typescript_bindings() {
 
     let files = std::fs::read_dir(output_dir).expect("Failed to read output directory");
     assert!(files.count() > 0, "No files generated in the output directory");
+
+    // Clean up: remove the output directory and its contents
+    std::fs::remove_dir_all(OUTPUT_DIR).expect("Failed to delete output directory");
 }

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -1,0 +1,32 @@
+use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
+use super::util::deploy_swap;
+
+pub const OUTPUT_DIR: &str = "./bindings-output";
+
+
+#[tokio::test]
+async fn invoke_test_generate_typescript_bindings() {
+    let sandbox = &TestEnv::new();
+    let contract_id = deploy_swap(sandbox).await;
+    let cmd = sandbox.cmd_arr::<soroban_cli::commands::contract::bindings::typescript::Cmd>(&[
+        "--network-passphrase",
+        LOCAL_NETWORK_PASSPHRASE,
+        "--rpc-url",
+        &sandbox.rpc_url,
+        "--output-dir",
+        OUTPUT_DIR,
+        "--overwrite",
+        "--contract-id",
+        &contract_id.to_string(),
+    ]);
+
+    let result = sandbox.run_cmd_with(cmd, "test").await;
+
+    assert!(result.is_ok(), "Failed to generate TypeScript bindings");
+
+    let output_dir = std::path::Path::new(OUTPUT_DIR);
+    assert!(output_dir.exists(), "Output directory does not exist");
+
+    let files = std::fs::read_dir(output_dir).expect("Failed to read output directory");
+    assert!(files.count() > 0, "No files generated in the output directory");
+}

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -31,5 +31,4 @@ async fn invoke_test_generate_typescript_bindings() {
         files.count() > 0,
         "No files generated in the output directory"
     );
-
 }

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -1,8 +1,7 @@
-use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
 use super::util::deploy_swap;
+use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
 
 const OUTPUT_DIR: &str = "./bindings-output";
-
 
 #[tokio::test]
 async fn invoke_test_generate_typescript_bindings() {
@@ -28,7 +27,10 @@ async fn invoke_test_generate_typescript_bindings() {
     assert!(output_dir.exists(), "Output directory does not exist");
 
     let files = std::fs::read_dir(output_dir).expect("Failed to read output directory");
-    assert!(files.count() > 0, "No files generated in the output directory");
+    assert!(
+        files.count() > 0,
+        "No files generated in the output directory"
+    );
 
     // Clean up: remove the output directory and its contents
     std::fs::remove_dir_all(OUTPUT_DIR).expect("Failed to delete output directory");

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -7,13 +7,14 @@ const OUTPUT_DIR: &str = "./bindings-output";
 async fn invoke_test_generate_typescript_bindings() {
     let sandbox = &TestEnv::new();
     let contract_id = deploy_swap(sandbox).await;
+    let outdir = sandbox.dir().join(OUTPUT_DIR);
     let cmd = sandbox.cmd_arr::<soroban_cli::commands::contract::bindings::typescript::Cmd>(&[
         "--network-passphrase",
         LOCAL_NETWORK_PASSPHRASE,
         "--rpc-url",
         &sandbox.rpc_url,
         "--output-dir",
-        OUTPUT_DIR,
+        &outdir.display().to_string(),
         "--overwrite",
         "--contract-id",
         &contract_id.to_string(),
@@ -23,15 +24,12 @@ async fn invoke_test_generate_typescript_bindings() {
 
     assert!(result.is_ok(), "Failed to generate TypeScript bindings");
 
-    let output_dir = std::path::Path::new(OUTPUT_DIR);
-    assert!(output_dir.exists(), "Output directory does not exist");
+    assert!(outdir.exists(), "Output directory does not exist");
 
-    let files = std::fs::read_dir(output_dir).expect("Failed to read output directory");
+    let files = std::fs::read_dir(outdir).expect("Failed to read output directory");
     assert!(
         files.count() > 0,
         "No files generated in the output directory"
     );
 
-    // Clean up: remove the output directory and its contents
-    std::fs::remove_dir_all(OUTPUT_DIR).expect("Failed to delete output directory");
 }

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -1,7 +1,7 @@
 use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
 use super::util::deploy_swap;
 
-pub const OUTPUT_DIR: &str = "./bindings-output";
+const OUTPUT_DIR: &str = "./bindings-output";
 
 
 #[tokio::test]

--- a/cmd/crates/soroban-test/tests/it/integration/util.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/util.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 
 pub const HELLO_WORLD: &Wasm = &Wasm::Custom("test-wasms", "test_hello_world");
 pub const CUSTOM_TYPES: &Wasm = &Wasm::Custom("test-wasms", "test_custom_types");
+pub const SWAP: &Wasm = &Wasm::Custom("test-wasms", "test_swap");
 
 pub async fn invoke_with_roundtrip<D>(e: &TestEnv, id: &str, func: &str, data: D)
 where
@@ -26,6 +27,10 @@ pub async fn deploy_hello(sandbox: &TestEnv) -> String {
 
 pub async fn deploy_custom(sandbox: &TestEnv) -> String {
     deploy_contract(sandbox, CUSTOM_TYPES).await
+}
+
+pub async fn deploy_swap(sandbox: &TestEnv) -> String {
+    deploy_contract(sandbox, SWAP).await
 }
 
 pub async fn deploy_contract(sandbox: &TestEnv, wasm: &Wasm<'static>) -> String {

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -5,12 +5,17 @@ use soroban_spec_tools::contract as contract_spec;
 use soroban_spec_typescript::{self as typescript, boilerplate::Project};
 use stellar_strkey::DecodeError;
 
-use crate::{commands::{
-    config::{self, locator}, contract::fetch, 
-    global, network::{self, Network}, 
-    NetworkRunnable
-}, get_spec::{self, get_remote_contract_spec}};
 use crate::wasm;
+use crate::{
+    commands::{
+        config::{self, locator},
+        contract::fetch,
+        global,
+        network::{self, Network},
+        NetworkRunnable,
+    },
+    get_spec::{self, get_remote_contract_spec},
+};
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -67,7 +72,7 @@ pub enum Error {
     #[error("Missing RPC Url")]
     MissingRpcUrl,
     #[error(transparent)]
-    UtilsError(#[from] get_spec::Error)
+    UtilsError(#[from] get_spec::Error),
 }
 
 #[async_trait::async_trait]
@@ -88,11 +93,14 @@ impl NetworkRunnable for Cmd {
                 .map_err(|e| Error::CannotParseContractId(self.contract_id.clone(), e))?;
             let spec_entries = get_remote_contract_spec(
                 &contract_id,
-                self.network.rpc_url.as_deref().ok_or(Error::MissingRpcUrl)?,
-                global_args
+                self.network
+                    .rpc_url
+                    .as_deref()
+                    .ok_or(Error::MissingRpcUrl)?,
+                global_args,
             )
-                .await
-                .map_err(Error::from)?; 
+            .await
+            .map_err(Error::from)?;
             spec_entries
         };
         if self.output_dir.is_file() {

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -83,7 +83,7 @@ impl NetworkRunnable for Cmd {
     async fn run_against_rpc_server(
         &self,
         global_args: Option<&global::Args>,
-        _config: Option<&config::Args>,
+        config: Option<&config::Args>,
     ) -> Result<(), Error> {
         let spec = if let Some(wasm) = &self.wasm {
             let wasm: wasm::Args = wasm.into();
@@ -93,11 +93,10 @@ impl NetworkRunnable for Cmd {
                 .map_err(|e| Error::CannotParseContractId(self.contract_id.clone(), e))?;
             let spec_entries = get_remote_contract_spec(
                 &contract_id,
-                self.network
-                    .rpc_url
-                    .as_deref()
-                    .ok_or(Error::MissingRpcUrl)?,
+                self.locator.clone(),
+                self.network.clone(),
                 global_args,
+                config,
             )
             .await
             .map_err(Error::from)?;

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -91,8 +91,8 @@ impl NetworkRunnable for Cmd {
                 .map_err(|e| Error::CannotParseContractId(self.contract_id.clone(), e))?;
             get_remote_contract_spec(
                 &contract_id,
-                self.locator.clone(),
-                self.network.clone(),
+                &self.locator,
+                &self.network,
                 global_args,
                 config,
             )

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -89,7 +89,7 @@ impl NetworkRunnable for Cmd {
         } else {
             let contract_id = soroban_spec_tools::utils::contract_id_from_str(&self.contract_id)
                 .map_err(|e| Error::CannotParseContractId(self.contract_id.clone(), e))?;
-            let spec_entries = get_remote_contract_spec(
+            get_remote_contract_spec(
                 &contract_id,
                 self.locator.clone(),
                 self.network.clone(),
@@ -97,8 +97,7 @@ impl NetworkRunnable for Cmd {
                 config,
             )
             .await
-            .map_err(Error::from)?;
-            spec_entries
+            .map_err(Error::from)?
         };
         if self.output_dir.is_file() {
             return Err(Error::IsFile(self.output_dir.clone()));

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsString, fmt::Debug, path::PathBuf};
 
 use clap::{command, Parser};
-use soroban_spec_tools::contract::{self as contract_spec};
+use soroban_spec_tools::contract as contract_spec;
 use soroban_spec_typescript::{self as typescript, boilerplate::Project};
 use stellar_strkey::DecodeError;
 
@@ -9,7 +9,7 @@ use crate::{commands::{
     config::{self, locator}, contract::fetch, 
     global, network::{self, Network}, 
     NetworkRunnable
-}, utils::{get_remote_contract_spec, UtilsError}};
+}, get_spec::{get_remote_contract_spec, GetSpecError}};
 use crate::wasm;
 
 #[derive(Parser, Debug, Clone)]
@@ -67,7 +67,7 @@ pub enum Error {
     #[error("Missing RPC Url")]
     MissingRpcUrl,
     #[error(transparent)]
-    UtilsError(#[from] UtilsError)
+    UtilsError(#[from] GetSpecError)
 }
 
 #[async_trait::async_trait]

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -9,7 +9,7 @@ use crate::{commands::{
     config::{self, locator}, contract::fetch, 
     global, network::{self, Network}, 
     NetworkRunnable
-}, get_spec::{get_remote_contract_spec, GetSpecError}};
+}, get_spec::{self, get_remote_contract_spec}};
 use crate::wasm;
 
 #[derive(Parser, Debug, Clone)]
@@ -67,7 +67,7 @@ pub enum Error {
     #[error("Missing RPC Url")]
     MissingRpcUrl,
     #[error(transparent)]
-    UtilsError(#[from] GetSpecError)
+    UtilsError(#[from] get_spec::Error)
 }
 
 #[async_trait::async_trait]

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -69,8 +69,6 @@ pub enum Error {
     FailedToGetFileName(PathBuf),
     #[error("cannot parse contract ID {0}: {1}")]
     CannotParseContractId(String, DecodeError),
-    #[error("Missing RPC Url")]
-    MissingRpcUrl,
     #[error(transparent)]
     UtilsError(#[from] get_spec::Error),
 }

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -37,7 +37,7 @@ use crate::{
     commands::{config::data, global, network},
     rpc, Pwd,
 };
-use crate::utils::{get_remote_contract_spec, UtilsError};
+use crate::get_spec::{get_remote_contract_spec, GetSpecError};
 use soroban_spec_tools::{contract, Spec};
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -151,7 +151,7 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] network::Error),
     #[error(transparent)]
-    UtilsError(#[from] UtilsError)
+    GetSpecError(#[from] GetSpecError)
 }
 
 impl From<Infallible> for Error {

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -33,11 +33,11 @@ use super::super::{
 };
 use crate::commands::txn_result::{TxnEnvelopeResult, TxnResult};
 use crate::commands::NetworkRunnable;
+use crate::get_spec::{self, get_remote_contract_spec};
 use crate::{
     commands::{config::data, global, network},
     rpc, Pwd,
 };
-use crate::get_spec::{self, get_remote_contract_spec};
 use soroban_spec_tools::{contract, Spec};
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -151,7 +151,7 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] network::Error),
     #[error(transparent)]
-    GetSpecError(#[from] get_spec::Error)
+    GetSpecError(#[from] get_spec::Error),
 }
 
 impl From<Infallible> for Error {
@@ -348,8 +348,7 @@ impl NetworkRunnable for Cmd {
 
         let spec_entries = get_remote_contract_spec(&contract_id, &network.rpc_url, global_args)
             .await
-            .map_err(Error::from)?; 
-
+            .map_err(Error::from)?;
 
         // Get the ledger footprint
         let (function, spec, host_function_params, signers) =

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -349,8 +349,8 @@ impl NetworkRunnable for Cmd {
 
         let spec_entries = get_remote_contract_spec(
             &contract_id,
-            unwrap_config.locator.clone(),
-            unwrap_config.network.clone(),
+            &unwrap_config.locator,
+            &unwrap_config.network,
             global_args,
             config,
         )

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -320,6 +320,7 @@ impl NetworkRunnable for Cmd {
         global_args: Option<&global::Args>,
         config: Option<&config::Args>,
     ) -> Result<TxnResult<String>, Error> {
+        let c = config;
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         tracing::trace!(?network);
@@ -346,9 +347,15 @@ impl NetworkRunnable for Cmd {
         let sequence: i64 = account_details.seq_num.into();
         let AccountId(PublicKey::PublicKeyTypeEd25519(account_id)) = account_details.account_id;
 
-        let spec_entries = get_remote_contract_spec(&contract_id, &network.rpc_url, global_args)
-            .await
-            .map_err(Error::from)?;
+        let spec_entries = get_remote_contract_spec(
+            &contract_id,
+            config.locator.clone(),
+            config.network.clone(),
+            global_args,
+            c,
+        )
+        .await
+        .map_err(Error::from)?;
 
         // Get the ledger footprint
         let (function, spec, host_function_params, signers) =

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -386,7 +386,7 @@ impl NetworkRunnable for Cmd {
                 very_verbose,
                 no_cache,
                 ..
-            } = global_args.map(Clone::clone).unwrap_or_default();
+            } = global_args.cloned().unwrap_or_default();
             let res = client
                 .send_assembled_transaction(
                     txn,

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -37,7 +37,7 @@ use crate::{
     commands::{config::data, global, network},
     rpc, Pwd,
 };
-use crate::get_spec::{get_remote_contract_spec, GetSpecError};
+use crate::get_spec::{self, get_remote_contract_spec};
 use soroban_spec_tools::{contract, Spec};
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -151,7 +151,7 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] network::Error),
     #[error(transparent)]
-    GetSpecError(#[from] GetSpecError)
+    GetSpecError(#[from] get_spec::Error)
 }
 
 impl From<Infallible> for Error {

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -1,15 +1,14 @@
 use soroban_env_host::xdr;
 
 use soroban_env_host::xdr::{
-    ContractDataEntry, ContractExecutable, ScSpecEntry, ScVal, ScContractInstance,
+    ContractDataEntry, ContractExecutable, ScContractInstance, ScSpecEntry, ScVal,
 };
 
 use soroban_spec::read::FromWasmError;
 pub use soroban_spec_tools::contract as contract_spec;
 
-use crate::rpc;
 use crate::commands::{config::data, global};
-
+use crate::rpc;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -36,7 +35,7 @@ pub async fn get_remote_contract_spec(
     // Get contract data
     let r = client.get_contract_data(&contract_id).await?;
     tracing::trace!("{r:?}");
-    
+
     let ContractDataEntry {
         val: ScVal::ContractInstance(ScContractInstance { executable, .. }),
         ..
@@ -66,4 +65,3 @@ pub async fn get_remote_contract_spec(
 
     Ok(spec_entries)
 }
-

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -40,7 +40,7 @@ pub async fn get_remote_contract_spec(
     config: Option<&config::Args>,
 ) -> Result<Vec<ScSpecEntry>, Error> {
     let network = config.map_or_else(
-        || network.get(&locator).map_err(Error::from),
+        || network.get(locator).map_err(Error::from),
         |c| c.get_network().map_err(Error::from),
     )?;
     tracing::trace!(?network);

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -8,7 +8,7 @@ use soroban_spec::read::FromWasmError;
 pub use soroban_spec_tools::contract as contract_spec;
 
 use crate::commands::config::{self, locator};
-use crate::commands::network::{self, Network};
+use crate::commands::network;
 use crate::commands::{config::data, global};
 use crate::rpc;
 
@@ -39,10 +39,10 @@ pub async fn get_remote_contract_spec(
     global_args: Option<&global::Args>,
     config: Option<&config::Args>,
 ) -> Result<Vec<ScSpecEntry>, Error> {
-    fn net(network: network::Args, locator: locator::Args) -> Result<Network, Error> {
-        Ok(network.get(&locator)?)
-    }
-    let network = config.map_or_else(|| net(network, locator), |c| Ok(c.get_network()?))?;
+    let network = config.map_or_else(
+    || network.get(&locator).map_err(Error::from),
+        |c| c.get_network().map_err(Error::from),
+    )?;
     tracing::trace!(?network);
     let client = rpc::Client::new(&network.rpc_url)?;
     // Get contract data

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -46,7 +46,7 @@ pub async fn get_remote_contract_spec(
     tracing::trace!(?network);
     let client = rpc::Client::new(&network.rpc_url)?;
     // Get contract data
-    let r = client.get_contract_data(&contract_id).await?;
+    let r = client.get_contract_data(contract_id).await?;
     tracing::trace!("{r:?}");
 
     let ContractDataEntry {
@@ -64,7 +64,7 @@ pub async fn get_remote_contract_spec(
             if let Ok(entries) = data::read_spec(&hash) {
                 entries
             } else {
-                let res = client.get_remote_contract_spec(&contract_id).await?;
+                let res = client.get_remote_contract_spec(contract_id).await?;
                 if global_args.map_or(true, |a| !a.no_cache) {
                     data::write_spec(&hash, &res)?;
                 }

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -40,7 +40,7 @@ pub async fn get_remote_contract_spec(
     config: Option<&config::Args>,
 ) -> Result<Vec<ScSpecEntry>, Error> {
     let network = config.map_or_else(
-    || network.get(&locator).map_err(Error::from),
+        || network.get(&locator).map_err(Error::from),
         |c| c.get_network().map_err(Error::from),
     )?;
     tracing::trace!(?network);

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -34,8 +34,8 @@ pub enum Error {
 /// # Errors
 pub async fn get_remote_contract_spec(
     contract_id: &[u8; 32],
-    locator: locator::Args,
-    network: network::Args,
+    locator: &locator::Args,
+    network: &network::Args,
     global_args: Option<&global::Args>,
     config: Option<&config::Args>,
 ) -> Result<Vec<ScSpecEntry>, Error> {

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -1,0 +1,69 @@
+use soroban_env_host::xdr;
+
+use soroban_env_host::xdr::{
+    ContractDataEntry, ContractExecutable, ScSpecEntry, ScVal, ScContractInstance,
+};
+
+use soroban_spec::read::FromWasmError;
+pub use soroban_spec_tools::contract as contract_spec;
+
+use crate::rpc;
+use crate::commands::{config::data, global};
+
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetSpecError {
+    #[error("parsing contract spec: {0}")]
+    CannotParseContractSpec(FromWasmError),
+    #[error(transparent)]
+    Rpc(#[from] rpc::Error),
+    #[error("missing result")]
+    MissingResult,
+    #[error(transparent)]
+    Data(#[from] data::Error),
+    #[error(transparent)]
+    Xdr(#[from] xdr::Error),
+}
+
+///
+/// # Errors
+pub async fn get_remote_contract_spec(
+    contract_id: &[u8; 32],
+    rpc_url: &str,
+    global_args: Option<&global::Args>,
+) -> Result<Vec<ScSpecEntry>, GetSpecError> {
+    let client = rpc::Client::new(rpc_url)?;
+    // Get contract data
+    let r = client.get_contract_data(&contract_id).await?;
+    tracing::trace!("{r:?}");
+    
+    let ContractDataEntry {
+        val: ScVal::ContractInstance(ScContractInstance { executable, .. }),
+        ..
+    } = r
+    else {
+        return Err(GetSpecError::MissingResult);
+    };
+
+    // Get the contract spec entries based on the executable type
+    let spec_entries = match executable {
+        ContractExecutable::Wasm(hash) => {
+            let hash = hash.to_string();
+            if let Ok(entries) = data::read_spec(&hash) {
+                entries
+            } else {
+                let res = client.get_remote_contract_spec(&contract_id).await?;
+                if global_args.map_or(true, |a| !a.no_cache) {
+                    data::write_spec(&hash, &res)?;
+                }
+                res
+            }
+        }
+        ContractExecutable::StellarAsset => {
+            soroban_spec::read::parse_raw(&soroban_sdk::token::StellarAssetSpec::spec_xdr())?
+        }
+    };
+
+    Ok(spec_entries)
+}
+

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -12,7 +12,7 @@ use crate::commands::{config::data, global};
 
 
 #[derive(thiserror::Error, Debug)]
-pub enum GetSpecError {
+pub enum Error {
     #[error("parsing contract spec: {0}")]
     CannotParseContractSpec(FromWasmError),
     #[error(transparent)]
@@ -31,7 +31,7 @@ pub async fn get_remote_contract_spec(
     contract_id: &[u8; 32],
     rpc_url: &str,
     global_args: Option<&global::Args>,
-) -> Result<Vec<ScSpecEntry>, GetSpecError> {
+) -> Result<Vec<ScSpecEntry>, Error> {
     let client = rpc::Client::new(rpc_url)?;
     // Get contract data
     let r = client.get_contract_data(&contract_id).await?;
@@ -42,7 +42,7 @@ pub async fn get_remote_contract_spec(
         ..
     } = r
     else {
-        return Err(GetSpecError::MissingResult);
+        return Err(Error::MissingResult);
     };
 
     // Get the contract spec entries based on the executable type

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -58,7 +58,7 @@ pub async fn get_remote_contract_spec(
     };
 
     // Get the contract spec entries based on the executable type
-    let spec_entries = match executable {
+    Ok(match executable {
         ContractExecutable::Wasm(hash) => {
             let hash = hash.to_string();
             if let Ok(entries) = data::read_spec(&hash) {
@@ -74,7 +74,5 @@ pub async fn get_remote_contract_spec(
         ContractExecutable::StellarAsset => {
             soroban_spec::read::parse_raw(&soroban_sdk::token::StellarAssetSpec::spec_xdr())?
         }
-    };
-
-    Ok(spec_entries)
+    })
 }

--- a/cmd/soroban-cli/src/lib.rs
+++ b/cmd/soroban-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub use cli::main;
 
 pub mod commands;
 pub mod fee;
+pub mod get_spec;
 pub mod key;
 pub mod log;
 pub mod toid;

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -1,20 +1,15 @@
 use ed25519_dalek::Signer;
 use sha2::{Digest, Sha256};
-use soroban_env_host::xdr;
 use stellar_strkey::ed25519::PrivateKey;
 
 use soroban_env_host::xdr::{
-    Asset, ContractDataEntry, ContractExecutable, ContractIdPreimage, DecoratedSignature, Error as XdrError, Hash, HashIdPreimage,
-    HashIdPreimageContractId, Limits, ScSpecEntry, ScVal, ScContractInstance, Signature, SignatureHint, Transaction, TransactionEnvelope,
+    Asset, ContractIdPreimage, DecoratedSignature, Error as XdrError, Hash, HashIdPreimage,
+    HashIdPreimageContractId, Limits, Signature, SignatureHint, Transaction, TransactionEnvelope,
     TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction,
     TransactionV1Envelope, WriteXdr,
 };
 
-use soroban_spec::read::FromWasmError;
 pub use soroban_spec_tools::contract as contract_spec;
-
-use crate::rpc;
-use crate::commands::{config::data, global};
 
 /// # Errors
 ///
@@ -132,62 +127,6 @@ pub fn contract_id_hash_from_asset(
     });
     let preimage_xdr = preimage.to_xdr(Limits::none())?;
     Ok(Hash(Sha256::digest(preimage_xdr).into()))
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum UtilsError {
-    #[error("parsing contract spec: {0}")]
-    CannotParseContractSpec(FromWasmError),
-    #[error(transparent)]
-    Rpc(#[from] rpc::Error),
-    #[error("missing result")]
-    MissingResult,
-    #[error(transparent)]
-    Data(#[from] data::Error),
-    #[error(transparent)]
-    Xdr(#[from] xdr::Error),
-}
-
-///
-/// # Errors
-pub async fn get_remote_contract_spec(
-    contract_id: &[u8; 32],
-    rpc_url: &str,
-    global_args: Option<&global::Args>,
-) -> Result<Vec<ScSpecEntry>, UtilsError> {
-    let client = rpc::Client::new(rpc_url)?;
-    // Get contract data
-    let r = client.get_contract_data(&contract_id).await?;
-    tracing::trace!("{r:?}");
-    
-    let ContractDataEntry {
-        val: ScVal::ContractInstance(ScContractInstance { executable, .. }),
-        ..
-    } = r
-    else {
-        return Err(UtilsError::MissingResult);
-    };
-
-    // Get the contract spec entries based on the executable type
-    let spec_entries = match executable {
-        ContractExecutable::Wasm(hash) => {
-            let hash = hash.to_string();
-            if let Ok(entries) = data::read_spec(&hash) {
-                entries
-            } else {
-                let res = client.get_remote_contract_spec(&contract_id).await?;
-                if global_args.map_or(true, |a| !a.no_cache) {
-                    data::write_spec(&hash, &res)?;
-                }
-                res
-            }
-        }
-        ContractExecutable::StellarAsset => {
-            soroban_spec::read::parse_raw(&soroban_sdk::token::StellarAssetSpec::spec_xdr())?
-        }
-    };
-
-    Ok(spec_entries)
 }
 
 pub mod parsing {

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -1,15 +1,20 @@
 use ed25519_dalek::Signer;
 use sha2::{Digest, Sha256};
+use soroban_env_host::xdr;
 use stellar_strkey::ed25519::PrivateKey;
 
 use soroban_env_host::xdr::{
-    Asset, ContractIdPreimage, DecoratedSignature, Error as XdrError, Hash, HashIdPreimage,
-    HashIdPreimageContractId, Limits, Signature, SignatureHint, Transaction, TransactionEnvelope,
+    Asset, ContractDataEntry, ContractExecutable, ContractIdPreimage, DecoratedSignature, Error as XdrError, Hash, HashIdPreimage,
+    HashIdPreimageContractId, Limits, ScSpecEntry, ScVal, ScContractInstance, Signature, SignatureHint, Transaction, TransactionEnvelope,
     TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction,
     TransactionV1Envelope, WriteXdr,
 };
 
+use soroban_spec::read::FromWasmError;
 pub use soroban_spec_tools::contract as contract_spec;
+
+use crate::rpc;
+use crate::commands::{config::data, global};
 
 /// # Errors
 ///
@@ -127,6 +132,62 @@ pub fn contract_id_hash_from_asset(
     });
     let preimage_xdr = preimage.to_xdr(Limits::none())?;
     Ok(Hash(Sha256::digest(preimage_xdr).into()))
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum UtilsError {
+    #[error("parsing contract spec: {0}")]
+    CannotParseContractSpec(FromWasmError),
+    #[error(transparent)]
+    Rpc(#[from] rpc::Error),
+    #[error("missing result")]
+    MissingResult,
+    #[error(transparent)]
+    Data(#[from] data::Error),
+    #[error(transparent)]
+    Xdr(#[from] xdr::Error),
+}
+
+///
+/// # Errors
+pub async fn get_remote_contract_spec(
+    contract_id: &[u8; 32],
+    rpc_url: &str,
+    global_args: Option<&global::Args>,
+) -> Result<Vec<ScSpecEntry>, UtilsError> {
+    let client = rpc::Client::new(rpc_url)?;
+    // Get contract data
+    let r = client.get_contract_data(&contract_id).await?;
+    tracing::trace!("{r:?}");
+    
+    let ContractDataEntry {
+        val: ScVal::ContractInstance(ScContractInstance { executable, .. }),
+        ..
+    } = r
+    else {
+        return Err(UtilsError::MissingResult);
+    };
+
+    // Get the contract spec entries based on the executable type
+    let spec_entries = match executable {
+        ContractExecutable::Wasm(hash) => {
+            let hash = hash.to_string();
+            if let Ok(entries) = data::read_spec(&hash) {
+                entries
+            } else {
+                let res = client.get_remote_contract_spec(&contract_id).await?;
+                if global_args.map_or(true, |a| !a.no_cache) {
+                    data::write_spec(&hash, &res)?;
+                }
+                res
+            }
+        }
+        ContractExecutable::StellarAsset => {
+            soroban_spec::read::parse_raw(&soroban_sdk::token::StellarAssetSpec::spec_xdr())?
+        }
+    };
+
+    Ok(spec_entries)
 }
 
 pub mod parsing {


### PR DESCRIPTION
### What

Bindings command can now generate for a StellarAsset type contract. Fixes https://github.com/stellar/stellar-cli/issues/1312
Logic for checking if its a StellarAsset was extracted from `invoke.rs` to `get_spec.rs` used by both `invoke` and `bindings`.

### Why

Bindings were failing when trying to retrieve the wasm for a StellarAsset type from the contract Id. 

### Known limitations

none
