### PR TITLE
Update alias help.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -460,7 +460,7 @@ Deploy a wasm contract
 
   Possible values: `true`, `false`
 
-* `--alias <ALIAS>` — The alias that will be used to save the contract's id
+* `--alias <ALIAS>` — The alias that will be used to save the contract's id. Whenever used, `--alias` will always overwrite the existing contract id configuration without asking for confirmation
 
 
 

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -56,6 +56,8 @@ pub struct Cmd {
     /// Whether to ignore safety checks when deploying contracts
     pub ignore_checks: bool,
     /// The alias that will be used to save the contract's id.
+    /// Whenever used, `--alias` will always overwrite the existing contract id
+    /// configuration without asking for confirmation.
     #[arg(long, value_parser = clap::builder::ValueParser::new(alias_validator))]
     pub alias: Option<String>,
 }


### PR DESCRIPTION
### What

The original `--alias` implementation had `--force` to overwrite existing contract id aliases, but @leighmcculloch [suggested](https://github.com/stellar/stellar-cli/pull/1356#discussion_r1626762468) that it'd be better to always use the latest id. Now, @willemneal created a [ticket to add that back](https://github.com/stellar/stellar-cli/issues/1417). Until we come to a decision, let's make the flag help explicit.

### Why

So people can know that `--alias` will always store the latest contract id without asking for confirmation.

### Known limitations

N/A