### PR TITLE
Install stellar and soroban CLIs when installing either

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,8 @@ endif
 install_rust: install
 
 install:
-	cargo install --locked --path ./cmd/soroban-cli --debug
-	cargo install --locked --path ./cmd/stellar-cli --debug
-	cargo install --locked --path ./cmd/crates/soroban-test/tests/fixtures/hello --root ./target --debug --quiet
+	cargo install --force --locked --path ./cmd/stellar-cli --debug
+	cargo install --force --locked --path ./cmd/crates/soroban-test/tests/fixtures/hello --root ./target --debug --quiet
 
 # regenerate the example lib in `cmd/crates/soroban-spec-typsecript/fixtures/ts`
 build-snapshot: typescript-bindings-fixtures

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -13,6 +13,10 @@ autobins = false
 default-run = "soroban"
 
 [[bin]]
+name = "stellar"
+path = "src/bin/main.rs"
+
+[[bin]]
 name = "soroban"
 path = "src/bin/main.rs"
 

--- a/cmd/stellar-cli/Cargo.toml
+++ b/cmd/stellar-cli/Cargo.toml
@@ -16,6 +16,10 @@ default-run = "stellar"
 name = "stellar"
 path = "src/bin/main.rs"
 
+[[bin]]
+name = "soroban"
+path = "src/bin/main.rs"
+
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"


### PR DESCRIPTION
### What
Install the `stellar` and `soroban` CLI binaries when installing either the `stellar-cli` or `soroban-cli` crate.

### Why
In short this change is being made to improve the developer experience during the rename of the CLI.

The CLI is transitioning from being the Soroban CLI to the Stellar CLI, and with that the binary is also transitioning from being `soroban` to `stellar`. It'll take a while for that rename to reverberate through the community, docs, tutorials, video walkthroughs, etc. During that transition period this rename should be a non-event, uninteresting, boring, and zero impact. For an undetermined (read long) period of time both the `stellar-cli` and `soroban-cli` crates will be published so that if someone is following an old tutorial or docs in a blog somewhere, the install instructions will continue to work.

This change takes it step further and makes it so that no matter which crate you install, you get both binaries. This is to help the situation where someone reads an install tutorial and installs the `soroban-cli`, then reads a newer tutorial that uses the `stellar` binary, they'll find the example commands work because the `soroban-cli` installed both. We've already had at least one person in the community fall into this situation where they did the reverse and installed the `stellar-cli` crate then followed a tutorial that used the `soroban` binary.

Note that it will be possible to identify which crate a binary was installed from, by running the `version` subcommand. For either binary, the name displayed will be the name of the crate the binary was installed from.