### PR TITLE
reformat link to stellar lab, remove surrounding angle brackets

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1338,7 +1338,7 @@ Sign a transaction envelope appending the signature to the envelope
 
 * `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
 * `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with <https://lab.stellar.org>
+* `--sign-with-lab` — Sign with https://lab.stellar.org
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config

--- a/cmd/soroban-cli/src/config/sign_with.rs
+++ b/cmd/soroban-cli/src/config/sign_with.rs
@@ -42,7 +42,8 @@ pub struct Args {
     /// If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
     pub hd_path: Option<usize>,
 
-    /// Sign with <https://lab.stellar.org>
+    #[allow(clippy::doc_markdown)]
+    /// Sign with https://lab.stellar.org
     #[arg(long, conflicts_with = "sign_with_key", env = "STELLAR_SIGN_WITH_LAB")]
     pub sign_with_lab: bool,
 }


### PR DESCRIPTION
### What

Removing the surrounding `<` angle brackets `>` from a link to Stellar Lab.

### Why

The [docs are failing to build](https://github.com/stellar/stellar-docs/actions/runs/11039190470/job/30664887729), since MDX3 throws a compliation error when it encounters this kind of "bare URL."