### PR TITLE
Move container output to the rich print system.

### DIFF
--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -110,7 +110,7 @@ impl Root {
             Cmd::Contract(contract) => contract.run(&self.global_args).await?,
             Cmd::Events(events) => events.run().await?,
             Cmd::Xdr(xdr) => xdr.run()?,
-            Cmd::Network(network) => network.run().await?,
+            Cmd::Network(network) => network.run(&self.global_args).await?,
             Cmd::Snapshot(snapshot) => snapshot.run(&self.global_args).await?,
             Cmd::Version(version) => version.run(),
             Cmd::Keys(id) => id.run().await?,

--- a/cmd/soroban-cli/src/commands/network/container.rs
+++ b/cmd/soroban-cli/src/commands/network/container.rs
@@ -1,3 +1,5 @@
+use crate::commands::global;
+
 pub(crate) mod logs;
 mod shared;
 pub(crate) mod start;
@@ -37,11 +39,11 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match &self {
             Cmd::Logs(cmd) => cmd.run().await?,
-            Cmd::Start(cmd) => cmd.run().await?,
-            Cmd::Stop(cmd) => cmd.run().await?,
+            Cmd::Start(cmd) => cmd.run(global_args).await?,
+            Cmd::Stop(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -194,12 +194,12 @@ impl Runner {
         let tail = format!("{container_name} {additional_flags}");
 
         self.print.searchln(format!(
-            "You can see logs by running `stellar network container logs {}`",
+            "Watch logs with `stellar network container logs {}`",
             tail.trim()
         ));
 
         self.print.infoln(format!(
-            "To stop this container, use `stellar network container stop {}`",
+            "Stop the container with `stellar network container stop {}`",
             tail.trim()
         ));
     }

--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -7,7 +7,13 @@ use bollard::{
 };
 use futures_util::TryStreamExt;
 
-use crate::commands::network::container::shared::{Error as ConnectionError, Network};
+use crate::{
+    commands::{
+        global,
+        network::container::shared::{Error as ConnectionError, Network},
+    },
+    print,
+};
 
 use super::shared::{Args, Name};
 
@@ -53,13 +59,27 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
-        println!("ℹ️  Starting {} network", &self.network);
-        self.run_docker_command().await
-    }
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let runner = Runner {
+            args: self.clone(),
+            print: print::Print::new(global_args.quiet),
+        };
 
+        runner.run_docker_command().await
+    }
+}
+
+struct Runner {
+    args: Cmd,
+    print: print::Print,
+}
+
+impl Runner {
     async fn run_docker_command(&self) -> Result<(), Error> {
-        let docker = self.container_args.connect_to_docker().await?;
+        self.print
+            .infoln(format!("Starting {} network", &self.args.network));
+
+        let docker = self.args.container_args.connect_to_docker().await?;
 
         let image = self.get_image_name();
         docker
@@ -103,27 +123,23 @@ impl Cmd {
                 None::<StartContainerOptions<String>>,
             )
             .await?;
-        println!(
-            "✅ Container started: {}",
-            self.container_name().get_external_container_name()
-        );
-        self.print_log_message();
-        self.print_stop_message();
+        self.print.checkln("Started container");
+        self.print_instructions();
         Ok(())
     }
 
     fn get_image_name(&self) -> String {
         // this can be overriden with the `-t` flag
-        let mut image_tag = match &self.network {
+        let mut image_tag = match &self.args.network {
             Network::Pubnet => "latest",
             Network::Futurenet => "future",
             _ => "testing", // default to testing for local and testnet
         };
 
-        if let Some(image_override) = &self.image_tag_override {
-            println!(
+        if let Some(image_override) = &self.args.image_tag_override {
+            self.print.infoln(format!(
                 "Overriding docker image tag to use '{image_override}' instead of '{image_tag}'"
-            );
+            ));
             image_tag = image_override;
         }
 
@@ -132,7 +148,7 @@ impl Cmd {
 
     fn get_container_args(&self) -> Vec<String> {
         [
-            format!("--{}", self.network),
+            format!("--{}", self.args.network),
             "--enable rpc,horizon".to_string(),
             self.get_protocol_version_arg(),
             self.get_limits_arg(),
@@ -146,7 +162,7 @@ impl Cmd {
     // The port mapping in the bollard crate is formatted differently than the docker CLI. In the docker CLI, we usually specify exposed ports as `-p  HOST_PORT:CONTAINER_PORT`. But with the bollard crate, it is expecting the port mapping to be a map of the container port (with the protocol) to the host port.
     fn get_port_mapping(&self) -> HashMap<String, Option<Vec<PortBinding>>> {
         let mut port_mapping_hash = HashMap::new();
-        for port_mapping in &self.ports_mapping {
+        for port_mapping in &self.args.ports_mapping {
             let ports_vec: Vec<&str> = port_mapping.split(':').collect();
             let from_port = ports_vec[0];
             let to_port = ports_vec[1];
@@ -164,31 +180,33 @@ impl Cmd {
     }
 
     fn container_name(&self) -> Name {
-        Name(self.name.clone().unwrap_or(self.network.to_string()))
+        Name(
+            self.args
+                .name
+                .clone()
+                .unwrap_or(self.args.network.to_string()),
+        )
     }
 
-    fn print_log_message(&self) {
-        let log_message = format!(
-            "ℹ️ To see the logs for this container run: stellar network container logs {container_name} {additional_flags}",
-            container_name = self.container_name().get_external_container_name(),
-            additional_flags = self.container_args.get_additional_flags(),
-        );
-        println!("{log_message}");
-    }
+    fn print_instructions(&self) {
+        let container_name = self.container_name().get_external_container_name().clone();
+        let additional_flags = self.args.container_args.get_additional_flags().clone();
+        let tail = format!("{container_name} {additional_flags}");
 
-    fn print_stop_message(&self) {
-        let stop_message =
-            format!(
-            "ℹ️ To stop this container run: stellar network container stop {container_name} {additional_flags}",
-            container_name = self.container_name().get_external_container_name(),
-            additional_flags = self.container_args.get_additional_flags(),
-        );
-        println!("{stop_message}");
+        self.print.searchln(format!(
+            "You can see logs by running `stellar network container logs {}`",
+            tail.trim()
+        ));
+
+        self.print.infoln(format!(
+            "To stop this container, use `stellar network container stop {}`",
+            tail.trim()
+        ));
     }
 
     fn get_protocol_version_arg(&self) -> String {
-        if self.network == Network::Local && self.protocol_version.is_some() {
-            let version = self.protocol_version.as_ref().unwrap();
+        if self.args.network == Network::Local && self.args.protocol_version.is_some() {
+            let version = self.args.protocol_version.as_ref().unwrap();
             format!("--protocol-version {version}")
         } else {
             String::new()
@@ -196,8 +214,8 @@ impl Cmd {
     }
 
     fn get_limits_arg(&self) -> String {
-        if self.network == Network::Local && self.limits.is_some() {
-            let limits = self.limits.as_ref().unwrap();
+        if self.args.network == Network::Local && self.args.limits.is_some() {
+            let limits = self.args.limits.as_ref().unwrap();
             format!("--limits {limits}")
         } else {
             String::new()

--- a/cmd/soroban-cli/src/commands/network/container/stop.rs
+++ b/cmd/soroban-cli/src/commands/network/container/stop.rs
@@ -1,4 +1,7 @@
-use crate::commands::network::container::shared::Error as BollardConnectionError;
+use crate::{
+    commands::{global, network::container::shared::Error as BollardConnectionError},
+    print,
+};
 
 use super::shared::{Args, Name};
 
@@ -28,18 +31,22 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = print::Print::new(global_args.quiet);
         let container_name = Name(self.name.clone());
         let docker = self.container_args.connect_to_docker().await?;
-        println!(
-            "ℹ️ Stopping container: {}",
+
+        print.infoln(format!(
+            "Stopping {} container",
             container_name.get_external_container_name()
-        );
+        ));
+
         docker
             .stop_container(&container_name.get_internal_container_name(), None)
             .await
             .map_err(|e| {
                 let msg = e.to_string();
+
                 if msg.contains("No such container") {
                     Error::ContainerNotFound {
                         container_name: container_name.get_external_container_name(),
@@ -49,10 +56,9 @@ impl Cmd {
                     Error::ContainerStopFailed(e)
                 }
             })?;
-        println!(
-            "✅ Container stopped: {}",
-            container_name.get_external_container_name()
-        );
+
+        print.checkln("Container has been stopped");
+
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/network/container/stop.rs
+++ b/cmd/soroban-cli/src/commands/network/container/stop.rs
@@ -57,7 +57,7 @@ impl Cmd {
                 }
             })?;
 
-        print.checkln("Container has been stopped");
+        print.checkln("Container stopped");
 
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 use crate::rpc::{self};
 
-use super::config::locator;
+use super::{config::locator, global};
 
 pub mod add;
 pub mod container;
@@ -81,22 +81,22 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
             Cmd::Add(cmd) => cmd.run()?,
             Cmd::Rm(new) => new.run()?,
             Cmd::Ls(cmd) => cmd.run()?,
-            Cmd::Container(cmd) => cmd.run().await?,
+            Cmd::Container(cmd) => cmd.run(global_args).await?,
 
             // TODO Remove this once `network start` is removed
             Cmd::Start(cmd) => {
                 eprintln!("⚠️ Warning: `network start` has been deprecated. Use `network container start` instead");
-                cmd.run().await?;
+                cmd.run(global_args).await?;
             }
             // TODO Remove this once `network stop` is removed
             Cmd::Stop(cmd) => {
                 println!("⚠️ Warning: `network stop` has been deprecated. Use `network container stop` instead");
-                cmd.run().await?;
+                cmd.run(global_args).await?;
             }
         };
         Ok(())


### PR DESCRIPTION
### What

```console
$ stellar network container start testnet
ℹ️ Starting testnet network
✅ Started container
🔎 You can see logs by running `stellar network container logs testnet`
ℹ️ To stop this container, use `stellar network container stop testnet`

$ stellar network container stop testnet
ℹ️ Stopping testnet container
✅ Container has been stopped
```

### Why

So we only have one way of printing rich output everywhere.

### Known limitations

N/A
