### PR TITLE
Use attestation in install action

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,6 +13,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write
+  contents: write
+  attestations: write
+
 jobs:
 
   build:

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,14 @@ runs:
       mkdir -p $HOME/.local/bin
       echo "$HOME/.local/bin" >> $GITHUB_PATH
   - name: Copy binary to install location
+    id: version
     shell: bash
-    env:
-      REF: ${{ github.action_ref }}
     run: |
-      version="${{ inputs.version || env.REF }}"
+      echo "version=${{ inputs.version || github.action_ref }}" >> "$GITHUB_OUTPUT"
+  - name: Copy binary to install location
+    shell: bash
+    run: |
+      version="${{ steps.version.outputs.version }}"
       case "${{ runner.os }}-${{ runner.arch }}" in
       'Linux-X64')
         os_arch=x86_64-unknown-linux-gnu
@@ -45,3 +48,15 @@ runs:
       url="https://github.com/stellar/stellar-cli/releases/download/v$version/$file"
       echo "$url"
       curl -fL "$url" | tar xvz -C $HOME/.local/bin
+  - name: Verify binary against attestation
+    shell: bash
+    run: |
+      version="${{ steps.version.outputs.version }}"
+      subject="$(gh attestation verify ~/.local/bin/stellar --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"
+      expected_subject="https://github.com/stellar/stellar-cli/.github/workflows/binaries.yml@refs/tags/v$version"
+      if [[ "$subject" != "$expected_subject" ]]; then
+        echo "Attestation verification found unexpected subject" >&2
+        echo "Found subject: $subject" >&2
+        echo "Expected subject: $expected_subject" >&2
+        exit 1
+      fi

--- a/action.yml
+++ b/action.yml
@@ -55,10 +55,10 @@ runs:
     run: |
       version="${{ steps.version.outputs.version }}"
       subject="$(gh attestation verify ~/.local/bin/stellar --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"
+      echo "Found subject: $subject" >&2
       expected_subject="https://github.com/stellar/stellar-cli/.github/workflows/binaries.yml@refs/tags/v$version"
+      echo "Expected subject: $expected_subject" >&2
       if [[ "$subject" != "$expected_subject" ]]; then
         echo "Attestation verification found unexpected subject" >&2
-        echo "Found subject: $subject" >&2
-        echo "Expected subject: $expected_subject" >&2
         exit 1
       fi

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,8 @@ runs:
       curl -fL "$url" | tar xvz -C $HOME/.local/bin
   - name: Verify binary against attestation
     shell: bash
+    env:
+      GH_TOKEN: ${{ github.token }}
     run: |
       version="${{ steps.version.outputs.version }}"
       subject="$(gh attestation verify ~/.local/bin/stellar --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     run: |
       mkdir -p $HOME/.local/bin
       echo "$HOME/.local/bin" >> $GITHUB_PATH
-  - name: Copy binary to install location
+  - name: Determine version to install
     id: version
     shell: bash
     run: |


### PR DESCRIPTION
### What
Verify GitHub attestation in install action for the cli and fail if the verification fails, or the verified subject does not match the binaries.yml build for the tag of the release.

### Why
The GitHub Attestation allows us to see who produced the binary. We may as well at install points check that the binary being installed from the GitHub releases was built by the appropriate job, and not modified at some point.