### PR TITLE
Build artifacts for both stellar-cli and soroban-cli

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,8 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         crate:
-          - stellar-cli
-          - soroban-cli
+          - name: stellar-cli
+            binary: stellar
+          - name: soroban-cli
+            binary: soroban
         include:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
@@ -41,25 +43,25 @@ jobs:
       run: |
         version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stellar-cli") | .version')"
         echo "VERSION=${version}" >> $GITHUB_ENV
-        echo "NAME=${{ matrix.crate }}-${version}-${{ matrix.target }}" >> $GITHUB_ENV
+        echo "NAME=${{ matrix.crate.name }}-${version}-${{ matrix.target }}" >> $GITHUB_ENV
     - name: Package (release only)
       if: github.event_name == 'release'
-      run: cargo package --no-verify --package ${{ matrix.crate }}
+      run: cargo package --no-verify --package ${{ matrix.crate.name }}
     - name: Package Extract (release only)
       if: github.event_name == 'release'
       run: |
         cd target/package
-        tar xvfz ${{ matrix.crate }}-$VERSION.crate
-        echo "BUILD_WORKING_DIR=target/package/${{ matrix.crate }}-$VERSION" >> $GITHUB_ENV
+        tar xvfz ${{ matrix.crate.name }}-$VERSION.crate
+        echo "BUILD_WORKING_DIR=target/package/${{ matrix.crate.name }}-$VERSION" >> $GITHUB_ENV
     - name: Build
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       working-directory: ${{ env.BUILD_WORKING_DIR }}
-      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate }} --features opt --release --target ${{ matrix.target }}
+      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.target }}
     - name: Compress
       run: |
           cd target/${{ matrix.target }}/release
-          tar czvf $NAME.tar.gz stellar${{ matrix.ext }} soroban${{ matrix.ext }}
+          tar czvf $NAME.tar.gz ${{ matrix.crate.binary }}${{ matrix.ext }}
     - name: Upload to Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,7 +20,7 @@ jobs:
             binary: stellar
           - name: soroban-cli
             binary: soroban
-        include:
+        sys:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
@@ -32,18 +32,18 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ext: .exe
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: rustup target add ${{ matrix.target }}
-    - if: matrix.target == 'aarch64-unknown-linux-gnu'
+    - run: rustup target add ${{ matrix.sys.target }}
+    - if: matrix.sys.target == 'aarch64-unknown-linux-gnu'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - name: Setup vars
       run: |
         version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stellar-cli") | .version')"
         echo "VERSION=${version}" >> $GITHUB_ENV
-        echo "NAME=${{ matrix.crate.name }}-${version}-${{ matrix.target }}" >> $GITHUB_ENV
+        echo "NAME=${{ matrix.crate.name }}-${version}-${{ matrix.sys.target }}" >> $GITHUB_ENV
     - name: Package (release only)
       if: github.event_name == 'release'
       run: cargo package --no-verify --package ${{ matrix.crate.name }}
@@ -57,16 +57,16 @@ jobs:
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       working-directory: ${{ env.BUILD_WORKING_DIR }}
-      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.target }}
+      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
     - name: Compress
       run: |
-          cd target/${{ matrix.target }}/release
-          tar czvf $NAME.tar.gz ${{ matrix.crate.binary }}${{ matrix.ext }}
+          cd target/${{ matrix.sys.target }}/release
+          tar czvf $NAME.tar.gz ${{ matrix.crate.binary }}${{ matrix.sys.ext }}
     - name: Upload to Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.NAME }}
-        path: 'target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'
+        path: 'target/${{ matrix.sys.target }}/release/${{ env.NAME }}.tar.gz'
     - name: Upload to Release (release only)
       if: github.event_name == 'release'
       uses: actions/github-script@v6
@@ -78,5 +78,5 @@ jobs:
             repo: context.repo.repo,
             release_id: ${{ github.event.release.id }},
             name: '${{ env.NAME }}.tar.gz',
-            data: fs.readFileSync('target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'),
+            data: fs.readFileSync('target/${{ matrix.sys.target }}/release/${{ env.NAME }}.tar.gz'),
           });

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -15,6 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        crate:
+          - stellar-cli
+          - soroban-cli
         include:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
@@ -36,27 +39,27 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - name: Setup vars
       run: |
-        version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "soroban-cli") | .version')"
+        version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stellar-cli") | .version')"
         echo "VERSION=${version}" >> $GITHUB_ENV
-        echo "NAME=soroban-cli-${version}-${{ matrix.target }}" >> $GITHUB_ENV
+        echo "NAME=${{ matrix.crate }}-${version}-${{ matrix.target }}" >> $GITHUB_ENV
     - name: Package (release only)
       if: github.event_name == 'release'
-      run: cargo package --no-verify
+      run: cargo package --no-verify --package ${{ matrix.crate }}
     - name: Package Extract (release only)
       if: github.event_name == 'release'
       run: |
         cd target/package
-        tar xvfz soroban-cli-$VERSION.crate
-        echo "BUILD_WORKING_DIR=target/package/soroban-cli-$VERSION" >> $GITHUB_ENV
+        tar xvfz ${{ matrix.crate }}-$VERSION.crate
+        echo "BUILD_WORKING_DIR=target/package/${{ matrix.crate }}-$VERSION" >> $GITHUB_ENV
     - name: Build
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       working-directory: ${{ env.BUILD_WORKING_DIR }}
-      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --features opt --release --target ${{ matrix.target }}
+      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate }} --features opt --release --target ${{ matrix.target }}
     - name: Compress
       run: |
           cd target/${{ matrix.target }}/release
-          tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
+          tar czvf $NAME.tar.gz stellar${{ matrix.ext }} soroban${{ matrix.ext }}
     - name: Upload to Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,9 +25,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
-          - os: macos-latest
+          - os: macos-14
             target: x86_64-apple-darwin
-          - os: macos-latest
+          - os: macos-12
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
### What
Build artifacts for both stellar-cli and soroban-cli

### Why
Both the stellar-cli and soroban-cli are published, but the binary artifacts produced and uploaded to the release are currently only the soroban-cli. Both should be uploaded.