### PR TITLE
Print status messages when pulling quickstart image

### DIFF
--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -102,8 +102,11 @@ impl Runner {
                     }
                 }
             } else {
-                self.print.warnln("Failed to fetch image from Docker Hub.");
-                self.print.warnln("Attempting to start local quickstart image. The image may be out-of-date.");
+                self.print
+                    .warnln(format!("Failed to fetch image: {image}."));
+                self.print.warnln(
+                    "Attempting to start local quickstart image. The image may be out-of-date.",
+                );
                 break;
             }
         }

--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -92,22 +92,19 @@ impl Runner {
         );
 
         while let Some(result) = stream.try_next().await.transpose() {
-            match result {
-                Ok(item) => {
-                    if let Some(status) = item.status {
-                        if status.contains("Pulling from")
-                            || status.contains("Digest")
-                            || status.contains("Status")
-                        {
-                            self.print.infoln(format!("{}", status));
-                        }
+            if let Ok(item) = result {
+                if let Some(status) = item.status {
+                    if status.contains("Pulling from")
+                        || status.contains("Digest")
+                        || status.contains("Status")
+                    {
+                        self.print.infoln(status);
                     }
                 }
-                Err(_) => {
-                    self.print.warnln("Failed to fetch image from Docker Hub.");
-                    self.print.warnln("Attempting to start local quickstart image instead. Please note this image may be out-of-date.");
-                    break;
-                }
+            } else {
+                self.print.warnln("Failed to fetch image from Docker Hub.");
+                self.print.warnln("Attempting to start local quickstart image instead. Please note this image may be out-of-date.");
+                break;
             }
         }
 

--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -103,7 +103,7 @@ impl Runner {
                 }
             } else {
                 self.print.warnln("Failed to fetch image from Docker Hub.");
-                self.print.warnln("Attempting to start local quickstart image instead. Please note this image may be out-of-date.");
+                self.print.warnln("Attempting to start local quickstart image. The image may be out-of-date.");
                 break;
             }
         }

--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -91,13 +91,22 @@ impl Runner {
             None,
         );
 
-        while let Ok(Some(output)) = stream.try_next().await {
-            if let Some(status) = output.status {
-                if status.contains("Pulling from")
-                    || status.contains("Digest")
-                    || status.contains("Status")
-                {
-                    self.print.infoln(format!("{}", status));
+        while let Some(result) = stream.try_next().await.transpose() {
+            match result {
+                Ok(item) => {
+                    if let Some(status) = item.status {
+                        if status.contains("Pulling from")
+                            || status.contains("Digest")
+                            || status.contains("Status")
+                        {
+                            self.print.infoln(format!("{}", status));
+                        }
+                    }
+                }
+                Err(_) => {
+                    self.print.warnln("Failed to fetch image from Docker Hub.");
+                    self.print.warnln("Attempting to start local quickstart image instead. Please note this image may be out-of-date.");
+                    break;
                 }
             }
         }

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -88,3 +88,4 @@ create_print_functions!(info, infoln, "ℹ️");
 create_print_functions!(link, linkln, "🔗");
 create_print_functions!(save, saveln, "💾");
 create_print_functions!(search, searchln, "🔎");
+create_print_functions!(warn, warnln, "⚠️");


### PR DESCRIPTION
### What

Closes https://github.com/stellar/stellar-cli/issues/1354

To make sure that the user is aware if they are using an up-to-date version of the quickstart image or not, this PR adds some additional logging with that information. 

### when the image is on the local machine
#### with internet connection
```
$ stellar network container start local
ℹ️ Starting local network
ℹ️ Pulling from stellar/quickstart
ℹ️ Digest: sha256:12d852bb5224f72415cb74624eabc2220c83cd16b2ea50646a6b078b219c430e
ℹ️ Status: Image is up to date for stellar/quickstart:testing
✅ Started container
🔎 Watch logs with `stellar network container logs local`
ℹ️ Stop the container with `stellar network container stop local`
```

#### without internet connection
```
$ stellar network container start local
ℹ️ Starting local network
⚠️ Failed to fetch image from dockerhub.
⚠️ Attempting to start local quickstart image instead. Please note this image may be out-of-date.
✅ Started container
🔎 Watch logs with `stellar network container logs local`
ℹ️ Stop the container with `stellar network container stop local`
```

### when the image has not been pulled to the machine

#### with internet connection
```
$ stellar network container start local
ℹ️ Starting local network
ℹ️ Pulling from stellar/quickstart
ℹ️ Digest: sha256:12d852bb5224f72415cb74624eabc2220c83cd16b2ea50646a6b078b219c430e
ℹ️ Status: Downloaded newer image for stellar/quickstart:testing
✅ Started container
🔎 Watch logs with `stellar network container logs local`
ℹ️ Stop the container with `stellar network container stop local`
```

#### without internet connection
```
$ stellar network container start local
ℹ️ Starting local network
⚠️ Failed to fetch image from Docker Hub.
⚠️ Attempting to start local quickstart image instead. Please note this image may be out-of-date.
error: ⛔ ️Failed to create container: Docker responded with status code 404: No such image: stellar/quickstart:testing
```

### Why

#1354 was to make sure that users are easily able to use the most up-to-date version of a given quickstart image. Since we were already doing `docker pull` and `docker run` on `stellar network container start` this is happening already by default, but was not very clear. This PR aims to make that a bit more visible. Also its important to note that if the user already has the most recent version of an image tag, it will not re-download it, but will just verify the local image's digest vs dockerhub to make sure that it's up-to-date.

### Known limitations

n/a

