### PR TITLE
Rename contract

### DIFF
--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -72,7 +72,7 @@ fn build_no_package_found() {
         .failure()
         .stderr(predicate::eq(
             "\
-error: package nopkgwiththisname not found
+❌ error: package nopkgwiththisname not found
 ",
         ));
 }

--- a/cmd/soroban-cli/src/utils/contract-init-template/contracts/hello_world/src/lib.rs
+++ b/cmd/soroban-cli/src/utils/contract-init-template/contracts/hello_world/src/lib.rs
@@ -2,10 +2,10 @@
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
-pub struct HelloContract;
+pub struct Contract;
 
 #[contractimpl]
-impl HelloContract {
+impl Contract {
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
     }

--- a/cmd/soroban-cli/src/utils/contract-init-template/contracts/hello_world/src/test.rs
+++ b/cmd/soroban-cli/src/utils/contract-init-template/contracts/hello_world/src/test.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{vec, Env, String};
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, HelloContract);
-    let client = HelloContractClient::new(&env, &contract_id);
+    let contract_id = env.register_contract(None, Contract);
+    let client = ContractClient::new(&env, &contract_id);
 
     let words = client.hello(&String::from_str(&env, "Dev"));
     assert_eq!(


### PR DESCRIPTION
### What

Rename the contract.

### Why

Because it's scoped by the module, so having a unique name doesn't bring much.

### Known limitations

N/A
