### PR TITLE
Add `other_custom_types` example

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -400,7 +400,7 @@ Initialize a Soroban project with an example contract
 
 * `-w`, `--with-example <WITH_EXAMPLE>` — An optional flag to specify Soroban example contracts to include. A hello-world contract will be included by default.
 
-  Possible values: `account`, `alloc`, `atomic_multiswap`, `atomic_swap`, `auth`, `cross_contract`, `custom_types`, `deep_contract_auth`, `deployer`, `errors`, `eth_abi`, `events`, `fuzzing`, `increment`, `liquidity_pool`, `logging`, `mint-lock`, `simple_account`, `single_offer`, `timelock`, `token`, `ttl`, `upgradeable_contract`, `workspace`
+  Possible values: `account`, `alloc`, `atomic_multiswap`, `atomic_swap`, `auth`, `cross_contract`, `custom_types`, `deep_contract_auth`, `deployer`, `errors`, `eth_abi`, `events`, `fuzzing`, `increment`, `liquidity_pool`, `logging`, `mint-lock`, `other_custom_types`, `simple_account`, `single_offer`, `timelock`, `token`, `ttl`, `upgradeable_contract`, `workspace`
 
 * `--frontend-template <FRONTEND_TEMPLATE>` — An optional flag to pass in a url for a frontend template repository.
 

--- a/cmd/soroban-cli/example_contracts.list
+++ b/cmd/soroban-cli/example_contracts.list
@@ -15,6 +15,7 @@ increment
 liquidity_pool
 logging
 mint-lock
+other_custom_types
 simple_account
 single_offer
 timelock


### PR DESCRIPTION
### What

Adds `other_custom_types` to example list (https://github.com/stellar/soroban-examples/pull/322)

### Why

Keeping list synced with the examples

### Known limitations

N/A
