### PR TITLE
Fix: exclude host only functions from client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5286,6 +5286,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "test_custom_account"
+version = "21.0.0-rc.1"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "test_custom_types"
 version = "21.0.0-rc.1"
 dependencies = [

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
@@ -27,9 +27,9 @@
       "integrity": "sha512-3gnPjAz78htgqsNEDkEsKHKosV2BF2iZkoHCNxpmZwUxiPsw+2VaXMed8RRMe0rGk3d5GZe7RrSba8zV80J3Ag=="
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.0.0.tgz",
-      "integrity": "sha512-uGpahDFFXbE39myOmBnEZSjVys4yUkQ/ASNuYENGyS8MNdfA0TS7DPWkiO6t17P+rW+FRV1zmumJtjRHwxxMdw==",
+      "version": "12.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.0.0-rc.1.tgz",
+      "integrity": "sha512-Nm2WeqAnhfsZ2ETTttIJy8epgxGb03EXmWkcmxhyRd0us0qz++i0ry/cSnWaNYDWKipZTuepITUc4nM7o/s1tA==",
       "dependencies": {
         "@stellar/js-xdr": "^3.1.1",
         "base32.js": "^0.1.0",
@@ -62,9 +62,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
+      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
@@ -27,9 +27,9 @@
       "integrity": "sha512-3gnPjAz78htgqsNEDkEsKHKosV2BF2iZkoHCNxpmZwUxiPsw+2VaXMed8RRMe0rGk3d5GZe7RrSba8zV80J3Ag=="
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.0.0-rc.1.tgz",
-      "integrity": "sha512-Nm2WeqAnhfsZ2ETTttIJy8epgxGb03EXmWkcmxhyRd0us0qz++i0ry/cSnWaNYDWKipZTuepITUc4nM7o/s1tA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.0.0.tgz",
+      "integrity": "sha512-uGpahDFFXbE39myOmBnEZSjVys4yUkQ/ASNuYENGyS8MNdfA0TS7DPWkiO6t17P+rW+FRV1zmumJtjRHwxxMdw==",
       "dependencies": {
         "@stellar/js-xdr": "^3.1.1",
         "base32.js": "^0.1.0",
@@ -62,9 +62,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-      "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -96,13 +96,10 @@ pub fn generate(spec: &[ScSpecEntry]) -> String {
             cases: vec![],
         });
     }
-    // Filter out function entries with names that start with "__"
-    let filtered_collected: Vec<_> = collected
+    // Filter out function entries with names that start with "__" and partition the results
+    let (fns, other): (Vec<_>, Vec<_>) = collected
         .into_iter()
         .filter(|entry| matches!(entry, Entry::Function { name, .. } if !name.starts_with("__")))
-        .collect();
-    let (fns, other): (Vec<_>, Vec<_>) = filtered_collected
-        .into_iter()
         .partition(|entry| matches!(entry, Entry::Function { .. }));
     let top = other.iter().map(entry_to_method_type).join("\n");
     let bottom = generate_class(&fns, spec);

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -96,7 +96,12 @@ pub fn generate(spec: &[ScSpecEntry]) -> String {
             cases: vec![],
         });
     }
-    let (fns, other): (Vec<_>, Vec<_>) = collected
+    // Filter out function entries with names that start with "__"
+    let filtered_collected: Vec<_> = collected
+        .into_iter()
+        .filter(|entry| !matches!(entry, Entry::Function { name, .. } if name.starts_with("__")))
+        .collect();
+    let (fns, other): (Vec<_>, Vec<_>) = filtered_collected
         .into_iter()
         .partition(|entry| matches!(entry, Entry::Function { .. }));
     let top = other.iter().map(entry_to_method_type).join("\n");

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -99,7 +99,7 @@ pub fn generate(spec: &[ScSpecEntry]) -> String {
     // Filter out function entries with names that start with "__"
     let filtered_collected: Vec<_> = collected
         .into_iter()
-        .filter(|entry| !matches!(entry, Entry::Function { name, .. } if name.starts_with("__")))
+        .filter(|entry| matches!(entry, Entry::Function { name, .. } if !name.starts_with("__")))
         .collect();
     let (fns, other): (Vec<_>, Vec<_>) = filtered_collected
         .into_iter()

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test_custom_account"
+version = "21.0.0-rc.1"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"]}

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version.workspace = true
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/src/lib.rs
@@ -1,0 +1,91 @@
+#![no_std]
+use soroban_sdk::{
+    auth::{Context, CustomAccountInterface},
+    contract, contracterror, contractimpl, contracttype,
+    crypto::Hash,
+    symbol_short, Bytes, BytesN, Env, Symbol, Vec,
+};
+
+#[contract]
+pub struct Contract;
+
+#[contracterror]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Error {
+    NotFound = 1,
+    NotPermitted = 2,
+    ClientDataJsonChallengeIncorrect = 3,
+    JsonParseError = 7,
+    InvalidContext = 8,
+}
+
+const SUDO_SIGNER: Symbol = symbol_short!("sudo_sig");
+
+#[contracttype]
+pub struct Signature {
+    pub id: BytesN<32>,
+    pub authenticator_data: Bytes,
+    pub client_data_json: Bytes,
+    pub signature: BytesN<64>,
+}
+
+// Dummy implementation for the demo
+#[derive(Debug)]
+struct ClientDataJson<'a> {
+    challenge: &'a str,
+}
+
+#[contractimpl]
+impl CustomAccountInterface for Contract {
+    type Error = Error;
+    type Signature = Signature;
+
+    #[allow(non_snake_case)]
+    fn __check_auth(
+        env: Env,
+        _signature_payload: Hash<32>,
+        signature: Signature,
+        auth_contexts: Vec<Context>,
+    ) -> Result<(), Error> {
+
+        // Only the sudo signer can `add_sig`, `rm_sig` and `resudo`
+        for context in auth_contexts.iter() {
+            match context {
+                Context::Contract(c) => {
+                    if c.contract == env.current_contract_address()
+                        && (c.fn_name == Symbol::new(&env, "add_sig")
+                            || c.fn_name == Symbol::new(&env, "rm_sig")
+                            || c.fn_name == Symbol::new(&env, "resudo"))
+                    {
+                        if signature.id
+                            != env
+                                .storage()
+                                .instance()
+                                .get::<Symbol, BytesN<32>>(&SUDO_SIGNER)
+                                .ok_or(Error::NotFound)?
+                        {
+                            return Err(Error::NotPermitted);
+                        }
+                    }
+                }
+                Context::CreateContractHostFn(_) => return Err(Error::InvalidContext),
+            };
+        }
+
+        // Dummy public key verification check
+        env.storage()
+            .persistent()
+            .get::<BytesN<32>, Bytes>(&signature.id)
+            .ok_or(Error::NotFound)?;
+
+        let client_data = ClientDataJson {
+            challenge: "dummy_challenge",
+        };
+
+        if client_data.challenge != "dummy_challenge" {
+            return Err(Error::ClientDataJsonChallengeIncorrect);
+        }
+
+        Ok(())
+    }
+}

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/src/lib.rs
@@ -47,7 +47,6 @@ impl CustomAccountInterface for Contract {
         signature: Signature,
         auth_contexts: Vec<Context>,
     ) -> Result<(), Error> {
-
         // Only the sudo signer can `add_sig`, `rm_sig` and `resudo`
         for context in auth_contexts.iter() {
             match context {

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -1,4 +1,5 @@
 use super::util::deploy_swap;
+use super::util::deploy_custom_account;
 use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
 
 const OUTPUT_DIR: &str = "./bindings-output";
@@ -7,6 +8,36 @@ const OUTPUT_DIR: &str = "./bindings-output";
 async fn invoke_test_generate_typescript_bindings() {
     let sandbox = &TestEnv::new();
     let contract_id = deploy_swap(sandbox).await;
+    let outdir = sandbox.dir().join(OUTPUT_DIR);
+    let cmd = sandbox.cmd_arr::<soroban_cli::commands::contract::bindings::typescript::Cmd>(&[
+        "--network-passphrase",
+        LOCAL_NETWORK_PASSPHRASE,
+        "--rpc-url",
+        &sandbox.rpc_url,
+        "--output-dir",
+        &outdir.display().to_string(),
+        "--overwrite",
+        "--contract-id",
+        &contract_id.to_string(),
+    ]);
+
+    let result = sandbox.run_cmd_with(cmd, "test").await;
+
+    assert!(result.is_ok(), "Failed to generate TypeScript bindings");
+
+    assert!(outdir.exists(), "Output directory does not exist");
+
+    let files = std::fs::read_dir(outdir).expect("Failed to read output directory");
+    assert!(
+        files.count() > 0,
+        "No files generated in the output directory"
+    );
+}
+
+#[tokio::test]
+async fn invoke_test_bindings_context_failure() {
+    let sandbox = &TestEnv::new();
+    let contract_id = deploy_custom_account(sandbox).await;
     let outdir = sandbox.dir().join(OUTPUT_DIR);
     let cmd = sandbox.cmd_arr::<soroban_cli::commands::contract::bindings::typescript::Cmd>(&[
         "--network-passphrase",

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -1,5 +1,5 @@
-use super::util::deploy_swap;
 use super::util::deploy_custom_account;
+use super::util::deploy_swap;
 use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
 
 const OUTPUT_DIR: &str = "./bindings-output";
@@ -57,9 +57,19 @@ async fn invoke_test_bindings_context_failure() {
 
     assert!(outdir.exists(), "Output directory does not exist");
 
-    let files = std::fs::read_dir(outdir).expect("Failed to read output directory");
+    let files = std::fs::read_dir(&outdir).expect("Failed to read output directory");
     assert!(
         files.count() > 0,
         "No files generated in the output directory"
+    );
+    // Read the src/index.ts file and check for `__check_auth:`
+    let index_ts_path = outdir.join("src/index.ts");
+
+    assert!(index_ts_path.exists(), "src/index.ts file does not exist");
+
+    let content = std::fs::read_to_string(&index_ts_path).expect("Failed to read index.ts file");
+    assert!(
+        !content.contains("__check_auth"),
+        "Test failed: `__check_auth` found in src/index.ts"
     );
 }

--- a/cmd/crates/soroban-test/tests/it/integration/util.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/util.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 
 pub const HELLO_WORLD: &Wasm = &Wasm::Custom("test-wasms", "test_hello_world");
 pub const CUSTOM_TYPES: &Wasm = &Wasm::Custom("test-wasms", "test_custom_types");
+pub const CUSTOM_ACCOUNT: &Wasm = &Wasm::Custom("test-wasms", "test_custom_account");
 pub const SWAP: &Wasm = &Wasm::Custom("test-wasms", "test_swap");
 
 pub async fn invoke_with_roundtrip<D>(e: &TestEnv, id: &str, func: &str, data: D)
@@ -31,6 +32,10 @@ pub async fn deploy_custom(sandbox: &TestEnv) -> String {
 
 pub async fn deploy_swap(sandbox: &TestEnv) -> String {
     deploy_contract(sandbox, SWAP).await
+}
+
+pub async fn deploy_custom_account(sandbox: &TestEnv) -> String {
+    deploy_contract(sandbox, CUSTOM_ACCOUNT).await
 }
 
 pub async fn deploy_contract(sandbox: &TestEnv, wasm: &Wasm<'static>) -> String {


### PR DESCRIPTION
### What

Exclude functions starting with `__` from the typescript bindings Client methods.  Fix for https://github.com/stellar/stellar-cli/issues/1344

### Why

These functions are intended to only be run by the host, they may contain names like `Context` which cannot be imported by the client. 

### Known limitations

N/A
