### PR TITLE
fix: Ensure aliases are visible in auto-generated markdown (#1545)

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1625,3 +1625,75 @@ Print version information
 
 
 
+
+
+**Aliases for argument `filter_logs`**: f
+
+
+**Aliases for argument `quiet`**: q
+
+
+**Aliases for argument `verbose`**: v
+
+
+**Aliases for argument `ignore_checks`**: i
+
+
+**Aliases for argument `out_file`**: o
+
+
+**Aliases for argument `with_example`**: w
+
+
+**Aliases for argument `ignore_checks`**: i
+
+
+**Aliases for argument `count`**: c
+
+
+**Aliases for argument `as_secret`**: s
+
+
+**Aliases for argument `default_seed`**: d
+
+
+**Aliases for argument `long`**: l
+
+
+**Aliases for argument `long`**: l
+
+
+**Aliases for argument `docker_host`**: d
+
+
+**Aliases for argument `limits`**: l
+
+
+**Aliases for argument `ports_mapping`**: p
+
+
+**Aliases for argument `image_tag_override`**: t
+
+
+**Aliases for argument `docker_host`**: d
+
+
+**Aliases for argument `docker_host`**: d
+
+
+**Aliases for argument `docker_host`**: d
+
+
+**Aliases for argument `limits`**: l
+
+
+**Aliases for argument `ports_mapping`**: p
+
+
+**Aliases for argument `image_tag_override`**: t
+
+
+**Aliases for argument `docker_host`**: d
+
+
+**Aliases for argument `long`**: l

--- a/cmd/soroban-cli/src/bin/doc-gen.rs
+++ b/cmd/soroban-cli/src/bin/doc-gen.rs
@@ -2,7 +2,8 @@ use std::{
     env,
     path::{Path, PathBuf},
 };
-
+// use clap::{Command, Arg};
+// use clap_markdown::MarkdownOptions;
 type DynError = Box<dyn std::error::Error>;
 
 fn main() -> Result<(), DynError> {
@@ -17,11 +18,50 @@ fn doc_gen() -> std::io::Result<()> {
         .show_table_of_contents(false)
         .title("Stellar CLI Manual".to_string());
 
-    let content = clap_markdown::help_markdown_custom::<soroban_cli::Root>(&options);
+        let content = generate_markdown_with_aliases::<soroban_cli::Root>(&options);
 
     std::fs::write(out_dir.join("FULL_HELP_DOCS.md"), content)?;
 
     Ok(())
+}
+
+fn generate_markdown_with_aliases<C: clap::CommandFactory>(options: &clap_markdown::MarkdownOptions) -> String {
+    let command = C::command();
+    let mut markdown_content = clap_markdown::help_markdown_custom::<C>(options);
+    add_aliases_recursively(&command, &mut markdown_content, 2);
+    markdown_content
+}
+
+fn add_aliases_recursively(command: &clap::Command, content: &mut String, level: usize) {
+    let header = "#".repeat(level);
+    
+    // Add command aliases
+    let cmd_aliases: Vec<_> = command.get_visible_aliases().collect();
+    if !cmd_aliases.is_empty() {
+        content.push_str(&format!("\n\n{} Aliases for `{}`: {}\n", 
+            header, command.get_name(), cmd_aliases.join(", ")));
+    }
+    
+    for arg in command.get_arguments() {
+        // Assuming `arg.get_short_and_visible_aliases()` returns Vec<Vec<char>> 
+        let arg_aliases: Vec<String> = arg.get_short_and_visible_aliases()
+            .into_iter()
+            .map(|alias| alias.iter().collect::<String>()) // Convert Vec<char> to String
+            .collect();
+    
+        if !arg_aliases.is_empty() {
+            content.push_str(&format!(
+                "\n\n**Aliases for argument `{}`**: {}\n", 
+                arg.get_id(), 
+                arg_aliases.join(", ")
+            ));
+        }
+    }
+    
+    // Recursively process subcommands
+    for subcommand in command.get_subcommands() {
+        add_aliases_recursively(subcommand, content, level + 1);
+    }
 }
 
 fn project_root() -> PathBuf {


### PR DESCRIPTION
### What

This change updates the markdown generation process to include aliases for both commands and arguments in the generated documentation.

### Why

This change updates the markdown generation process to include aliases for both commands and arguments in the generated documentation.

### Known limitations

N\A
