### PR TITLE
Remove list of crates from publish dry run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,6 @@ jobs:
 
     uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
     with:
-      crates: soroban-spec-tools soroban-spec-json soroban-spec-typescript soroban-test soroban-cli
       runs-on: ${{ matrix.os }}
       target: ${{ matrix.target }}
       cargo-hack-feature-options: ${{ matrix.cargo-hack-feature-options }}


### PR DESCRIPTION
### What

Remove list of crates from publish dry run.

### Why

They are no longer required and the workflow can pickup the list of crates itself since:
- https://github.com/stellar/actions/pull/71

