### PR TITLE
Add support for contract id alias on `stellar contract bindings typescript`.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -71,6 +71,8 @@ pub enum Error {
     CannotParseContractId(String, DecodeError),
     #[error(transparent)]
     UtilsError(#[from] get_spec::Error),
+    #[error(transparent)]
+    Config(#[from] config::Error),
 }
 
 #[async_trait::async_trait]
@@ -87,8 +89,15 @@ impl NetworkRunnable for Cmd {
             let wasm: wasm::Args = wasm.into();
             wasm.parse()?.spec
         } else {
-            let contract_id = soroban_spec_tools::utils::contract_id_from_str(&self.contract_id)
-                .map_err(|e| Error::CannotParseContractId(self.contract_id.clone(), e))?;
+            let network = config.map_or_else(
+                || self.network.get(&self.locator).map_err(Error::from),
+                |c| c.get_network().map_err(Error::from),
+            )?;
+
+            let contract_id = self
+                .locator
+                .resolve_contract_id(&self.contract_id, &network.network_passphrase)?;
+
             get_remote_contract_spec(
                 &contract_id,
                 &self.locator,


### PR DESCRIPTION
### What

Add alias support to `stellar contract bindings typescript`.

```console
$ stellar contract bindings typescript --network standalone --global --output-dir tmp --id alice --overwrite

added 28 packages, and audited 29 packages in 878ms

5 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

> tmp@0.0.0 build
> tsc
```

### Why

So you don't have to use the contract's id.

### Known limitations

N/A
