### PR TITLE
feat: add arg parsing to deploy command to support new constructor feature

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -367,7 +367,11 @@ If no keys are specified the contract itself is extended.
 
 Deploy a wasm contract
 
-**Usage:** `stellar contract deploy [OPTIONS] --source-account <SOURCE_ACCOUNT> <--wasm <WASM>|--wasm-hash <WASM_HASH>>`
+**Usage:** `stellar contract deploy [OPTIONS] --source-account <SOURCE_ACCOUNT> <--wasm <WASM>|--wasm-hash <WASM_HASH>> [-- <CONTRACT_CONSTRUCTOR_ARGS>...]`
+
+###### **Arguments:**
+
+* `<CONTRACT_CONSTRUCTOR_ARGS>` — If provided, in one transaction will deploy and call `__constructor` with provided arguments for that function as `--arg-name value`
 
 ###### **Options:**
 

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -66,6 +66,11 @@ impl Contract {
         );
         log!(&env, "hello {}", str);
     }
+
+    /// Example constructor
+    pub fn __constructor(env: Env, world: String) {
+        log!(&env, "Initialized with {}", world);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
~Depends on #1569.~

If a contract has a method called `__contructor` then it parses the slop, e.i. anything after `--`. So after adding one to the hello world contract you would use it like:

```
cargo s contract deploy --build-only --wasm ./target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm --source default --network testnet -- --help
ℹ️ Using wasm hash 75eca9c92c997f6b1b1c7caba32311e81077f29c2f11eb3be6d453406e939a34
Example constructor
Usage Notes:
Each arg has a corresponding --<arg_name>-file-path which is a path to a file containing the corresponding JSON argument.
Note: The only types which aren't JSON are Bytes and BytesN, which are raw bytes

Usage: __constructor [OPTIONS]

Options:
      --world <String>
          Example:
            --world '"hello world"'

  -h, --help
          Print help (see a summary with '-h')
```

For now this is a noop. And adding the new operation is still needed but hard to test now.

Close #1561 