### PR TITLE
Chore/use rich printer for network container

### DIFF
--- a/cmd/soroban-cli/src/commands/network/container.rs
+++ b/cmd/soroban-cli/src/commands/network/container.rs
@@ -41,7 +41,7 @@ pub enum Error {
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match &self {
-            Cmd::Logs(cmd) => cmd.run().await?,
+            Cmd::Logs(cmd) => cmd.run(global_args).await?,
             Cmd::Start(cmd) => cmd.run(global_args).await?,
             Cmd::Stop(cmd) => cmd.run(global_args).await?,
         }

--- a/cmd/soroban-cli/src/commands/network/container/logs.rs
+++ b/cmd/soroban-cli/src/commands/network/container/logs.rs
@@ -27,9 +27,9 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let printer = print::Print::new(global_args.quiet);
+        let print = print::Print::new(global_args.quiet);
         let container_name = Name(self.name.clone()).get_internal_container_name();
-        let docker = self.container_args.connect_to_docker(&printer).await?;
+        let docker = self.container_args.connect_to_docker(&print).await?;
         let logs_stream = &mut docker.logs(
             &container_name,
             Some(bollard::container::LogsOptions {

--- a/cmd/soroban-cli/src/commands/network/container/logs.rs
+++ b/cmd/soroban-cli/src/commands/network/container/logs.rs
@@ -1,6 +1,9 @@
 use futures_util::TryStreamExt;
 
-use crate::commands::network::container::shared::Error as ConnectionError;
+use crate::{
+    commands::{global, network::container::shared::Error as ConnectionError},
+    print,
+};
 
 use super::shared::{Args, Name};
 
@@ -23,9 +26,10 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let printer = print::Print::new(global_args.quiet);
         let container_name = Name(self.name.clone()).get_internal_container_name();
-        let docker = self.container_args.connect_to_docker().await?;
+        let docker = self.container_args.connect_to_docker(&printer).await?;
         let logs_stream = &mut docker.logs(
             &container_name,
             Some(bollard::container::LogsOptions {

--- a/cmd/soroban-cli/src/commands/network/container/shared.rs
+++ b/cmd/soroban-cli/src/commands/network/container/shared.rs
@@ -48,6 +48,7 @@ impl Args {
             .unwrap_or_default()
     }
 
+    #[allow(unused_variables)]
     pub(crate) async fn connect_to_docker(&self, printer: &print::Print) -> Result<Docker, Error> {
         // if no docker_host is provided, use the default docker host:
         // "unix:///var/run/docker.sock" on unix machines

--- a/cmd/soroban-cli/src/commands/network/container/shared.rs
+++ b/cmd/soroban-cli/src/commands/network/container/shared.rs
@@ -49,7 +49,7 @@ impl Args {
     }
 
     #[allow(unused_variables)]
-    pub(crate) async fn connect_to_docker(&self, printer: &print::Print) -> Result<Docker, Error> {
+    pub(crate) async fn connect_to_docker(&self, print: &print::Print) -> Result<Docker, Error> {
         // if no docker_host is provided, use the default docker host:
         // "unix:///var/run/docker.sock" on unix machines
         // "npipe:////./pipe/docker_engine" on windows machines
@@ -92,7 +92,7 @@ impl Args {
                 // if on unix, try to connect to the default docker desktop socket
                 #[cfg(unix)]
                 {
-                    let docker_desktop_connection = try_docker_desktop_socket(&host, printer)?;
+                    let docker_desktop_connection = try_docker_desktop_socket(&host, print)?;
                     match check_docker_connection(&docker_desktop_connection).await {
                         Ok(()) => Ok(docker_desktop_connection),
                         Err(err) => Err(err)?,
@@ -143,13 +143,13 @@ impl Name {
 #[cfg(unix)]
 fn try_docker_desktop_socket(
     host: &str,
-    printer: &print::Print,
+    print: &print::Print,
 ) -> Result<Docker, bollard::errors::Error> {
     let default_docker_desktop_host =
         format!("{}/.docker/run/docker.sock", home_dir().unwrap().display());
-    printer.warnln(format!("Failed to connect to Docker daemon at {host}."));
+    print.warnln(format!("Failed to connect to Docker daemon at {host}."));
 
-    printer.infoln(format!(
+    print.infoln(format!(
         "Attempting to connect to the default Docker Desktop socket at {default_docker_desktop_host} instead."
     ));
 
@@ -158,13 +158,13 @@ fn try_docker_desktop_socket(
         DEFAULT_TIMEOUT,
         API_DEFAULT_VERSION,
     ).map_err(|e| {
-        printer.errorln(format!(
+        print.errorln(format!(
             "Failed to connect to the Docker daemon at {host:?}. Is the docker daemon running?"
         ));
-        printer.infoln(
+        print.infoln(
             "Running a local Stellar network requires a Docker-compatible container runtime."
         );
-        printer.infoln(
+        print.infoln(
             "Please note that if you are using Docker Desktop, you may need to utilize the `--docker-host` flag to pass in the location of the docker socket on your machine."
         );
         e

--- a/cmd/soroban-cli/src/commands/network/container/start.rs
+++ b/cmd/soroban-cli/src/commands/network/container/start.rs
@@ -79,7 +79,11 @@ impl Runner {
         self.print
             .infoln(format!("Starting {} network", &self.args.network));
 
-        let docker = self.args.container_args.connect_to_docker().await?;
+        let docker = self
+            .args
+            .container_args
+            .connect_to_docker(&self.print)
+            .await?;
 
         let image = self.get_image_name();
         let mut stream = docker.create_image(

--- a/cmd/soroban-cli/src/commands/network/container/stop.rs
+++ b/cmd/soroban-cli/src/commands/network/container/stop.rs
@@ -34,7 +34,7 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = print::Print::new(global_args.quiet);
         let container_name = Name(self.name.clone());
-        let docker = self.container_args.connect_to_docker().await?;
+        let docker = self.container_args.connect_to_docker(&print).await?;
 
         print.infoln(format!(
             "Stopping {} container",


### PR DESCRIPTION
### What

Uses the rich printer for `network container` commands.

### Why

Closes https://github.com/stellar/stellar-cli/issues/1617
### Known limitations
 
N/A