### PR TITLE
docs: fix markdown link to ledger header docs

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -627,7 +627,9 @@ Watch the network for contract events
 
 ###### **Options:**
 
-* `--start-ledger <START_LEDGER>` — The first ledger sequence number in the range to pull events <https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence>
+* `--start-ledger <START_LEDGER>` — The first [ledger sequence] number in the range to pull events
+
+   [ledger sequence]: https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
 * `--cursor <CURSOR>` — The cursor corresponding to the start of the event range
 * `--output <OUTPUT>` — Output formatting options for event stream
 

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -12,8 +12,9 @@ use crate::rpc;
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// The first ledger sequence number in the range to pull events
-    /// <https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence>
+    /// The first [ledger sequence] number in the range to pull events
+    ///
+    /// [ledger sequence]: https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
     #[arg(long, conflicts_with = "cursor", required_unless_present = "cursor")]
     start_ledger: Option<u32>,
     /// The cursor corresponding to the start of the event range.


### PR DESCRIPTION
### What

 This commit removes the surrounding angle brackets from a link to the docs, turns it into a link definition, and also re-generates the full help docs file.

### Why

The syntax `<www.example.com>` will result in an MDX v3 compilation error, due to the unexpected `<` character.

### Known limitations

Using the link definition, separated by a "blank" line works in the markdown rendering, and I've tested it (locally) when built into the docs site. The words `ledger sequence` link to the desired `page#and-anchor` in the docs.

![Screenshot 2024-07-17 at 9 39 09 AM](https://github.com/user-attachments/assets/feee5907-88ec-4cfa-bc7f-942451d80107)

What I **don't know** how to check is what this would appear like in the cli help itself. It could be terrible, I just don't know how to check the output from a branch.