### PR TITLE
unifying formatting to reflect stellar-docs#1541

### DIFF
--- a/cookbook/contract-lifecycle.mdx
+++ b/cookbook/contract-lifecycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contract Lifecycle
 hide_table_of_contents: true
-description: Manage the lifecycle of a Stellar smart contract using the CLI.
+description: Manage the lifecycle of a Stellar smart contract using the CLI
 ---
 
 To manage the lifecycle of a Stellar smart contract using the CLI, follow these steps:

--- a/cookbook/deploy-contract.mdx
+++ b/cookbook/deploy-contract.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy a contract from installed Wasm bytecode
 hide_table_of_contents: true
-description: Deploy an instance of a compiled contract that is already installed on the network.
+description: Deploy an instance of a compiled contract that is already installed on the network
 ---
 
 To deploy an instance of a compiled smart contract that has already been installed onto the Stellar network, use the `stellar contract deploy` command:

--- a/cookbook/deploy-stellar-asset-contract.mdx
+++ b/cookbook/deploy-stellar-asset-contract.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy the Stellar Asset Contract for a Stellar asset
 hide_table_of_contents: true
-description: Deploy an SAC for a Stellar asset so that it can interact with smart contracts.
+description: Deploy an SAC for a Stellar asset so that it can interact with smart contracts
 ---
 
 The Stellar CLI can deploy a [Stellar Asset Contract] for a Stellar asset so that any Stellar smart contract can interact with the asset.

--- a/cookbook/extend-contract-instance.mdx
+++ b/cookbook/extend-contract-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Extend a deployed contract instance's TTL
 hide_table_of_contents: true
-description: Use the CLI to extend the time to live (TTL) of a contract instance.
+description: Use the CLI to extend the time to live (TTL) of a contract instance
 ---
 
 You can use the Stellar CLI to extend the TTL of a contract instance like so:

--- a/cookbook/extend-contract-storage.mdx
+++ b/cookbook/extend-contract-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: Extend a deployed contract's storage entry TTL
 hide_table_of_contents: true
-description: Use the CLI to extend the time to live (TTL) of a contract's persistent storage entry.
+description: Use the CLI to extend the time to live (TTL) of a contract's persistent storage entry
 ---
 
 You can use the Stellar CLI to extend the TTL of a contract's persistent storage entry. For a storage entry that uses a simple `Symbol` as its storage key, you can run a command like so:

--- a/cookbook/extend-contract-wasm.mdx
+++ b/cookbook/extend-contract-wasm.mdx
@@ -1,7 +1,7 @@
 ---
 title: Extend a deployed contract's Wasm code TTL
 hide_table_of_contents: true
-description: Use Stellar CLI to extend contract's Wasm bytecode TTL, with or without local binary.
+description: Use Stellar CLI to extend contract's Wasm bytecode TTL, with or without local binary
 ---
 
 You can use the Stellar CLI to extend the TTL of a contract's Wasm bytecode. This can be done in two forms: if you do or do not have the compiled contract locally. If you do have the compiled binary on your local machine:

--- a/cookbook/install-deploy.mdx
+++ b/cookbook/install-deploy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install and deploy a smart contract
 hide_table_of_contents: true
-description: Combine the install and deploy commands in the Stellar CLI to accomplish both tasks.
+description: Combine the install and deploy commands in the Stellar CLI to accomplish both tasks
 ---
 
 You can combine the `install` and `deploy` commands of the Stellar CLI to accomplish both tasks:

--- a/cookbook/install-wasm.mdx
+++ b/cookbook/install-wasm.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install Wasm bytecode
 hide_table_of_contents: true
-description: Use the Stellar CLI to install a compiled smart contract on the ledger.
+description: Use the Stellar CLI to install a compiled smart contract on the ledger
 ---
 
 To use the Stellar CLI to install a compiled smart contract on the ledger, use the `stellar contract install` command:

--- a/cookbook/payments-and-assets.mdx
+++ b/cookbook/payments-and-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: Payments and Assets
 hide_table_of_contents: true
-description: Send XLM, stellar classic, or a soroban asset using the Stellar CLI.
+description: Send XLM, stellar classic, or a soroban asset using the Stellar CLI
 ---
 
 To send payments and work with assets using the Stellar CLI, follow these steps:

--- a/cookbook/restore-contract-instance.mdx
+++ b/cookbook/restore-contract-instance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restore an archived contract using the Stellar CLI
 hide_table_of_contents: true
-description: Restore an archived contract instance using the Stellar CLI.
+description: Restore an archived contract instance using the Stellar CLI
 ---
 
 If your contract instance has been archived, it can easily be restored using the Stellar CLI.

--- a/cookbook/restore-contract-storage.mdx
+++ b/cookbook/restore-contract-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: Restore archived contract data using the Stellar CLI
 hide_table_of_contents: true
-description: Restore archived contract storage entries using Stellar CLI.
+description: Restore archived contract storage entries using Stellar CLI
 ---
 
 If a contract's persistent storage entry has been archived, you can restore it using the Stellar CLI. For a storage entry that uses a simple `Symbol` as its storage key, you can run a command like so:


### PR DESCRIPTION
### What

Remove periods at end of descriptions ( see https://github.com/stellar/stellar-cli/pull/1541 )

### Why

This reflects the most recent docs changes

### Known limitations

N/a
