### PR TITLE
Add `contract alias add`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -161,6 +161,7 @@ Utilities to manage contract aliases
 ###### **Subcommands:**
 
 * `remove` — Remove contract alias
+* `add` — Add contract alias
 
 
 
@@ -181,6 +182,28 @@ Remove contract alias
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config
+
+
+
+## `stellar contract alias add`
+
+Add contract alias
+
+**Usage:** `stellar contract alias add [OPTIONS] --id <CONTRACT_ID> <ALIAS>`
+
+###### **Arguments:**
+
+* `<ALIAS>` — The contract alias that will be removed
+
+###### **Options:**
+
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--network <NETWORK>` — Name of network to use from config
+* `--overwrite` — Overwrite the contract alias if it already exists
+* `--id <CONTRACT_ID>` — The contract id that will be associated with the alias
 
 
 

--- a/cmd/soroban-cli/src/commands/contract/alias.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias.rs
@@ -1,23 +1,31 @@
 use crate::commands::global;
 
+pub mod add;
 pub mod remove;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
     /// Remove contract alias
     Remove(remove::Cmd),
+
+    /// Add contract alias
+    Add(add::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
     Remove(#[from] remove::Error),
+
+    #[error(transparent)]
+    Add(#[from] add::Error),
 }
 
 impl Cmd {
-    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match &self {
-            Cmd::Remove(remove) => remove.run(global_args).await?,
+            Cmd::Remove(remove) => remove.run(global_args)?,
+            Cmd::Add(add) => add.run(global_args)?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/alias/add.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/add.rs
@@ -1,0 +1,87 @@
+use std::fmt::Debug;
+
+use clap::{command, Parser};
+
+use crate::commands::{config::network, global};
+use crate::config::locator;
+use crate::print::Print;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+
+    #[command(flatten)]
+    network: network::Args,
+
+    /// The contract alias that will be removed.
+    pub alias: String,
+
+    /// Overwrite the contract alias if it already exists.
+    #[arg(long)]
+    pub overwrite: bool,
+
+    /// The contract id that will be associated with the alias.
+    #[arg(long = "id")]
+    pub contract_id: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Locator(#[from] locator::Error),
+
+    #[error(transparent)]
+    Network(#[from] network::Error),
+
+    #[error("no contract found with alias `{alias}`")]
+    NoContract { alias: String },
+
+    #[error(
+        "alias '{alias}' is already referencing contract '{contract}' on network '{network_passphrase}'"
+    )]
+    AlreadyExist {
+        alias: String,
+        network_passphrase: String,
+        contract: String,
+    },
+}
+
+impl Cmd {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = Print::new(global_args.quiet);
+        let alias = &self.alias;
+        let network = self.network.get(&self.config_locator)?;
+        let network_passphrase = &network.network_passphrase;
+
+        let contract = self
+            .config_locator
+            .get_contract_id(&self.alias, network_passphrase)?;
+
+        if let Some(contract) = contract {
+            if contract != self.contract_id && !self.overwrite {
+                return Err(Error::AlreadyExist {
+                    alias: alias.to_string(),
+                    network_passphrase: network_passphrase.to_string(),
+                    contract,
+                });
+            }
+        };
+
+        print.infoln(format!(
+            "Contract alias '{alias}' will reference {contract} on network '{network_passphrase}'",
+            contract = self.contract_id
+        ));
+
+        self.config_locator.save_contract_id(
+            &network.network_passphrase,
+            &self.contract_id,
+            alias,
+        )?;
+
+        print.checkln(format!("Contract alias '{alias}' has been added"));
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/alias/add.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/add.rs
@@ -24,7 +24,7 @@ pub struct Cmd {
 
     /// The contract id that will be associated with the alias.
     #[arg(long = "id")]
-    pub contract_id: String,
+    pub contract_id: stellar_strkey::Contract,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -57,7 +57,7 @@ impl Cmd {
             .get_contract_id(&self.alias, network_passphrase)?;
 
         if let Some(contract) = contract {
-            if contract != self.contract_id && !self.overwrite {
+            if contract != self.contract_id.to_string() && !self.overwrite {
                 return Err(Error::AlreadyExist {
                     alias: alias.to_string(),
                     network_passphrase: network_passphrase.to_string(),
@@ -73,7 +73,7 @@ impl Cmd {
 
         self.config_locator.save_contract_id(
             &network.network_passphrase,
-            &self.contract_id,
+            &self.contract_id.to_string(),
             alias,
         )?;
 

--- a/cmd/soroban-cli/src/commands/contract/alias/add.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/add.rs
@@ -35,9 +35,6 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] network::Error),
 
-    #[error("no contract found with alias `{alias}`")]
-    NoContract { alias: String },
-
     #[error(
         "alias '{alias}' is already referencing contract '{contract}' on network '{network_passphrase}'"
     )]

--- a/cmd/soroban-cli/src/commands/contract/alias/remove.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/remove.rs
@@ -32,8 +32,7 @@ pub enum Error {
 }
 
 impl Cmd {
-    #[allow(clippy::unused_async)]
-    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = Print::new(global_args.quiet);
         let alias = &self.alias;
         let network = self.network.get(&self.config_locator)?;

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -141,7 +141,7 @@ impl Cmd {
             Cmd::Bindings(bindings) => bindings.run().await?,
             Cmd::Build(build) => build.run()?,
             Cmd::Extend(extend) => extend.run().await?,
-            Cmd::Alias(alias) => alias.run(global_args).await?,
+            Cmd::Alias(alias) => alias.run(global_args)?,
             Cmd::Deploy(deploy) => deploy.run(global_args).await?,
             Cmd::Id(id) => id.run()?,
             Cmd::Info(info) => info.run().await?,


### PR DESCRIPTION
### What

```console
$ cargo run contract alias add increment --id CDUQDWIBBXWYHEEROXASCIBNZOZ45WJ3EOMAGMG4VTY36O2SGQTWCM23 --network testnet --global --overwrite
   Compiling soroban-cli v21.4.1 (/Users/fnando/Projects/stellar/stellar-cli/cmd/soroban-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.09s
     Running `target/debug/soroban contract alias add increment --id CDUQDWIBBXWYHEEROXASCIBNZOZ45WJ3EOMAGMG4VTY36O2SGQTWCM23 --network testnet --global --overwrite`
ℹ️ Contract alias 'increment' will reference CDUQDWIBBXWYHEEROXASCIBNZOZ45WJ3EOMAGMG4VTY36O2SGQTWCM23 on network 'Test SDF Network ; September 2015'
✅ Contract alias 'increment' has been added

$ cargo run contract alias add increment --id CALLOOCCCJRZ6AZAJSKNCTDZ766N4ANVRKRJPHC65KDV7RJCS37PS4XY --network testnet --global
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/soroban contract alias add increment --id CALLOOCCCJRZ6AZAJSKNCTDZ766N4ANVRKRJPHC65KDV7RJCS37PS4XY --network testnet --global`
error: alias 'increment' is already referencing contract 'CDUQDWIBBXWYHEEROXASCIBNZOZ45WJ3EOMAGMG4VTY36O2SGQTWCM23' on network 'Test SDF Network ; September 2015'

$ cargo run contract alias add increment --id CALLOOCCCJRZ6AZAJSKNCTDZ766N4ANVRKRJPHC65KDV7RJCS37PS4XY --network testnet --global --overwrite
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/soroban contract alias add increment --id CALLOOCCCJRZ6AZAJSKNCTDZ766N4ANVRKRJPHC65KDV7RJCS37PS4XY --network testnet --global --overwrite`
ℹ️ Contract alias 'increment' will reference CALLOOCCCJRZ6AZAJSKNCTDZ766N4ANVRKRJPHC65KDV7RJCS37PS4XY on network 'Test SDF Network ; September 2015'
✅ Contract alias 'increment' has been added

$ cargo run contract alias add increment --id invalid --network testnet --global --overwrite
   Compiling soroban-cli v21.4.1 (/Users/fnando/Projects/stellar/stellar-cli/cmd/soroban-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.17s
     Running `target/debug/soroban contract alias add increment --id invalid --network testnet --global --overwrite`
error: invalid value 'invalid' for '--id <CONTRACT_ID>': the strkey is invalid

For more information, try '--help'.

$ cat ~/.config/soroban/contract-ids/increment.json
{"ids":{"Test SDF Network ; September 2015":"CALLOOCCCJRZ6AZAJSKNCTDZ766N4ANVRKRJPHC65KDV7RJCS37PS4XY"}}
```

### Why

https://github.com/stellar/stellar-cli/issues/1420

### Known limitations

N/A
