### PR TITLE
Fix/init blocking

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration.rs
+++ b/cmd/crates/soroban-test/tests/it/integration.rs
@@ -4,6 +4,7 @@ mod custom_types;
 mod dotenv;
 mod fund;
 mod hello_world;
+mod init;
 mod snapshot;
 mod tx;
 mod util;

--- a/cmd/crates/soroban-test/tests/it/integration/init.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/init.rs
@@ -23,4 +23,5 @@ fn init() {
             table["workspace"]["dependencies"]["soroban-sdk"].as_str()
                 == Some(&format!("{major}.0.0"))
         }));
+    // this is true, that is does create the dir, but it also panics
 }

--- a/cmd/crates/soroban-test/tests/it/integration/init.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/init.rs
@@ -23,5 +23,4 @@ fn init() {
             table["workspace"]["dependencies"]["soroban-sdk"].as_str()
                 == Some(&format!("{major}.0.0"))
         }));
-    // this is true, that is does create the dir, but it also panics
 }

--- a/cmd/crates/soroban-test/tests/it/main.rs
+++ b/cmd/crates/soroban-test/tests/it/main.rs
@@ -2,7 +2,6 @@ mod arg_parsing;
 mod build;
 mod config;
 mod help;
-mod init;
 #[cfg(feature = "it")]
 mod integration;
 mod plugin;

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -147,7 +147,7 @@ impl Cmd {
             Cmd::Deploy(deploy) => deploy.run(global_args).await?,
             Cmd::Id(id) => id.run()?,
             Cmd::Info(info) => info.run().await?,
-            Cmd::Init(init) => init.run(global_args)?,
+            Cmd::Init(init) => init.run(global_args).await?,
             Cmd::Inspect(inspect) => inspect.run(global_args)?,
             Cmd::Install(install) => install.run(global_args).await?,
             Cmd::Invoke(invoke) => invoke.run(global_args).await?,


### PR DESCRIPTION
### What

- moves the init integration test into the integration dir
- makes the init command async, and then uses the async reqwest client. 

### Why

I was seeing this error when running `contract init` on `main`:
```
thread 'main' panicked at .cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This happens because we were trying to use the blocking reqwest client inside of an async runtime, since all of the cli is in an tokio runtime. This doesn't work well together, so I've changed the `init` command to be async and then we're able to `await` the HTTP calls.

### Known limitations

This won't be an issue once https://github.com/stellar/stellar-cli/pull/1628/files is merged - but we'll still want to move the `init` test into the integration dir - I think that this test was previously not being run. 
