### PR TITLE
Add support for alias to `stellar contract extend|read|restore`.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -133,7 +133,11 @@ impl NetworkRunnable for Cmd {
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         tracing::trace!(?network);
-        let entry_keys = self.key.parse_keys()?;
+        let contract = config.locator.resolve_contract_id(
+            self.key.contract_id.as_ref().unwrap(),
+            &network.network_passphrase,
+        )?;
+        let entry_keys = self.key.parse_keys(contract)?;
         let client = Client::new(&network.rpc_url)?;
         let key = config.key_pair()?;
 

--- a/cmd/soroban-cli/src/key.rs
+++ b/cmd/soroban-cli/src/key.rs
@@ -4,12 +4,9 @@ use soroban_env_host::xdr::{
     ScVal,
 };
 use std::path::PathBuf;
+use stellar_strkey::Contract;
 
-use crate::{
-    commands::contract::Durability,
-    utils::{self},
-    wasm,
-};
+use crate::{commands::contract::Durability, wasm};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -64,7 +61,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn parse_keys(&self) -> Result<Vec<LedgerKey>, Error> {
+    pub fn parse_keys(&self, contract: Contract) -> Result<Vec<LedgerKey>, Error> {
         let keys = if let Some(keys) = &self.key {
             keys.iter()
                 .map(|key| {
@@ -90,21 +87,16 @@ impl Args {
         } else {
             vec![ScVal::LedgerKeyContractInstance]
         };
-        let contract_id = contract_id(self.contract_id.as_ref().unwrap())?;
 
         Ok(keys
             .into_iter()
             .map(|key| {
                 LedgerKey::ContractData(LedgerKeyContractData {
-                    contract: ScAddress::Contract(xdr::Hash(contract_id)),
+                    contract: ScAddress::Contract(xdr::Hash(contract.0)),
                     durability: (&self.durability).into(),
                     key,
                 })
             })
             .collect())
     }
-}
-
-fn contract_id(s: &str) -> Result<[u8; 32], Error> {
-    utils::contract_id_from_str(s).map_err(|e| Error::CannotParseContractId(s.to_string(), e))
 }


### PR DESCRIPTION
### What

Add support for alias to `stellar contract extend|read|restore`.

```console
$ stellar contract read --id alice --global --network standalone --source alice --durability persistent
LedgerKeyContractInstance,"{""hash"":""d68f72ee0e95c63263e64e1802d0bb511461e0948da7fe355bcfe16163e78b95""}",360380,2433979

$ stellar contract read --id CAYXES5COIN3UEAQ7QM6CNRKQAXGW45YHRH32GHWAMRLI5AR7PWL7OTS --global --network standalone --source alice --durability persistent
LedgerKeyContractInstance,"{""hash"":""d68f72ee0e95c63263e64e1802d0bb511461e0948da7fe355bcfe16163e78b95""}",360380,2433979
```

### Why

So users can pass in an alias, rather than the contract id.

### Known limitations

N/A
