### PR TITLE
fix: mark `deploy::wasm::Cmd` fields as public

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -25,17 +25,17 @@ pub struct Cmd {
     pub wasm: Option<std::path::PathBuf>,
     /// Where to place generated project
     #[arg(long)]
-    output_dir: PathBuf,
+    pub output_dir: PathBuf,
     /// Whether to overwrite output directory if it already exists
     #[arg(long)]
-    overwrite: bool,
+    pub overwrite: bool,
     /// The contract ID/address on the network
     #[arg(long, visible_alias = "id")]
-    contract_id: String,
+    pub contract_id: String,
     #[command(flatten)]
-    locator: locator::Args,
+    pub locator: locator::Args,
     #[command(flatten)]
-    network: network::Args,
+    pub network: network::Args,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -37,18 +37,18 @@ use crate::{
 pub struct Cmd {
     /// WASM file to deploy
     #[arg(long, group = "wasm_src")]
-    wasm: Option<std::path::PathBuf>,
+    pub wasm: Option<std::path::PathBuf>,
     /// Hash of the already installed/deployed WASM file
     #[arg(long = "wasm-hash", conflicts_with = "wasm", group = "wasm_src")]
-    wasm_hash: Option<String>,
+    pub wasm_hash: Option<String>,
     /// Custom salt 32-byte salt for the token id
     #[arg(
         long,
         help_heading = HEADING_RPC,
     )]
-    salt: Option<String>,
+    pub salt: Option<String>,
     #[command(flatten)]
-    config: config::Args,
+    pub config: config::Args,
     #[command(flatten)]
     pub fee: crate::fee::Args,
     #[arg(long, short = 'i', default_value = "false")]


### PR DESCRIPTION
This is currently unusable as a library because you either don't define
these fields, or get yelled at because you try to define private fields