### PR TITLE
Fix invoke send default behavior

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -498,11 +498,11 @@ stellar contract invoke ... -- --help
 * `--sim-only` — Simulate the transaction and only write the base64 xdr to stdout
 * `--send <SEND>` — Whether or not to send a transaction
 
-  Default value: `if-write`
+  Default value: `default`
 
   Possible values:
-  - `if-write`:
-    Only send transaction if there are ledger writes or published events, otherwise return simulation result
+  - `default`:
+    Only send transaction if simulation indicates there are ledger writes, published events, or auth required, otherwise return simulation result
   - `no`:
     Do not send transaction, return simulation result
   - `yes`:

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -502,7 +502,7 @@ stellar contract invoke ... -- --help
 
   Possible values:
   - `default`:
-    Only send transaction if simulation indicates there are ledger writes, published events, or auth required, otherwise return simulation result
+    Send transaction if simulation indicates there are ledger writes, published events, or auth required, otherwise return simulation result
   - `no`:
     Do not send transaction, return simulation result
   - `yes`:

--- a/cmd/crates/soroban-test/tests/it/integration/custom_types.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/custom_types.rs
@@ -201,16 +201,14 @@ fn void(sandbox: &TestEnv, id: &str) {
     invoke_custom(sandbox, id, "woid")
         .assert()
         .success()
-        .stdout("\n")
-        .stderr("");
+        .stdout("\n");
 }
 
 fn val(sandbox: &TestEnv, id: &str) {
     invoke_custom(sandbox, id, "val")
         .assert()
         .success()
-        .stdout("null\n")
-        .stderr("");
+        .stdout("null\n");
 }
 
 async fn i32(sandbox: &TestEnv, id: &str) {

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -388,7 +388,7 @@ impl NetworkRunnable for Cmd {
             (res.return_value()?, events)
         } else {
             let print = print::Print::new(global_args.map_or(false, |g| g.quiet));
-            print.infoln("Invoke simulated only because simulation identified a read-only transaction. To send invoke to network in a transaction use --send=yes.");
+            print.infoln("Send skipped because simulation identified a read-only invoke. Send invoke to network with `--send=yes`.");
             (sim_res.results()?[0].xdr.clone(), sim_res.events()?)
         };
         crate::log::events(&events);

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -58,7 +58,7 @@ pub struct Cmd {
     #[command(flatten)]
     pub fee: crate::fee::Args,
     /// Whether or not to send a transaction
-    #[arg(long, value_enum, env = "STELLAR_SEND")]
+    #[arg(long, value_enum, default_value_t, env = "STELLAR_SEND")]
     pub send: Send,
 }
 
@@ -598,7 +598,7 @@ fn has_write(sim_res: &SimulateTransactionResponse) -> Result<bool, Error> {
 }
 
 fn has_published_event(sim_res: &SimulateTransactionResponse) -> Result<bool, Error> {
-    Ok(!sim_res.events()?.iter().any(
+    Ok(sim_res.events()?.iter().any(
         |DiagnosticEvent {
              event: ContractEvent { type_, .. },
              ..
@@ -607,7 +607,7 @@ fn has_published_event(sim_res: &SimulateTransactionResponse) -> Result<bool, Er
 }
 
 fn has_auth(sim_res: &SimulateTransactionResponse) -> Result<bool, Error> {
-    Ok(!sim_res
+    Ok(sim_res
         .results()?
         .iter()
         .any(|SimulateHostFunctionResult { auth, .. }| !auth.is_empty()))

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -585,7 +585,7 @@ Note: The only types which aren't JSON are Bytes and BytesN, which are raw bytes
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum, Default)]
 pub enum Send {
-    /// Only send transaction if simulation indicates there are ledger writes,
+    /// Send transaction if simulation indicates there are ledger writes,
     /// published events, or auth required, otherwise return simulation result
     #[default]
     Default,

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -29,6 +29,7 @@ use super::super::events;
 use crate::commands::txn_result::{TxnEnvelopeResult, TxnResult};
 use crate::commands::NetworkRunnable;
 use crate::get_spec::{self, get_remote_contract_spec};
+use crate::print;
 use crate::{
     commands::global,
     config::{self, data, locator, network},
@@ -386,6 +387,8 @@ impl NetworkRunnable for Cmd {
                 .unwrap_or_default();
             (res.return_value()?, events)
         } else {
+            let print = print::Print::new(global_args.map_or(false, |g| g.quiet));
+            print.infoln("Invoke simulated only because simulation identified a read-only transaction. To send invoke to network in a transaction use --send=yes.");
             (sim_res.results()?[0].xdr.clone(), sim_res.events()?)
         };
         crate::log::events(&events);

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -18,21 +18,21 @@ impl Print {
 
     pub fn print<T: Display + Sized>(&self, message: T) {
         if !self.quiet {
-            print!("{message}");
+            eprint!("{message}");
         }
     }
 
     pub fn println<T: Display + Sized>(&self, message: T) {
         if !self.quiet {
-            println!("{message}");
+            eprintln!("{message}");
         }
     }
 
     pub fn clear_line(&self) {
         if cfg!(windows) {
-            print!("\r");
+            eprint!("\r");
         } else {
-            print!("\r\x1b[2K");
+            eprint!("\r\x1b[2K");
         }
     }
 
@@ -66,14 +66,14 @@ macro_rules! create_print_functions {
             #[allow(dead_code)]
             pub fn $name<T: Display + Sized>(&self, message: T) {
                 if !self.quiet {
-                    print!("{} {}", $icon, message);
+                    eprint!("{} {}", $icon, message);
                 }
             }
 
             #[allow(dead_code)]
             pub fn $nameln<T: Display + Sized>(&self, message: T) {
                 if !self.quiet {
-                    println!("{} {}", $icon, message);
+                    eprintln!("{} {}", $icon, message);
                 }
             }
         }


### PR DESCRIPTION
### What
Change the recently merged (and not yet released) invoke `--send` default behavior so that by default send occurs if there are any contract events, send occurs if there is any soroban auth involved, and change the name of the default enum value to `default`.

Also add output that tells the user simulation-only has occurred automatically.

### Why
There's a bug in the code that checks if there are any events, a not that shouldn't be present, so the default behavior is sending when there are no events, rather when there are events.

Also, if auth is required it's more ambiguous to if a user would expect or not a transaction to be sent. Since read-only operations are rarely gated by auth, we can probably assume auth means the transaction should be sent, even if we can't otherwise detect a write to storage or a published event. It could be that the auth itself will do one of these two things and sending to the network could be desirable because of that.

The default behavior of sending should for the most part be as least surprising as possible. It's meant to be an optimisation for when folks are truly calling those read-only operations where sending makes little sense, but if there's any doubt it should just send.

I renamed the enum value because this isn't released yet and because `if-write` doesn't feel like it fully captures the default behavior given the addition of the auth logic. Given the default behavior is somewhat complex I named it `default` influenced by some of the git cli's options where it uses that term for default behavior that isn't easy to capture in another word.