### PR TITLE
Remove the contract-ids dir

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,7 @@
 
 [alias] # command aliases
 f = "fmt"
+md-gen = "run --bin doc-gen --features clap-markdown"
 # b = "build"
 # c = "check"
 # t = "test"

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -547,7 +547,7 @@ Initialize a Soroban project with an example contract
 
 * `-w`, `--with-example <WITH_EXAMPLE>`
 
-  Possible values: `account`, `alloc`, `atomic_multiswap`, `atomic_swap`, `auth`, `cross_contract`, `custom_types`, `deep_contract_auth`, `deployer`, `errors`, `eth_abi`, `events`, `fuzzing`, `increment`, `liquidity_pool`, `logging`, `mint-lock`, `simple_account`, `single_offer`, `timelock`, `token`, `upgradeable_contract`, `workspace`
+  Possible values: `account`, `alloc`, `atomic_multiswap`, `atomic_swap`, `auth`, `cross_contract`, `custom_types`, `deep_contract_auth`, `deployer`, `errors`, `eth_abi`, `events`, `fuzzing`, `increment`, `liquidity_pool`, `logging`, `mint-lock`, `simple_account`, `single_offer`, `timelock`, `token`, `ttl`, `upgradeable_contract`, `workspace`
 
 * `-f`, `--frontend-template <FRONTEND_TEMPLATE>`
 

--- a/cmd/soroban-cli/example_contracts.list
+++ b/cmd/soroban-cli/example_contracts.list
@@ -19,5 +19,6 @@ simple_account
 single_offer
 timelock
 token
+ttl
 upgradeable_contract
 workspace


### PR DESCRIPTION
### What

Remove the contract-ids directory from the .soroban directory prefilled in initialised contracts.

### Why

The contract-ids directory isn't used in examples, and isn't a pattern being encouraged since there are plans to add aliases.

cc @elizabethengelman 

### Known limitations

N/A