### PR TITLE
feat: Bring colors to help message

### DIFF
--- a/cmd/soroban-cli/src/commands/global.rs
+++ b/cmd/soroban-cli/src/commands/global.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use super::config;
 
 const USAGE_STYLES: Styles = Styles::styled()
-    .header(AnsiColor::Red.on_default().bold())
-    .usage(AnsiColor::Red.on_default().bold())
-    .literal(AnsiColor::Blue.on_default().bold())
+    .header(AnsiColor::Yellow.on_default())
+    .usage(AnsiColor::Green.on_default())
+    .literal(AnsiColor::Green.on_default())
     .placeholder(AnsiColor::Green.on_default());
 
 #[derive(Debug, clap::Args, Clone, Default)]

--- a/cmd/soroban-cli/src/commands/global.rs
+++ b/cmd/soroban-cli/src/commands/global.rs
@@ -1,16 +1,19 @@
 use clap::{
     arg,
-    builder::styling::{AnsiColor, Styles},
+    builder::styling::{AnsiColor, Effects, Styles},
 };
 use std::path::PathBuf;
 
 use super::config;
 
 const USAGE_STYLES: Styles = Styles::styled()
-    .header(AnsiColor::Yellow.on_default())
-    .usage(AnsiColor::Green.on_default())
-    .literal(AnsiColor::Green.on_default())
-    .placeholder(AnsiColor::Green.on_default());
+    .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .error(AnsiColor::Red.on_default().effects(Effects::BOLD))
+    .valid(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .invalid(AnsiColor::Yellow.on_default().effects(Effects::BOLD));
 
 #[derive(Debug, clap::Args, Clone, Default)]
 #[group(skip)]

--- a/cmd/soroban-cli/src/commands/global.rs
+++ b/cmd/soroban-cli/src/commands/global.rs
@@ -1,11 +1,21 @@
-use clap::arg;
+use clap::{
+    arg,
+    builder::styling::{AnsiColor, Styles},
+};
 use std::path::PathBuf;
 
 use super::config;
 
+const USAGE_STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Red.on_default().bold())
+    .usage(AnsiColor::Red.on_default().bold())
+    .literal(AnsiColor::Blue.on_default().bold())
+    .placeholder(AnsiColor::Green.on_default());
+
 #[derive(Debug, clap::Args, Clone, Default)]
 #[group(skip)]
 #[allow(clippy::struct_excessive_bools)]
+#[command(styles = USAGE_STYLES)]
 pub struct Args {
     #[clap(flatten)]
     pub locator: config::locator::Args,


### PR DESCRIPTION
### Bring colors to help message

Adds a color theme to the help message printed on the terminal

### Current color theme is black and white

- Improved Readability
- More engaging presentation

### closes #1624 