### PR TITLE
Add dev shell environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ snapshot.json
 test_snapshots
 .vscode/settings.json
 .idea
+local.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ There are 2 ways to being developing stellar-cli:
 
 ### Installing all required dependencies 
 
-You may want to install all required dependencies locally. This includes installing `rustup`, `make`, `libudev`, `jq` from your package manager. After all dependencies are installed, you can start with running `make build` to build `stellar-cli` on your machine! 
+You may want to install all required dependencies locally. This includes installing `rustup`, `make`, `libudev`, `jq` from your package manager. After all dependencies are installed, you can start with running `make install` to build `stellar-cli` and install it! 
 
 ### Using `nix`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,31 @@ changes quickly.
   * Clearly describe the issue including steps to reproduce if it is a bug.
 * Fork the repository on GitHub.
 
+## Setting up development environment
+
+There are 2 ways to being developing stellar-cli:
+
+### Installing all required dependencies 
+
+You may want to install all required dependencies locally. This includes installing `rustup`, `make`, `libudev`, `jq` from your package manager. After all dependencies are installed, you can start with running `make build` to build `stellar-cli` on your machine! 
+
+### Using `nix`
+
+If you don't want to install necessary dependencies from above, you can run development shell using [nix](https://nixos.org/guides/how-nix-works/) (make sure to [install](https://nixos.org/download/) version above 2.20). After installing `nix`, simply run `nix develop` that will start new `bash` session in your current terminal. If you want to use different shell (e.g. `zsh`) you can run `nix develop -c zsh`
+
+This session will have:
+1. All required dependencies installed
+2. `stellar` alias (overwriting your existing `stellar` installed via cargo, if any)
+3. Configured auto-complete for the working git branch
+
+You can add extra configuration in your `local.sh` file (for example, if you want to export some extra variables for your devshell you can put following in your `local.sh`:
+```shell
+#!/usr/bin/env bash
+export STELLAR_NETWORK=testnet
+```
+Note that all of dependencies and configurations mentioned above is available only in your local development shell, not outside of it.
+
+
 ### Minor Changes
 
 #### Documentation

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722813957,
+        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1722997267,
+        "narHash": "sha256-8Pncp8IKd0f0N711CRrCGTC4iLfBE+/5kaMqyWxnYic=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d720bf3cebac38c2426d77ee2e59943012854cb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "stellar-cli development shell";
+
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      with pkgs;
+      {
+        devShells.default = mkShell {
+          buildInputs = [
+            openssl
+            pkg-config
+            libudev-zero
+            jq
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-src" ];
+              targets = [ "wasm32-unknown-unknown" ];
+            })
+          ];
+          shellHook =
+          ''
+            echo "Using `nix --version`"
+            alias stellar="cargo run --bin stellar --"
+            SOROBAN_SECRET_KEY=SBPXU3OP65M2DQPRM4YFZ5NME66NWWH5DHN44IBDYAN4TFKKY7CS4OHY stellar keys add dev_key
+            export STELLAR_NETWORK=testnet
+            export STELLAR_ACCOUNT=dev_key
+            shell=$SHELL
+            shell=`basename $SHELL`
+            source <(stellar completion --shell $shell)
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,9 +32,7 @@
           ''
             echo "Using `nix --version`"
             alias stellar="cargo run --bin stellar --"
-            SOROBAN_SECRET_KEY=SBPXU3OP65M2DQPRM4YFZ5NME66NWWH5DHN44IBDYAN4TFKKY7CS4OHY stellar keys add dev_key
-            export STELLAR_NETWORK=testnet
-            export STELLAR_ACCOUNT=dev_key
+            [ -f ./local.sh ] && source ./local.sh
             shell=$0
             shell=`basename $SHELL`
             source <(stellar completion --shell $shell)

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             SOROBAN_SECRET_KEY=SBPXU3OP65M2DQPRM4YFZ5NME66NWWH5DHN44IBDYAN4TFKKY7CS4OHY stellar keys add dev_key
             export STELLAR_NETWORK=testnet
             export STELLAR_ACCOUNT=dev_key
-            shell=$SHELL
+            shell=$0
             shell=`basename $SHELL`
             source <(stellar completion --shell $shell)
           '';


### PR DESCRIPTION
### What

This PR adds a [devshell environment](https://nix.dev/tutorials/first-steps/declarative-shell.html) using [nix](https://nixos.org/guides/how-nix-works/) 
### Why

Currently, in order to develop stellar-cli locally you need to install some dependencies, and sometimes you also need to modify your `.<shell>rc` file to make your environment easy to use for development.
However, this makes switching between different branches/versions or switching between development/production builds more complicated.
This change adds a configuration for a development shell, which automatically does the following:
1. Installs all necessary dependencies (only accessible in the shell) -> rust, make, libudev, etc. without affecting your global environment. Dependencies are pinned into the lockfile. We can always update rust version to latest stable or change it to nightly with re-generating lockfile/changing nix config. Dependencies are installed once and cached. Can clean them out of your system with `nix collect-garbage`.
2. Setup `stellar` alias, configure development key and environment (set `STELLAR_NETWORK` and `STELLAR_ACCOUNT` variables) 
3. Add up-to-date autocomplete in the shell

Developer simply needs to install nix and run `nix develop`

This should work both on any Linux distro, Mac (Darwin builds are available for all packages in nixpkgs) and Windows WSL 

### Known limitations

[nix](https://nixos.org/download/) is required to be installed in the system, with v2.20+
Currently `bash` is used as a default shell. It's possible to use other shells with `nix develop -c zsh`