### PR TITLE
Update bytes from 1.6.0 to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,9 +594,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bytes-lit"


### PR DESCRIPTION
### What
Update dependency `bytes` from 1.6.0 to 1.6.1.

### Why
Installing `stellar-cli` with the `--locked` option is currently displaying a warning that one of the dependencies, `bytes` 1.6.0, has been yanked.

Usually yanks of a published version are because of something like an accidental publish so we'd want to update urgently and republish so folks can continue to use `cargo install --locked`. In this case it was just a bug fix and that crate has a different policy for yanking where bugs cause yanks too (https://github.com/tokio-rs/bytes/issues/722).

The bug fix isn't critical to the stellar-cli as far as I can tell, but without updating, cargo install displays warnings which can be worrying to users and result in them running cargo install without `--locked` which results in untested code from executing.

```
❯ cargo install --locked stellar-cli
    Updating crates.io index
  Downloaded stellar-cli v21.2.0
  Downloaded 1 crate (30.8 KB) in 0.93s
  Installing stellar-cli v21.2.0
    Updating crates.io index
warning: package `bytes v1.6.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
    Updating crates.io index
...
```
