### PR TITLE
docs: reformat link to ledger headers in `events.rs`

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -627,9 +627,7 @@ Watch the network for contract events
 
 ###### **Options:**
 
-* `--start-ledger <START_LEDGER>` — The first [ledger sequence] number in the range to pull events
-
-   [ledger sequence]: https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
+* `--start-ledger <START_LEDGER>` — The first ledger sequence number in the range to pull events https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
 * `--cursor <CURSOR>` — The cursor corresponding to the start of the event range
 * `--output <OUTPUT>` — Output formatting options for event stream
 

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -12,9 +12,9 @@ use crate::rpc;
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// The first [ledger sequence] number in the range to pull events
-    ///
-    /// [ledger sequence]: https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
+    #[allow(clippy::doc_markdown)]
+    /// The first ledger sequence number in the range to pull events
+    /// https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
     #[arg(long, conflicts_with = "cursor", required_unless_present = "cursor")]
     start_ledger: Option<u32>,
     /// The cursor corresponding to the start of the event range.


### PR DESCRIPTION
For better appearance in the CLI, and to still work with MDX v3, this change removes the link definition, in favor of the bare URL. I'm also adding a macro for clippy to ignore the "improper markdown" in this comment.