### PR TITLE
Do not require source account when fetching an asset's contract id.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -111,7 +111,7 @@ Utilities to deploy a Stellar Asset Contract or get its id
 
 Get Id of builtin Soroban Asset Contract. Deprecated, use `stellar contract id asset` instead
 
-**Usage:** `stellar contract asset id [OPTIONS] --asset <ASSET> --source-account <SOURCE_ACCOUNT>`
+**Usage:** `stellar contract asset id [OPTIONS] --asset <ASSET>`
 
 ###### **Options:**
 
@@ -119,8 +119,6 @@ Get Id of builtin Soroban Asset Contract. Deprecated, use `stellar contract id a
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config
-* `--source-account <SOURCE_ACCOUNT>` — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--hd-path <HD_PATH>` — If using a seed phrase, which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
 
@@ -444,7 +442,7 @@ Generate the contract id for a given contract or asset
 
 Deploy builtin Soroban Asset Contract
 
-**Usage:** `stellar contract id asset [OPTIONS] --asset <ASSET> --source-account <SOURCE_ACCOUNT>`
+**Usage:** `stellar contract id asset [OPTIONS] --asset <ASSET>`
 
 ###### **Options:**
 
@@ -452,8 +450,6 @@ Deploy builtin Soroban Asset Contract
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config
-* `--source-account <SOURCE_ACCOUNT>` — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--hd-path <HD_PATH>` — If using a seed phrase, which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
 

--- a/cmd/crates/soroban-test/tests/it/integration/cookbook.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/cookbook.rs
@@ -236,8 +236,6 @@ mod tests {
             .arg("asset")
             .arg("--asset")
             .arg("native")
-            .arg("--source-account")
-            .arg(source)
             .assert()
             .stdout_as_str();
         let contract_id = deploy_hello(&sandbox).await;

--- a/cmd/soroban-cli/src/commands/contract/id/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/asset.rs
@@ -13,7 +13,7 @@ pub struct Cmd {
     pub asset: builder::Asset,
 
     #[command(flatten)]
-    pub config: config::Args,
+    pub config: config::ArgsLocatorAndNetwork,
 }
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -63,16 +63,6 @@ pub struct Args {
     pub locator: locator::Args,
 }
 
-#[derive(Debug, clap::Args, Clone, Default)]
-#[group(skip)]
-pub struct ArgsLocatorAndNetwork {
-    #[command(flatten)]
-    pub network: network::Args,
-
-    #[command(flatten)]
-    pub locator: locator::Args,
-}
-
 impl Args {
     // TODO: Replace PublicKey with MuxedAccount once https://github.com/stellar/rs-stellar-xdr/pull/396 is merged.
     pub fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
@@ -121,7 +111,7 @@ impl Args {
     }
 
     pub fn get_network(&self) -> Result<Network, Error> {
-        HasNetwork::get_network(self)
+        Ok(self.network.get(&self.locator)?)
     }
 
     pub async fn next_sequence_number(&self, account_str: &str) -> Result<SequenceNumber, Error> {
@@ -140,37 +130,18 @@ impl Pwd for Args {
 #[derive(Default, Serialize, Deserialize)]
 pub struct Config {}
 
-trait HasNetwork {
-    fn network_args(&self) -> &network::Args;
-    fn locator_args(&self) -> &locator::Args;
+#[derive(Debug, clap::Args, Clone, Default)]
+#[group(skip)]
+pub struct ArgsLocatorAndNetwork {
+    #[command(flatten)]
+    pub network: network::Args,
 
-    fn get_network(&self) -> Result<Network, Error> {
-        Ok(self.network_args().get(self.locator_args())?)
-    }
-}
-
-impl HasNetwork for Args {
-    fn network_args(&self) -> &network::Args {
-        &self.network
-    }
-
-    fn locator_args(&self) -> &locator::Args {
-        &self.locator
-    }
-}
-
-impl HasNetwork for ArgsLocatorAndNetwork {
-    fn network_args(&self) -> &network::Args {
-        &self.network
-    }
-
-    fn locator_args(&self) -> &locator::Args {
-        &self.locator
-    }
+    #[command(flatten)]
+    pub locator: locator::Args,
 }
 
 impl ArgsLocatorAndNetwork {
     pub fn get_network(&self) -> Result<Network, Error> {
-        HasNetwork::get_network(self)
+        Ok(self.network.get(&self.locator)?)
     }
 }

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -63,6 +63,16 @@ pub struct Args {
     pub locator: locator::Args,
 }
 
+#[derive(Debug, clap::Args, Clone, Default)]
+#[group(skip)]
+pub struct ArgsLocatorAndNetwork {
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
 impl Args {
     // TODO: Replace PublicKey with MuxedAccount once https://github.com/stellar/rs-stellar-xdr/pull/396 is merged.
     pub fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
@@ -111,7 +121,7 @@ impl Args {
     }
 
     pub fn get_network(&self) -> Result<Network, Error> {
-        Ok(self.network.get(&self.locator)?)
+        HasNetwork::get_network(self)
     }
 
     pub async fn next_sequence_number(&self, account_str: &str) -> Result<SequenceNumber, Error> {
@@ -129,3 +139,38 @@ impl Pwd for Args {
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct Config {}
+
+trait HasNetwork {
+    fn network_args(&self) -> &network::Args;
+    fn locator_args(&self) -> &locator::Args;
+
+    fn get_network(&self) -> Result<Network, Error> {
+        Ok(self.network_args().get(self.locator_args())?)
+    }
+}
+
+impl HasNetwork for Args {
+    fn network_args(&self) -> &network::Args {
+        &self.network
+    }
+
+    fn locator_args(&self) -> &locator::Args {
+        &self.locator
+    }
+}
+
+impl HasNetwork for ArgsLocatorAndNetwork {
+    fn network_args(&self) -> &network::Args {
+        &self.network
+    }
+
+    fn locator_args(&self) -> &locator::Args {
+        &self.locator
+    }
+}
+
+impl ArgsLocatorAndNetwork {
+    pub fn get_network(&self) -> Result<Network, Error> {
+        HasNetwork::get_network(self)
+    }
+}

--- a/cookbook/deploy-stellar-asset-contract.mdx
+++ b/cookbook/deploy-stellar-asset-contract.mdx
@@ -42,7 +42,6 @@ For any asset, the contract address can be fetched with:
 
 ```bash
 stellar contract id asset \
-    --source S... \
     --network testnet \
     --asset native
 ```

--- a/cookbook/payments-and-assets.mdx
+++ b/cookbook/payments-and-assets.mdx
@@ -35,7 +35,7 @@ stellar keys fund bob
 3. Obtain the stellar asset contract ID:
 
 ```bash
-stellar contract id asset --asset native --source-account alice
+stellar contract id asset --asset native
 ```
 
 4. Get Bob's public key:


### PR DESCRIPTION
### What

Close #1645

### Why

Because we don't need a source account or hd path to return the asset's contract id.

### Known limitations

N/A
