### PR TITLE
Require ci doc check on prs

### DIFF
--- a/.github/workflows/full-help-docs.yml
+++ b/.github/workflows/full-help-docs.yml
@@ -12,7 +12,15 @@ permissions:
   pull-requests: read
 
 jobs:
-  doc_check:
+  complete:
+    if: always()
+    needs: [doc-check]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
+
+  doc-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/full-help-docs.yml
+++ b/.github/workflows/full-help-docs.yml
@@ -24,7 +24,7 @@ jobs:
       run: exit 1
 
   doc-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main

--- a/.github/workflows/full-help-docs.yml
+++ b/.github/workflows/full-help-docs.yml
@@ -1,6 +1,9 @@
 name: CLI Help Doc
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, release/**]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       run: exit 1
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
     - run: rustup update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,20 +18,20 @@ jobs:
   complete:
     if: always()
     needs: [fmt, build-and-test, publish-dry-run]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
   fmt:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: cargo fmt --all --check
 
   check-generated-examples-list:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - run: make generate-examples-list

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -899,7 +899,7 @@ By default, when starting a testnet container, without any optional arguments, i
 
   Default value: `8000:8000`
 * `-t`, `--image-tag-override <IMAGE_TAG_OVERRIDE>` — Optional argument to override the default docker image tag for the given network
-* `-v`, `--protocol-version <PROTOCOL_VERSION>` — Optional argument to specify the protocol version for the local network only
+* `--protocol-version <PROTOCOL_VERSION>` — Optional argument to specify the protocol version for the local network only
 
 
 
@@ -979,7 +979,7 @@ By default, when starting a testnet container, without any optional arguments, i
 
   Default value: `8000:8000`
 * `-t`, `--image-tag-override <IMAGE_TAG_OVERRIDE>` — Optional argument to override the default docker image tag for the given network
-* `-v`, `--protocol-version <PROTOCOL_VERSION>` — Optional argument to specify the protocol version for the local network only
+* `--protocol-version <PROTOCOL_VERSION>` — Optional argument to specify the protocol version for the local network only
 
 
 


### PR DESCRIPTION
### What
Require ci doc check on prs. Also use appropriate instance size for small ci jobs that do not require significant resources.

### Why
The CI doc check is something we should satisfy before merging, but at the moment it is ignored by the auto merge. Any job named 'complete' will block the auto merge.