### PR TITLE
fix: only resolve contract alias if needed when generating ledger keys

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -130,11 +130,7 @@ impl NetworkRunnable for Cmd {
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         tracing::trace!(?network);
-        let contract = config.locator.resolve_contract_id(
-            self.key.contract_id.as_ref().unwrap(),
-            &network.network_passphrase,
-        )?;
-        let keys = self.key.parse_keys(contract)?;
+        let keys = self.key.parse_keys(&config.locator, &network)?;
         let network = &config.get_network()?;
         let client = Client::new(&network.rpc_url)?;
         let key = config.key_pair()?;

--- a/cmd/soroban-cli/src/commands/contract/read.rs
+++ b/cmd/soroban-cli/src/commands/contract/read.rs
@@ -186,11 +186,7 @@ impl NetworkRunnable for Cmd {
         let network = config.get_network()?;
         tracing::trace!(?network);
         let client = Client::new(&network.rpc_url)?;
-        let contract = config.locator.resolve_contract_id(
-            self.key.contract_id.as_ref().unwrap(),
-            &network.network_passphrase,
-        )?;
-        let keys = self.key.parse_keys(contract)?;
+        let keys = self.key.parse_keys(&config.locator, &network)?;
         Ok(client.get_full_ledger_entries(&keys).await?)
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -133,11 +133,7 @@ impl NetworkRunnable for Cmd {
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         tracing::trace!(?network);
-        let contract = config.locator.resolve_contract_id(
-            self.key.contract_id.as_ref().unwrap(),
-            &network.network_passphrase,
-        )?;
-        let entry_keys = self.key.parse_keys(contract)?;
+        let entry_keys = self.key.parse_keys(&config.locator, &network)?;
         let client = Client::new(&network.rpc_url)?;
         let key = config.key_pair()?;
 


### PR DESCRIPTION
Currently for the commands that used `key::Args`, the contract was resolved even if it wasn't required to generate the ledger keys involved.

fixes: #1557 