### PR TITLE
Update completions to use stellar instead of soroban

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -136,10 +136,10 @@ Ensure the completion package for your shell is installed,
 e.g., bash-completion for bash.
 
 To enable autocomplete in the current bash shell, run:
-  source <(soroban completion --shell bash)
+  source <(stellar completion --shell bash)
 
 To enable autocomplete permanently, run:
-  echo "source <(soroban completion --shell bash)" >> ~/.bashrc
+  echo "source <(stellar completion --shell bash)" >> ~/.bashrc
 
 **Usage:** `stellar completion --shell <SHELL>`
 

--- a/cmd/soroban-cli/src/commands/completion.rs
+++ b/cmd/soroban-cli/src/commands/completion.rs
@@ -11,10 +11,10 @@ Ensure the completion package for your shell is installed,
 e.g., bash-completion for bash.
 
 To enable autocomplete in the current bash shell, run:
-  source <(soroban completion --shell bash)
+  source <(stellar completion --shell bash)
 
 To enable autocomplete permanently, run:
-  echo \"source <(soroban completion --shell bash)\" >> ~/.bashrc";
+  echo \"source <(stellar completion --shell bash)\" >> ~/.bashrc";
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -27,6 +27,6 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(&self) {
         let cmd = &mut Root::command();
-        generate(self.shell, cmd, "soroban", &mut io::stdout());
+        generate(self.shell, cmd, "stellar", &mut io::stdout());
     }
 }


### PR DESCRIPTION
### What

Updates the completion script to match "stellar" instead of "soroban"

### Why

Self explanatory 

### Known limitations

N/A
