### PR TITLE
fix incorrect filter logic

### DIFF
--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -99,7 +99,7 @@ pub fn generate(spec: &[ScSpecEntry]) -> String {
     // Filter out function entries with names that start with "__" and partition the results
     let (fns, other): (Vec<_>, Vec<_>) = collected
         .into_iter()
-        .filter(|entry| matches!(entry, Entry::Function { name, .. } if !name.starts_with("__")))
+        .filter(|entry| !matches!(entry, Entry::Function { name, .. } if name.starts_with("__")))
         .partition(|entry| matches!(entry, Entry::Function { .. }));
     let top = other.iter().map(entry_to_method_type).join("\n");
     let bottom = generate_class(&fns, spec);


### PR DESCRIPTION
### What

Fixes a bug introduced in https://github.com/stellar/stellar-cli/pull/1359

### Why

This commit: [8976b6c](https://github.com/stellar/stellar-cli/pull/1359/commits/8976b6cc5f7f91577b487871b2f240169e4eb2a2) needs to be reverted. The original logic was correct. Now all non-functions are being excluded from the typescript generation; I noticed this when working on https://github.com/stellar/stellar-cli/issues/1346 and found that no error enum was being generated. This is because its excluding all function names with __ AND its excluding all Entries that fail the function pattern match. 

### Known limitations

none
