### PR TITLE
Change output of events in logs from Rust debug to JSON

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -394,12 +394,12 @@ fn invoke_log(sandbox: &TestEnv, id: &str) {
         .assert()
         .success()
         .stderr(predicates::str::contains(
-            "INFO contract_event: soroban_cli::log::event: 1: DiagnosticEvent {",
+            "INFO contract_event: soroban_cli::log::event: 1:",
         ))
-        .stderr(predicates::str::contains("StringM(hello)"))
+        .stderr(predicates::str::contains("hello"))
         .stderr(predicates::str::contains(
-            "INFO log_event: soroban_cli::log::event: 2: DiagnosticEvent",
+            "INFO log_event: soroban_cli::log::event: 2:",
         ))
-        .stderr(predicates::str::contains("StringM(hello {})"))
-        .stderr(predicates::str::contains("StringM(world)"));
+        .stderr(predicates::str::contains("hello {}"))
+        .stderr(predicates::str::contains("world"));
 }

--- a/cmd/soroban-cli/src/log/event.rs
+++ b/cmd/soroban-cli/src/log/event.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, info, span, Level};
+use tracing::{debug, error, info, span, Level};
 
 use crate::xdr;
 
@@ -14,10 +14,16 @@ pub fn events(events: &[xdr::DiagnosticEvent]) {
 
         let _enter = span.enter();
 
-        if span.metadata().unwrap().level() == &Level::INFO {
-            info!("{i}: {event:#?}");
-        } else {
-            debug!("{i}: {event:#?}");
+        let result = serde_json::to_string(event);
+        match result {
+            Ok(json) => {
+                if span.metadata().unwrap().level() == &Level::INFO {
+                    info!("{i}: {json}");
+                } else {
+                    debug!("{i}: {json}");
+                }
+            }
+            Err(err) => error!("converting event to json: {}: ", err),
         }
     }
 }

--- a/cmd/soroban-cli/src/log/event.rs
+++ b/cmd/soroban-cli/src/log/event.rs
@@ -1,6 +1,7 @@
-use tracing::{debug, error, info, span, Level};
+use tracing::{debug, info, span, Level};
 
 use crate::xdr;
+use xdr::WriteXdr;
 
 pub fn events(events: &[xdr::DiagnosticEvent]) {
     for (i, event) in events.iter().enumerate() {
@@ -14,16 +15,12 @@ pub fn events(events: &[xdr::DiagnosticEvent]) {
 
         let _enter = span.enter();
 
-        let result = serde_json::to_string(event);
-        match result {
-            Ok(json) => {
-                if span.metadata().unwrap().level() == &Level::INFO {
-                    info!("{i}: {json}");
-                } else {
-                    debug!("{i}: {json}");
-                }
-            }
-            Err(err) => error!("converting event to json: {}: ", err),
+        let xdr = event.to_xdr_base64(xdr::Limits::none()).unwrap();
+        let json = serde_json::to_string(event).unwrap();
+        if span.metadata().unwrap().level() == &Level::INFO {
+            info!("{i}: {xdr} {json}");
+        } else {
+            debug!("{i}: {xdr} {json}");
         }
     }
 }


### PR DESCRIPTION
### What

Change the output of contract events in logs from successful invocations from Rust debug to XDR and JSON.

#### Before

```
❯ stellar contract invoke --id $(stellar contract asset id --asset native) -- transfer --from me --to you --amount 1
2024-09-11T23:51:12.556972Z  INFO contract_event: soroban_cli::log::event: 1: DiagnosticEvent {
    in_successful_contract_call: true,
    event: ContractEvent {
        ext: V0,
        contract_id: Some(
            Hash(d7928b72c2703ccfeaf7eb9ff4ef4d504a55a8b979fc9b450ea2c842b4d1ce61),
        ),
        type_: Contract,
        body: V0(
            ContractEventV0 {
                topics: VecM(
                    [
                        Symbol(
                            ScSymbol(
                                StringM(transfer),
                            ),
                        ),
                        Address(
                            Account(
                                AccountId(
                                    PublicKeyTypeEd25519(
                                        Uint256(309d08c0d6e866993dfb33067291149d652b1ca75b690853b52a042b2947b1f5),
                                    ),
                                ),
                            ),
                        ),
                        Address(
                            Account(
                                AccountId(
                                    PublicKeyTypeEd25519(
                                        Uint256(7ac81d6ba7f93d9d17f226499d7df794f9ecd45c842f1e045aff9591e61c46d9),
                                    ),
                                ),
                            ),
                        ),
                        String(
                            ScString(
                                StringM(native),
                            ),
                        ),
                    ],
                ),
                data: I128(
                    Int128Parts {
                        hi: 0,
                        lo: 1,
                    },
                ),
            },
        ),
    },
}
```

#### After

> ❯ stellar contract invoke --id $(stellar contract asset id --asset native) -- transfer --from me --to you --amount 1
2024-09-12T00:00:01.671960Z  INFO contract_event: soroban_cli::log::event: 1: AAAAAQAAAAAAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAABAAAAAAAAAAQAAAAPAAAACHRyYW5zZmVyAAAAEgAAAAAAAAAAMJ0IwNboZpk9+zMGcpEUnWUrHKdbaQhTtSoEKylHsfUAAAASAAAAAAAAAAB6yB1rp/k9nRfyJkmdffeU+ezUXIQvHgRa/5WR5hxG2QAAAA4AAAAGbmF0aXZlAAAAAAAKAAAAAAAAAAAAAAAAAAAAAQ== {"in_successful_contract_call":true,"event":{"ext":"v0","contract_id":"d7928b72c2703ccfeaf7eb9ff4ef4d504a55a8b979fc9b450ea2c842b4d1ce61","type_":"contract","body":{"v0":{"topics":[{"symbol":"transfer"},{"address":"GAYJ2CGA23UGNGJ57MZQM4URCSOWKKY4U5NWSCCTWUVAIKZJI6Y7KL63"},{"address":"GB5MQHLLU74T3HIX6ITETHL566KPT3GULSCC6HQELL7ZLEPGDRDNS5OC"},{"string":"native"}],"data":{"i128":{"hi":0,"lo":1}}}}}}

### Why

The rust debug is less human readable than JSON, because the Rust debug representation of the XDR types outputs values like the contract ID Hash, instead of the C string.

The output format has attempted to be as similar as possible to the output that @BlaineHeffron is using in:
- https://github.com/stellar/stellar-cli/pull/1499

Close https://github.com/stellar/stellar-cli/issues/1447