### PR TITLE
fix: typo: second "Bytes" should be "BytesN"

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -560,6 +560,6 @@ fn arg_file_help(docs: &str) -> String {
         r#"{docs}
 Usage Notes:
 Each arg has a corresponding --<arg_name>-file-path which is a path to a file containing the corresponding JSON argument.
-Note: The only types which aren't JSON are Bytes and Bytes which are raw bytes"#
+Note: The only types which aren't JSON are Bytes and BytesN, which are raw bytes"#
     )
 }


### PR DESCRIPTION
### What

typo

### Why

it's been saying "Bytes and Bytes" for almost a year now 🙃