### PR TITLE
docs: correct the URL to the ledger headers page

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -627,7 +627,7 @@ Watch the network for contract events
 
 ###### **Options:**
 
-* `--start-ledger <START_LEDGER>` — The first ledger sequence number in the range to pull events https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
+* `--start-ledger <START_LEDGER>` — The first ledger sequence number in the range to pull events https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/ledger-headers#ledger-sequence
 * `--cursor <CURSOR>` — The cursor corresponding to the start of the event range
 * `--output <OUTPUT>` — Output formatting options for event stream
 

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -14,7 +14,7 @@ use crate::rpc;
 pub struct Cmd {
     #[allow(clippy::doc_markdown)]
     /// The first ledger sequence number in the range to pull events
-    /// https://developers.stellar.org/docs/encyclopedia/ledger-headers#ledger-sequence
+    /// https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/ledger-headers#ledger-sequence
     #[arg(long, conflicts_with = "cursor", required_unless_present = "cursor")]
     start_ledger: Option<u32>,
     /// The cursor corresponding to the start of the event range.


### PR DESCRIPTION
The ledger headers page has moved, and this commit uses the new location.