### PR TITLE
chore: ignore vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ captive-core/
 !test.toml
 *.sqlite
 test_snapshots
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.features": [
+        "it"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "rust-analyzer.cargo.features": [
-        "it"
-    ]
-}

--- a/cmd/crates/soroban-test/README.md
+++ b/cmd/crates/soroban-test/README.md
@@ -52,3 +52,8 @@ fn invoke() {
     });
 }
 ```
+
+Itegration tests in Crate
+==============
+
+Currently all tests that require an RPC server are hidden behind a `it` feature, [found here](./tests/it/integration). To allow Rust-Analyzer to see the tests in vscode, `.vscode/settings.json`. Without RA, you can't follow through definitions and more importantly see errors before running tests tests.


### PR DESCRIPTION
This is for developing as it will allow integration tests (hidden behind the feature flag) to be indexed by RA
