### PR TITLE
Do not require source account when reading contract.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -747,7 +747,7 @@ Optimize a WASM file
 
 Print the current value of a contract-data ledger entry
 
-**Usage:** `stellar contract read [OPTIONS] --source-account <SOURCE_ACCOUNT>`
+**Usage:** `stellar contract read [OPTIONS]`
 
 ###### **Options:**
 
@@ -781,8 +781,6 @@ Print the current value of a contract-data ledger entry
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config
-* `--source-account <SOURCE_ACCOUNT>` — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--hd-path <HD_PATH>` — If using a seed phrase, which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
 

--- a/cmd/crates/soroban-test/tests/it/integration/cookbook.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/cookbook.rs
@@ -252,8 +252,6 @@ mod tests {
             .arg("xdr")
             .arg("--key")
             .arg("COUNTER")
-            .arg("--source-account")
-            .arg(source)
             .assert()
             .stdout_as_str();
         let key_xdr = read_xdr.split(',').next().unwrap_or("").trim();

--- a/cmd/soroban-cli/src/commands/contract/read.rs
+++ b/cmd/soroban-cli/src/commands/contract/read.rs
@@ -28,7 +28,7 @@ pub struct Cmd {
     #[command(flatten)]
     pub key: key::Args,
     #[command(flatten)]
-    config: config::Args,
+    config: config::ArgsLocatorAndNetwork,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
@@ -179,10 +179,10 @@ impl NetworkRunnable for Cmd {
 
     async fn run_against_rpc_server(
         &self,
-        _: Option<&global::Args>,
-        config: Option<&config::Args>,
+        _global_args: Option<&global::Args>,
+        _config: Option<&config::Args>,
     ) -> Result<FullLedgerEntries, Error> {
-        let config = config.unwrap_or(&self.config);
+        let config: config::Args = self.config.clone().into();
         let network = config.get_network()?;
         tracing::trace!(?network);
         let client = Client::new(&network.rpc_url)?;

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -145,14 +145,3 @@ impl ArgsLocatorAndNetwork {
         Ok(self.network.get(&self.locator)?)
     }
 }
-
-impl From<ArgsLocatorAndNetwork> for Args {
-    fn from(value: ArgsLocatorAndNetwork) -> Self {
-        Args {
-            network: value.network,
-            source_account: Address::AliasOrSecret(String::new()),
-            hd_path: Some(0),
-            locator: value.locator,
-        }
-    }
-}

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -145,3 +145,14 @@ impl ArgsLocatorAndNetwork {
         Ok(self.network.get(&self.locator)?)
     }
 }
+
+impl From<ArgsLocatorAndNetwork> for Args {
+    fn from(value: ArgsLocatorAndNetwork) -> Self {
+        Args {
+            network: value.network,
+            source_account: Address::AliasOrSecret(String::new()),
+            hd_path: Some(0),
+            locator: value.locator,
+        }
+    }
+}

--- a/cookbook/contract-lifecycle.mdx
+++ b/cookbook/contract-lifecycle.mdx
@@ -47,7 +47,7 @@ stellar contract invoke --id <CONTRACT_ID> --source alice --network testnet -- f
 6. View the contract's state:
 
 ```bash
-stellar contract read --id <CONTRACT_ID> --network testnet --source alice --durability <DURABILITY> --key <KEY>
+stellar contract read --id <CONTRACT_ID> --network testnet --durability <DURABILITY> --key <KEY>
 ```
 
 Note: `<DURABILITY>` is either `persistent` or `temporary`. `KEY` provides the key of the storage entry being read.


### PR DESCRIPTION
### What

Before:

```console
$ stellar contract read --id hello --network testnet
error: the following required arguments were not provided:
  --source-account <SOURCE_ACCOUNT>

Usage: stellar contract read --source-account <SOURCE_ACCOUNT> --id <CONTRACT_ID> --network <NETWORK>

For more information, try '--help'.
```

After:

```console
$ stellar contract read --id hello --network testnet
LedgerKeyContractInstance,"{""hash"":""4e1ff745c9f12141dca37e5116e994594812c23c091650c5756a2de7857423d3""}",329089,2402688
```

### Why

The source account was being required just because of how clap's flattening work.

### Known limitations

N/A
