### PR TITLE
Disable ubuntu arm.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,10 +92,10 @@ jobs:
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: --feature-powerset
           additional_deb_packages: libudev-dev
-        - os: ubuntu-latest-16-cores
-          target: aarch64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset
-          additional_deb_packages: libudev-dev
+        # - os: ubuntu-latest-16-cores
+        #   target: aarch64-unknown-linux-gnu
+        #   cargo-hack-feature-options: --feature-powerset
+        #   additional_deb_packages: libudev-dev
         - os: macos-latest
           target: x86_64-apple-darwin
           cargo-hack-feature-options: --feature-powerset


### PR DESCRIPTION
The linux arm build is failing with errors related to openssl-sys (or the underlying dependency).