### PR TITLE
chore: remove unused `enum FrontendTemplate`

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -1,6 +1,6 @@
 use clap::{
     builder::{PossibleValue, PossibleValuesParser, ValueParser},
-    Parser, ValueEnum,
+    Parser,
 };
 use gix::{clone, create, open, progress, remote};
 use rust_embed::RustEmbed;

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -26,12 +26,6 @@ const GITHUB_URL: &str = "https://github.com";
 const WITH_EXAMPLE_LONG_HELP_TEXT: &str =
     "An optional flag to specify Soroban example contracts to include. A hello-world contract will be included by default.";
 
-#[derive(Clone, Debug, ValueEnum, PartialEq)]
-pub enum FrontendTemplate {
-    Astro,
-    None,
-}
-
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {


### PR DESCRIPTION
It was marked as `pub` so the checker didn't tell us it was unused.

But it's not used anywhere else in the codebase.