### PR TITLE
Remove short name, so it doesn't conflict with the verbose short name.

### DIFF
--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -48,7 +48,7 @@ pub struct Cmd {
     pub image_tag_override: Option<String>,
 
     /// Optional argument to specify the protocol version for the local network only
-    #[arg(short = 'v', long)]
+    #[arg(long)]
     pub protocol_version: Option<String>,
 }
 


### PR DESCRIPTION
### What

Remove short flag due to a conflict introduced by #1510.

### Why

```console
$ stellar network container start
thread 'main' panicked at /Users/fnando/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.8/src/builder/debug_asserts.rs:112:17:
Command start: Short option names must be unique for each argument, but '-v' is in use by both 'protocol_version' and 'verbose'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Known limitations

N/A
