### PR TITLE
Fix attestation during binary release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,6 +13,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write
+  contents: write
+  attestations: write
+
 jobs:
 
   build:


### PR DESCRIPTION
### What
Fix attestation during binary release

### Why
When I added the attestation logic, I forgot to add permissions for it to the workflow.