### PR TITLE
fix(ts-tests): update js-stellar-sdk; use it correctly

### DIFF
--- a/.github/workflows/bindings-ts.yml
+++ b/.github/workflows/bindings-ts.yml
@@ -1,0 +1,42 @@
+name: bindings typescript
+
+on:
+  push:
+    branches: [main, release/**]
+  pull_request:
+
+jobs:
+  test:
+    name: test generated libraries
+    runs-on: ubuntu-22.04
+    services:
+      rpc:
+        image: stellar/quickstart:testing
+        ports:
+          - 8000:8000
+        env:
+          ENABLE_LOGS: true
+          NETWORK: local
+          ENABLE_SOROBAN_RPC: true
+        options: >-
+          --health-cmd "curl --no-progress-meter --fail-with-body -X POST \"http://localhost:8000/soroban/rpc\" -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":8675309,\"method\":\"getNetwork\"}' && curl --no-progress-meter \"http://localhost:8000/friendbot\" | grep '\"invalid_field\": \"addr\"'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 50
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: rustup update
+      - run: cargo build
+      - run: rustup target add wasm32-unknown-unknown
+      - run: make build-test-wasms
+      - run: npm ci && npm run test
+        working-directory: cmd/crates/soroban-spec-typescript/ts-tests

--- a/cmd/crates/soroban-spec-typescript/ts-tests/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "devDependencies": {
         "@ava/typescript": "^4.1.0",
-        "@stellar/stellar-sdk": "12.1.0",
+        "@stellar/stellar-sdk": "12.2.0",
         "@types/node": "^20.4.9",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
@@ -199,18 +199,18 @@
       }
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.1.tgz",
-      "integrity": "sha512-3gnPjAz78htgqsNEDkEsKHKosV2BF2iZkoHCNxpmZwUxiPsw+2VaXMed8RRMe0rGk3d5GZe7RrSba8zV80J3Ag==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
       "dev": true
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.0.1.tgz",
-      "integrity": "sha512-g6c27MNsDgEdUmoNQJn7zCWoCY50WHt0OIIOq3PhWaJRtUaT++qs1Jpb8+1bny2GmhtfRGOfPUFSyQBuHT9Mvg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.0.tgz",
+      "integrity": "sha512-pWwn+XWP5NotmIteZNuJzHeNn9DYSqH3lsYbtFUoSYy1QegzZdi9D8dK6fJ2fpBAnf/rcDjHgHOw3gtHaQFVbg==",
       "dev": true,
       "dependencies": {
-        "@stellar/js-xdr": "^3.1.1",
+        "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
         "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
@@ -222,12 +222,12 @@
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.1.0.tgz",
-      "integrity": "sha512-Va0hu9SaPezmMbO5eMwL5D15Wrx1AGWRtxayUDRWV2Fr3ynY58mvCZS1vsgNQ4kE8MZe3nBVKv6T9Kzqwgx1PQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
+      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
       "dev": true,
       "dependencies": {
-        "@stellar/stellar-base": "^12.0.1",
+        "@stellar/stellar-base": "^12.1.0",
         "axios": "^1.7.2",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",

--- a/cmd/crates/soroban-spec-typescript/ts-tests/package.json
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/package.json
@@ -14,7 +14,7 @@
     "ava": "^5.3.1",
     "dotenv": "^16.3.1",
     "eslint": "^8.53.0",
-    "@stellar/stellar-sdk": "12.1.0",
+    "@stellar/stellar-sdk": "12.2.0",
     "typescript": "^5.3.3"
   },
   "ava": {

--- a/cmd/crates/soroban-spec-typescript/ts-tests/src/util.ts
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/src/util.ts
@@ -1,15 +1,22 @@
 import { spawnSync } from "node:child_process";
 import { Address, Keypair } from "@stellar/stellar-sdk";
-import { basicNodeSigner } from "@stellar/stellar-sdk/ContractClient";
+import { basicNodeSigner } from "@stellar/stellar-sdk/contract";
 
-const rootKeypair = Keypair.fromSecret(spawnSync("./soroban", ["keys", "show", "root"], { shell: true, encoding: "utf8" }).stdout.trim());
+const rootKeypair = Keypair.fromSecret(
+  spawnSync("./soroban", ["keys", "show", "root"], {
+    shell: true,
+    encoding: "utf8",
+  }).stdout.trim(),
+);
 
 export const root = {
   keypair: rootKeypair,
   address: Address.fromString(rootKeypair.publicKey()),
-}
+};
 
 export const rpcUrl = process.env.SOROBAN_RPC_URL ?? "http://localhost:8000/";
-export const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE ?? "Standalone Network ; February 2017";
+export const networkPassphrase =
+  process.env.SOROBAN_NETWORK_PASSPHRASE ??
+  "Standalone Network ; February 2017";
 
 export const signer = basicNodeSigner(root.keypair, networkPassphrase);


### PR DESCRIPTION
### What

- Update the version of `stellar-sdk` used by the ts-tests
- Import and use the library correctly
- Re-add CI workflow mistakenly removed in #1207 

### Why

These tests weren't passing. There's still a couple tests here of the generated types themselves, though #1207 got it right that _most_ of these tests were moved to js-stellar-sdk itself.

### Known limitations

Is this workflow too much trouble here to be worth it?

We _could_ generate these types entirely within JS. Maybe within stellar-sdk? Maybe within some other package, run with `npx` or similar? We'd probably want to maintain it in the stellar-sdk monorepo, if it were a monorepo. Then the CLI could just check that you've got NPM installed correctly and run `npx [whatever]`.