### PR TITLE
Remove the short option -o for --overwrite

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -48,7 +48,7 @@ pub struct Cmd {
     )]
     pub frontend_template: String,
 
-    #[arg(short, long, long_help = "Overwrite all existing files.")]
+    #[arg(long, long_help = "Overwrite all existing files.")]
     pub overwrite: bool,
 }
 


### PR DESCRIPTION
### What
Remove the short option -o for --overwrite.

### Why
The --overwrite option is destructive and users can lose files and hard work by using it. We should make it very explicit and obvious when users are doing things that could cause them to lose work.

A second reason is that we should reserve short options for the most common workflows, and the workflows where someone can look at the short command in context and almost be able to guess as to what that short option means or at least the cognitive load of remembering what it means should be matched with the value the user gets out of having to remember. The overwrite workflow is unlikely to be used by many people, and on something like a init command the -o option is pretty ambiguous.