### PR TITLE
Feat: add stellar ledger as signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5127,6 +5127,7 @@ dependencies = [
  "soroban-spec-rust",
  "soroban-spec-tools",
  "soroban-spec-typescript",
+ "stellar-ledger",
  "stellar-rpc-client",
  "stellar-strkey 0.0.11",
  "stellar-xdr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ version = "21.4.0"
 version = "21.2.0"
 default-features = true
 
+[workspace.dependencies.stellar-ledger]
+version = "=21.5.0"
+path = "cmd/crates/stellar-ledger"
+
 [workspace.dependencies]
 stellar-strkey = "0.0.11"
 sep5 = "0.0.4"

--- a/cmd/crates/stellar-ledger/src/lib.rs
+++ b/cmd/crates/stellar-ledger/src/lib.rs
@@ -1,9 +1,13 @@
 use hd_path::HdPath;
-use ledger_transport::{APDUCommand, Exchange};
+use ledger_transport::APDUCommand;
+pub use ledger_transport::Exchange;
+
 use ledger_transport_hid::{
     hidapi::{HidApi, HidError},
-    LedgerHIDError, TransportNativeHID,
+    LedgerHIDError,
 };
+
+pub use ledger_transport_hid::TransportNativeHID;
 
 use soroban_env_host::xdr::{Hash, Transaction};
 use std::vec;

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -50,6 +50,8 @@ soroban-ledger-snapshot = { workspace = true }
 stellar-strkey = { workspace = true }
 soroban-sdk = { workspace = true }
 soroban-rpc = { workspace = true }
+stellar-ledger = { workspace = true }
+
 clap = { workspace = true, features = [
     "derive",
     "env",
@@ -113,7 +115,7 @@ async-compression = { version = "0.4.12", features = [ "tokio", "gzip" ] }
 tempfile = "3.8.1"
 toml_edit = "0.21.0"
 rust-embed = { version = "8.2.0", features = ["debug-embed"] }
-bollard = { workspace=true }
+bollard = { workspace = true }
 futures-util = "0.3.30"
 futures = "0.3.30"
 home = "0.5.9"


### PR DESCRIPTION
### What

This adds the ledger as a possible signer. If a source account is `ledger`, the ledger is used to sign the transaction.

Depends on #1406 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

Currently having issues with the deps in CI and potentially for end users. Might need to vendor the deps?