### PR TITLE
Update fund error handling

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration.rs
+++ b/cmd/crates/soroban-test/tests/it/integration.rs
@@ -1,6 +1,7 @@
 mod bindings;
 mod custom_types;
 mod dotenv;
+mod fund;
 mod hello_world;
 mod tx;
 mod util;

--- a/cmd/crates/soroban-test/tests/it/integration/fund.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/fund.rs
@@ -1,15 +1,4 @@
-use predicates::boolean::PredicateBooleanExt;
-use soroban_cli::{
-    commands::{
-        contract::{self, fetch},
-        txn_result::TxnResult,
-    },
-    config::{locator, secret},
-};
-use soroban_rpc::GetLatestLedgerResponse;
-use soroban_test::{AssertExt, TestEnv, LOCAL_NETWORK_PASSPHRASE};
-
-use crate::integration::util::extend_contract;
+use soroban_test::TestEnv;
 
 #[allow(clippy::too_many_lines)]
 async fn fund() {
@@ -25,6 +14,5 @@ async fn fund() {
         .arg("fund")
         .arg("test")
         .assert()
-        .failed()
-        .stderr(predicates::str::contains("failed"));
+        .stderr(predicates::str::contains("funding failed"));
 }

--- a/cmd/crates/soroban-test/tests/it/integration/fund.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/fund.rs
@@ -1,5 +1,6 @@
 use soroban_test::TestEnv;
 
+#[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn fund() {
     let sandbox = &TestEnv::new();

--- a/cmd/crates/soroban-test/tests/it/integration/fund.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/fund.rs
@@ -1,0 +1,30 @@
+use predicates::boolean::PredicateBooleanExt;
+use soroban_cli::{
+    commands::{
+        contract::{self, fetch},
+        txn_result::TxnResult,
+    },
+    config::{locator, secret},
+};
+use soroban_rpc::GetLatestLedgerResponse;
+use soroban_test::{AssertExt, TestEnv, LOCAL_NETWORK_PASSPHRASE};
+
+use crate::integration::util::extend_contract;
+
+#[allow(clippy::too_many_lines)]
+async fn fund() {
+    let sandbox = &TestEnv::new();
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("generate")
+        .arg("test")
+        .assert()
+        .success();
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("fund")
+        .arg("test")
+        .assert()
+        .failed()
+        .stderr(predicates::str::contains("failed"));
+}

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -37,7 +37,7 @@ async fn invoke() {
         .arg("fund")
         .arg("test")
         .assert()
-        .stderr(predicates::str::contains("Account already exists"));
+        .stderr(predicates::str::contains("createAccountAlreadyExist"));
     sandbox
         .new_assert_cmd("keys")
         .arg("fund")

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -36,12 +36,6 @@ async fn invoke() {
         .new_assert_cmd("keys")
         .arg("fund")
         .arg("test")
-        .assert()
-        .stderr(predicates::str::contains("createAccountAlreadyExist"));
-    sandbox
-        .new_assert_cmd("keys")
-        .arg("fund")
-        .arg("test")
         .arg("--hd-path=1")
         .assert()
         .success();

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -31,8 +31,8 @@ pub enum Error {
     FailedToParseJSON(String, serde_json::Error),
     #[error("Invalid URL {0}")]
     InvalidUrl(String),
-    #[error("Inproper response {0}")]
-    InproperResponse(String),
+    #[error("funding failed: {0}")]
+    FundingFailed(String),
 }
 
 #[derive(Debug, clap::Args, Clone, Default)]
@@ -149,16 +149,16 @@ impl Network {
                 return Err(Error::InvalidUrl(uri.to_string()));
             }
         };
+        let request_successful = response.status().is_success();
         let body = hyper::body::to_bytes(response.into_body()).await?;
         let res = serde_json::from_slice::<serde_json::Value>(&body)
             .map_err(|e| Error::FailedToParseJSON(uri.to_string(), e))?;
         tracing::debug!("{res:#?}");
-        if let Some(detail) = res.get("detail").and_then(Value::as_str) {
-            if detail.contains("createAccountAlreadyExist") {
-                eprintln!("Account already exists");
+        if !request_successful {
+            if let Some(detail) = res.get("detail").and_then(Value::as_str) {
+                return Err(Error::FundingFailed(detail.to_string()));
             }
-        } else if res.get("successful").is_none() {
-            return Err(Error::InproperResponse(res.to_string()));
+            return Err(Error::FundingFailed("unknown cause".to_string()));
         }
         Ok(())
     }


### PR DESCRIPTION
### What
Update fund error handling to generically handle any error message from friendbot.

### Why
Friendbot was updated in the change below to allow funding existing accounts if their balance is below the amount that friendbot funds to:
- https://github.com/stellar/go/pull/5399

Error handling in the cli was focused on handling a specific error message. Friendbot delivers error messages that can be passed on to the developer and the cli doesn't need to handle specific cases.

Close https://github.com/stellar/stellar-cli/issues/1389