### PR TITLE
Regenerate docs on pre-commit.

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -4,3 +4,6 @@ set -e
 
 echo '+cargo fmt --check'
 cargo fmt --check || (cargo fmt && exit 1)
+
+echo '+cargo run --bin doc-gen --features clap-markdown'
+cargo run --bin doc-gen --features clap-markdown


### PR DESCRIPTION
### What

Regenerate docs on pre-commit.

### Why

Right now, the full docs file is only regenerated before pushing changes, which requires you to be aware and do another commit with the changes. We should do it before commiting, so you only have to do it once.

### Known limitations

N/A
