### PR TITLE
Fix/update init error handling

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/dotenv.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/dotenv.rs
@@ -42,7 +42,7 @@ async fn current_env_not_overwritten() {
         .arg("--world=world")
         .assert()
         .stderr(
-            "error: Contract not found: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4\n",
+            "❌ error: Contract not found: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4\n",
         );
 }
 

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -243,7 +243,7 @@ fn contract_data_read_failure(sandbox: &TestEnv, id: &str) {
         .assert()
         .failure()
         .stderr(
-            "error: no matching contract data entries were found for the specified contract id\n",
+            "❌ error: no matching contract data entries were found for the specified contract id\n",
         );
 }
 

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -4,7 +4,7 @@ use std::thread;
 use tracing_subscriber::{fmt, EnvFilter};
 
 use crate::upgrade_check::upgrade_check;
-use crate::{commands, Root};
+use crate::{commands, print, Root};
 
 #[tokio::main]
 pub async fn main() {
@@ -79,8 +79,9 @@ pub async fn main() {
         upgrade_check(root.global_args.quiet);
     });
 
+    let printer = print::Print::new(root.global_args.quiet);
     if let Err(e) = root.run().await {
-        eprintln!("error: {e}");
+        printer.errorln(format!("error: {e}"));
         std::process::exit(1);
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -406,7 +406,7 @@ impl Runner {
     }
 
     fn copy_frontend_files(&self, from: &Path, to: &Path) -> Result<(), Error> {
-        self.print.infoln("ℹ️  Initializing with frontend template");
+        self.print.infoln("Initializing with frontend template");
         self.copy_contents(from, to)?;
         self.edit_package_json_files(to)
     }

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -60,25 +60,25 @@ pub enum Error {
     #[error("{0}: {1}")]
     Io(String, io::Error),
 
-    #[error("Io Error:")]
+    #[error("io error:")]
     StdIo(#[from] io::Error),
 
     #[error("{0}: {1}")]
     Json(String, JsonError),
 
-    #[error("Failed to parse toml file: {0}")]
+    #[error("failed to parse toml file: {0}")]
     TomlParse(#[from] TomlError),
 
-    #[error("Failed to convert bytes to string: {0}")]
+    #[error("failed to convert bytes to string: {0}")]
     ConvertBytesToString(#[from] str::Utf8Error),
 
-    #[error("Error preparing fetch repository: {0}")]
+    #[error("preparing fetch repository: {0}")]
     PrepareFetch(Box<clone::Error>),
 
-    #[error("Failed to fetch repository: {0}")]
+    #[error("failed to fetch repository: {0}")]
     Fetch(Box<clone::fetch::Error>),
 
-    #[error("Failed to checkout main worktree: {0}")]
+    #[error("failed to checkout main worktree: {0}")]
     Checkout(#[from] clone::checkout::main_worktree::Error),
 }
 
@@ -119,12 +119,8 @@ impl Runner {
 
         if !self.args.frontend_template.is_empty() {
             // create a temp dir for the template repo
-            let fe_template_dir = tempfile::tempdir().map_err(|e| {
-                Error::Io(
-                    "Error creating temp dir for frontend template".to_string(),
-                    e,
-                )
-            })?;
+            let fe_template_dir = tempfile::tempdir()
+                .map_err(|e| Error::Io("creating temp dir for frontend template".to_string(), e))?;
 
             // clone the template repo into the temp dir
             Self::clone_repo(&self.args.frontend_template, fe_template_dir.path())?;
@@ -136,12 +132,8 @@ impl Runner {
         // if there are --with-example flags, include the example contracts
         if self.include_example_contracts() {
             // create an examples temp dir
-            let examples_dir = tempfile::tempdir().map_err(|e| {
-                Error::Io(
-                    "Error creating temp dir for soroban-examples".to_string(),
-                    e,
-                )
-            })?;
+            let examples_dir = tempfile::tempdir()
+                .map_err(|e| Error::Io("creating temp dir for soroban-examples".to_string(), e))?;
 
             // clone the soroban-examples repo into the temp dir
             Self::clone_repo(SOROBAN_EXAMPLES_URL, examples_dir.path())?;
@@ -206,11 +198,11 @@ impl Runner {
             "target",
             "Cargo.lock",
         ];
-        for entry in read_dir(from)
-            .map_err(|e| Error::Io(format!("Error reading directory: {from:?}"), e))?
+        for entry in
+            read_dir(from).map_err(|e| Error::Io(format!("reading directory: {from:?}"), e))?
         {
-            let entry = entry
-                .map_err(|e| Error::Io(format!("Error reading entry in directory {from:?}",), e))?;
+            let entry =
+                entry.map_err(|e| Error::Io(format!("reading entry in directory {from:?}",), e))?;
             let path = entry.path();
             let entry_name = entry.file_name().to_string_lossy().to_string();
             let new_path = to.join(&entry_name);
@@ -248,7 +240,7 @@ impl Runner {
                 copy(&path, &new_path).map_err(|e| {
                     Error::Io(
                         format!(
-                            "Error copying from {:?} to {:?}",
+                            "copying from {:?} to {:?}",
                             path.to_string_lossy(),
                             new_path
                         ),
@@ -365,7 +357,7 @@ impl Runner {
             name.to_owned()
         } else {
             let current_dir = env::current_dir()
-                .map_err(|e| Error::Io("Error getting current dir from env".to_string(), e))?;
+                .map_err(|e| Error::Io("getting current dir from env".to_string(), e))?;
             let file_name = current_dir
                 .file_name()
                 .unwrap_or(OsStr::new("soroban-astro-template"))
@@ -386,20 +378,13 @@ impl Runner {
         let file_contents = Self::read_to_string(&file_path)?;
 
         let mut doc: JsonValue = from_str(&file_contents).map_err(|e| {
-            Error::Json(
-                format!("Error parsing {file_name} file in: {project_path:?}"),
-                e,
-            )
+            Error::Json(format!("parsing {file_name} file in: {project_path:?}"), e)
         })?;
 
         doc["name"] = json!(package_name.to_string_lossy());
 
-        let formatted_json = to_string_pretty(&doc).map_err(|e| {
-            Error::Json(
-                "Error calling to_string_pretty for package.json".to_string(),
-                e,
-            )
-        })?;
+        let formatted_json = to_string_pretty(&doc)
+            .map_err(|e| Error::Json("calling to_string_pretty for package.json".to_string(), e))?;
 
         Self::write(&file_path, &formatted_json)?;
 
@@ -442,16 +427,15 @@ impl Runner {
     }
 
     fn create_dir_all(path: &Path) -> Result<(), Error> {
-        create_dir_all(path)
-            .map_err(|e| Error::Io(format!("Error creating directory: {path:?}"), e))
+        create_dir_all(path).map_err(|e| Error::Io(format!("creating directory: {path:?}"), e))
     }
 
     fn write(path: &Path, contents: &str) -> Result<(), Error> {
-        write(path, contents).map_err(|e| Error::Io(format!("Error writing file: {path:?}"), e))
+        write(path, contents).map_err(|e| Error::Io(format!("writing file: {path:?}"), e))
     }
 
     fn read_to_string(path: &Path) -> Result<String, Error> {
-        read_to_string(path).map_err(|e| Error::Io(format!("Error reading file: {path:?}"), e))
+        read_to_string(path).map_err(|e| Error::Io(format!("reading file: {path:?}"), e))
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -127,7 +127,7 @@ impl Runner {
             })?;
 
             // clone the template repo into the temp dir
-            self.clone_repo(&self.args.frontend_template, fe_template_dir.path())?;
+            Self::clone_repo(&self.args.frontend_template, fe_template_dir.path())?;
 
             // copy the frontend template files into the project
             self.copy_frontend_files(fe_template_dir.path(), &project_path)?;
@@ -144,7 +144,7 @@ impl Runner {
             })?;
 
             // clone the soroban-examples repo into the temp dir
-            self.clone_repo(SOROBAN_EXAMPLES_URL, examples_dir.path())?;
+            Self::clone_repo(SOROBAN_EXAMPLES_URL, examples_dir.path())?;
 
             // copy the example contracts into the project
             self.copy_example_contracts(
@@ -280,7 +280,7 @@ impl Runner {
         !self.args.with_example.is_empty()
     }
 
-    fn clone_repo(&self, from_url: &str, to_path: &Path) -> Result<(), Error> {
+    fn clone_repo(from_url: &str, to_path: &Path) -> Result<(), Error> {
         let mut prepare = clone::PrepareFetch::new(
             from_url,
             to_path,
@@ -323,13 +323,13 @@ impl Runner {
             Self::create_dir_all(&to_contract_path)?;
 
             self.copy_contents(&from_contract_path, &to_contract_path)?;
-            self.edit_contract_cargo_file(&to_contract_path)?;
+            Self::edit_contract_cargo_file(&to_contract_path)?;
         }
 
         Ok(())
     }
 
-    fn edit_contract_cargo_file(&self, contract_path: &Path) -> Result<(), Error> {
+    fn edit_contract_cargo_file(contract_path: &Path) -> Result<(), Error> {
         let cargo_path = contract_path.join("Cargo.toml");
 
         let cargo_toml_str = Self::read_to_string(&cargo_path)?;
@@ -357,10 +357,10 @@ impl Runner {
     fn copy_frontend_files(&self, from: &Path, to: &Path) -> Result<(), Error> {
         self.print.infoln("Initializing with frontend template");
         self.copy_contents(from, to)?;
-        self.edit_package_json_files(to)
+        Self::edit_package_json_files(to)
     }
 
-    fn edit_package_json_files(&self, project_path: &Path) -> Result<(), Error> {
+    fn edit_package_json_files(project_path: &Path) -> Result<(), Error> {
         let package_name = if let Some(name) = project_path.file_name() {
             name.to_owned()
         } else {
@@ -373,12 +373,11 @@ impl Runner {
             file_name
         };
 
-        self.edit_package_name(project_path, &package_name, "package.json")?;
-        self.edit_package_name(project_path, &package_name, "package-lock.json")
+        Self::edit_package_name(project_path, &package_name, "package.json")?;
+        Self::edit_package_name(project_path, &package_name, "package-lock.json")
     }
 
     fn edit_package_name(
-        &self,
         project_path: &Path,
         package_name: &OsStr,
         file_name: &str,

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -193,8 +193,7 @@ impl Runner {
             } else {
                 self.print.plusln(format!("Writing {to:?}"));
             }
-            write(&to, file_contents)
-                .map_err(|e| Error::Io(format!("Error writing file: {to:?}"), e))?;
+            Self::write(&to, file_contents)?;
         }
         Ok(())
     }
@@ -356,12 +355,7 @@ impl Runner {
             .map_err(Error::TomlParse)?;
         doc.remove("profile");
 
-        write(&cargo_path, doc.to_string()).map_err(|e| {
-            Error::Io(
-                format!("Error writing to Cargo.toml file in: {contract_path:?}"),
-                e,
-            )
-        })?;
+        Self::write(&cargo_path, &doc.to_string())?;
 
         Ok(())
     }
@@ -414,7 +408,7 @@ impl Runner {
             )
         })?;
 
-        write(&file_path, formatted_json)?;
+        Self::write(&file_path, &formatted_json)?;
 
         Ok(())
     }
@@ -457,6 +451,10 @@ impl Runner {
     fn create_dir_all(path: &Path) -> Result<(), Error> {
         create_dir_all(path)
             .map_err(|e| Error::Io(format!("Error creating directory: {path:?}"), e))
+    }
+
+    fn write(path: &Path, contents: &str) -> Result<(), Error> {
+        write(path, contents).map_err(|e| Error::Io(format!("Error writing file: {path:?}"), e))
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -332,13 +332,8 @@ impl Runner {
 
     fn edit_contract_cargo_file(&self, contract_path: &Path) -> Result<(), Error> {
         let cargo_path = contract_path.join("Cargo.toml");
-        let cargo_toml_str = read_to_string(&cargo_path).map_err(|e| {
-            Error::Io(
-                format!("Error reading Cargo.toml file in: {contract_path:?}"),
-                e,
-            )
-        })?;
 
+        let cargo_toml_str = Self::read_to_string(&cargo_path)?;
         let cargo_toml_str = regex::Regex::new(r#"soroban-sdk = "[^\"]+""#)
             .unwrap()
             .replace_all(
@@ -390,7 +385,7 @@ impl Runner {
         file_name: &str,
     ) -> Result<(), Error> {
         let file_path = project_path.join(file_name);
-        let file_contents = read_to_string(&file_path)?;
+        let file_contents = Self::read_to_string(&file_path)?;
 
         let mut doc: JsonValue = from_str(&file_contents).map_err(|e| {
             Error::Json(
@@ -455,6 +450,10 @@ impl Runner {
 
     fn write(path: &Path, contents: &str) -> Result<(), Error> {
         write(path, contents).map_err(|e| Error::Io(format!("Error writing file: {path:?}"), e))
+    }
+
+    fn read_to_string(path: &Path) -> Result<String, Error> {
+        read_to_string(path).map_err(|e| Error::Io(format!("Error reading file: {path:?}"), e))
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -60,9 +60,8 @@ pub enum Error {
     #[error("{0}: {1}")]
     Io(String, io::Error),
 
-    // the gix::clone::Error is too large to include in the error enum as is, so we wrap it in a Box
-    #[error("Failed to clone repository: {0}")]
-    CloneError(#[from] Box<clone::Error>),
+    #[error("Io Error:")]
+    StdIo(#[from] io::Error),
 
     #[error("{0}: {1}")]
     Json(String, JsonError),


### PR DESCRIPTION
### What

Return custom errors with context from the init command. This PR comes from a comment on a previous init PR: https://github.com/stellar/stellar-cli/pull/1548#pullrequestreview-2262486637

### Why

We can reduce the error printing we're doing in individual commands by letting those errors bubble up to the root command. This will also allow the callers of the functions have some more context about the error.

### Known limitations

I'm not sure how I feel about the io error handling. Some of these errors were already printing out messages, so I used those messages for the custom error text. Some of the other io errors just returned as is - for those I created a `StdIo` error - partially because it may be overkill to `map_err` for each of those errors. Happy to rethink this piece if folks have other ideas.
