### PR TITLE
Remove windows not supported errors

### DIFF
--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -78,8 +78,6 @@ pub enum Error {
     InvalidUrl(String),
     #[error("Inproper response {0}")]
     InproperResponse(String),
-    #[error("Currently not supported on windows. Please visit:\n{0}")]
-    WindowsNotSupported(String),
 }
 
 impl Cmd {

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -33,8 +33,6 @@ pub enum Error {
     InvalidUrl(String),
     #[error("Inproper response {0}")]
     InproperResponse(String),
-    #[error("Currently not supported on windows. Please visit:\n{0}")]
-    WindowsNotSupported(String),
 }
 
 #[derive(Debug, clap::Args, Clone, Default)]


### PR DESCRIPTION
### What
Remove windows not supported errors.

### Why
We recently did work to make the stellar-cli support windows equally with other platforms. There shouldn't be any new cases where windows isn't supported and no further use of these errors.