### PR TITLE
Add `contract alias remove`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -76,6 +76,7 @@ Tools for smart contract developers
 ###### **Subcommands:**
 
 * `asset` — Utilities to deploy a Stellar Asset Contract or get its id
+* `alias` — Utilities to manage contract aliases
 * `bindings` — Generate code client bindings for a contract
 * `build` — Build a contract from source
 * `extend` — Extend the time to live ledger of a contract-data ledger entry
@@ -148,6 +149,38 @@ Deploy builtin Soroban Asset Contract
 * `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
 * `--build-only` — Build the transaction and only write the base64 xdr to stdout
 * `--sim-only` — Simulate the transaction and only write the base64 xdr to stdout
+
+
+
+## `stellar contract alias`
+
+Utilities to manage contract aliases
+
+**Usage:** `stellar contract alias <COMMAND>`
+
+###### **Subcommands:**
+
+* `remove` — Remove contract alias
+
+
+
+## `stellar contract alias remove`
+
+Remove contract alias
+
+**Usage:** `stellar contract alias remove [OPTIONS] <ALIAS>`
+
+###### **Arguments:**
+
+* `<ALIAS>` — The contract alias that will be removed
+
+###### **Options:**
+
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--network <NETWORK>` — Name of network to use from config
 
 
 

--- a/cmd/soroban-cli/src/commands/contract/alias.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias.rs
@@ -1,0 +1,24 @@
+use crate::commands::global;
+
+pub mod remove;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Cmd {
+    /// Remove contract alias
+    Remove(remove::Cmd),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Remove(#[from] remove::Error),
+}
+
+impl Cmd {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        match &self {
+            Cmd::Remove(remove) => remove.run(global_args).await?,
+        }
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/alias/remove.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/remove.rs
@@ -1,0 +1,72 @@
+use std::fmt::Debug;
+
+use clap::{command, Parser};
+
+use crate::commands::{config::network, global};
+use crate::config::locator;
+use crate::print::Print;
+
+#[derive(Parser, Debug, Clone)]
+// #[command(group(
+//     clap::ArgGroup::new("wasm_src")
+//         .required(true)
+//         .args(&["wasm", "wasm_hash"]),
+// ))]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+
+    #[command(flatten)]
+    network: network::Args,
+
+    /// The contract alias that will be removed.
+    pub alias: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Locator(#[from] locator::Error),
+
+    #[error(transparent)]
+    Network(#[from] network::Error),
+
+    #[error("no contract found with alias `{alias}`")]
+    NoContract { alias: String },
+}
+
+impl Cmd {
+    #[allow(clippy::unused_async)]
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = Print::new(global_args.quiet);
+        let alias = &self.alias;
+        let network = self.network.get(&self.config_locator)?;
+
+        print.infoln(format!(
+            "Network passphrase: {passphrase}",
+            passphrase = network.network_passphrase
+        ));
+
+        let contract = self
+            .config_locator
+            .get_contract_id(&self.alias, &network.network_passphrase)?;
+
+        if contract.is_none() {
+            return Err(Error::NoContract {
+                alias: alias.into(),
+            });
+        };
+
+        let contract = contract.expect("contract must be set");
+
+        print.infoln(format!("Contract is {contract}"));
+
+        self.config_locator
+            .remove_contract_id(&network.network_passphrase, alias)?;
+
+        print.checkln("Contract alias has been removed");
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -1,3 +1,4 @@
+pub mod alias;
 pub mod asset;
 pub mod bindings;
 pub mod build;
@@ -21,6 +22,11 @@ pub enum Cmd {
     /// Utilities to deploy a Stellar Asset Contract or get its id
     #[command(subcommand)]
     Asset(asset::Cmd),
+
+    /// Utilities to manage contract aliases
+    #[command(subcommand)]
+    Alias(alias::Cmd),
+
     /// Generate code client bindings for a contract
     #[command(subcommand)]
     Bindings(bindings::Cmd),
@@ -83,6 +89,9 @@ pub enum Error {
     Asset(#[from] asset::Error),
 
     #[error(transparent)]
+    Alias(#[from] alias::Error),
+
+    #[error(transparent)]
     Bindings(#[from] bindings::Error),
 
     #[error(transparent)]
@@ -132,6 +141,7 @@ impl Cmd {
             Cmd::Bindings(bindings) => bindings.run().await?,
             Cmd::Build(build) => build.run()?,
             Cmd::Extend(extend) => extend.run().await?,
+            Cmd::Alias(alias) => alias.run(global_args).await?,
             Cmd::Deploy(deploy) => deploy.run(global_args).await?,
             Cmd::Id(id) => id.run()?,
             Cmd::Info(info) => info.run().await?,


### PR DESCRIPTION
### What

Add command to remove contract aliases.

```console
$ cat ~/.config/soroban/contract-ids/increment.json
{"ids":{"Test SDF Network ; September 2015":"CCYBGMETD5TYZJ2ZBT3JBBCWODYJJWP274JA4LX4S7JGNUNQPXZBMNUY"}}%

$ cargo run contract alias remove increment --network standalone --global
   Compiling soroban-cli v21.4.1 (/Users/fnando/Projects/stellar/stellar-cli/cmd/soroban-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.22s
     Running `target/debug/soroban contract alias remove increment --network standalone --global`
ℹ️ Network passphrase: Standalone Network ; February 2017
error: no contract found with alias `increment`

$ cargo run contract alias remove increment --network testnet --global
   Compiling soroban-cli v21.4.1 (/Users/fnando/Projects/stellar/stellar-cli/cmd/soroban-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.01s
     Running `target/debug/soroban contract alias remove increment --network testnet --global`
ℹ️ Network passphrase: Test SDF Network ; September 2015
ℹ️ Contract is CCYBGMETD5TYZJ2ZBT3JBBCWODYJJWP274JA4LX4S7JGNUNQPXZBMNUY
✅ Contract alias has been removed

$ cat ~/.config/soroban/contract-ids/increment.json
{"ids":{}}%
```

### Why

https://github.com/stellar/stellar-cli/issues/1420

### Known limitations

N/A
