### PR TITLE
feat: allow source account to be a public key

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -97,11 +97,10 @@ impl NetworkRunnable for Cmd {
         client
             .verify_network_passphrase(Some(&network.network_passphrase))
             .await?;
-        let key = config.key_pair()?;
+        let key = config.source_account()?;
 
         // Get the account sequence number
-        let public_strkey =
-            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
+        let public_strkey = key.to_string();
         // TODO: use symbols for the method names (both here and in serve)
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
@@ -141,7 +140,7 @@ fn build_wrap_token_tx(
     sequence: i64,
     fee: u32,
     _network_passphrase: &str,
-    key: &ed25519_dalek::SigningKey,
+    key: &stellar_strkey::ed25519::PublicKey,
 ) -> Result<Transaction, Error> {
     let contract = ScAddress::Contract(contract_id.clone());
     let mut read_write = vec![
@@ -180,7 +179,7 @@ fn build_wrap_token_tx(
     };
 
     Ok(Transaction {
-        source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
+        source_account: MuxedAccount::Ed25519(Uint256(key.0)),
         fee,
         seq_num: SequenceNumber(sequence),
         cond: Preconditions::None,

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -132,17 +132,15 @@ impl NetworkRunnable for Cmd {
         tracing::trace!(?network);
         let keys = self.key.parse_keys(&config.locator, &network)?;
         let client = Client::new(&network.rpc_url)?;
-        let key = config.key_pair()?;
+        let key = config.source_account()?;
         let extend_to = self.ledgers_to_extend();
 
         // Get the account sequence number
-        let public_strkey =
-            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
-        let account_details = client.get_account(&public_strkey).await?;
+        let account_details = client.get_account(&key.to_string()).await?;
         let sequence: i64 = account_details.seq_num.into();
 
         let tx = Transaction {
-            source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
+            source_account: MuxedAccount::Ed25519(Uint256(key.0)),
             fee: self.fee.fee,
             seq_num: SequenceNumber(sequence + 1),
             cond: Preconditions::None,

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -216,12 +216,10 @@ impl NetworkRunnable for Cmd {
             client
                 .verify_network_passphrase(Some(&network.network_passphrase))
                 .await?;
-            let key = config.key_pair()?;
 
-            // Get the account sequence number
-            let public_strkey =
-                stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
-            client.get_account(&public_strkey).await?
+            client
+                .get_account(&config.source_account()?.to_string())
+                .await?
         };
         let sequence: i64 = account_details.seq_num.into();
         let AccountId(PublicKey::PublicKeyTypeEd25519(account_id)) = account_details.account_id;

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -135,16 +135,15 @@ impl NetworkRunnable for Cmd {
         tracing::trace!(?network);
         let entry_keys = self.key.parse_keys(&config.locator, &network)?;
         let client = Client::new(&network.rpc_url)?;
-        let key = config.key_pair()?;
+        let key = config.source_account()?;
 
         // Get the account sequence number
-        let public_strkey =
-            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
+        let public_strkey = key.to_string();
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
 
         let tx = Transaction {
-            source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
+            source_account: MuxedAccount::Ed25519(Uint256(key.0)),
             fee: self.fee.fee,
             seq_num: SequenceNumber(sequence + 1),
             cond: Preconditions::None,

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -57,6 +57,7 @@ pub struct Args {
 }
 
 impl Args {
+    // TODO: Replace PublicKey with MuxedAccount once https://github.com/stellar/rs-stellar-xdr/pull/396 is merged.
     pub fn source_account(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
         if let Ok(secret) = self.locator.read_identity(&self.source_account) {
             Ok(stellar_strkey::ed25519::PublicKey(


### PR DESCRIPTION

### What

Allow public keys to be used with `--source`.

### Why

This is will be useful for `--sign-with-lab` which users will likely copy their public keys from their wallet to use on the CLI. It will also be useful when we expand `--sign-with-*` more generally allowing a different key than the source account to sign the transaction.

### Known limitations

Currently this would fail if not `--build-only` since we rely on source account being a reference to a private key or seed