### PR TITLE
Add attestation of binaries uploaded to release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -62,6 +62,11 @@ jobs:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       working-directory: ${{ env.BUILD_WORKING_DIR }}
       run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
+    - name: Build provenance for attestation (release only)
+      if: github.event_name == 'release'
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: target/${{ matrix.sys.target }}/release/${{ matrix.crate.binary }}${{ matrix.sys.ext }}
     - name: Compress
       run: |
           cd target/${{ matrix.sys.target }}/release


### PR DESCRIPTION
### What
Add attestation of binaries uploaded to release.

### Why
So that folks can run `gh attestation stellar --repo stellar/stellar-cli` to verify that a binary they've downloaded from the releases page was built by a github workflow on the repo, and which workflow built it, to confirm that it hasn't been tampered with.