### PR TITLE
fix: default value for starting balance in create_account

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1517,7 +1517,7 @@ Creates and funds a new account with the specified starting balance
 * `--destination <DESTINATION>` — Account Id to create, e.g. `GBX...`
 * `--starting-balance <STARTING_BALANCE>` — Initial balance in stroops of the account, default 1 XLM
 
-  Default value: `10_000_000`
+  Default value: `10000000`
 
 
 

--- a/cmd/soroban-cli/src/commands/tx/new/create_account.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/create_account.rs
@@ -11,7 +11,7 @@ pub struct Cmd {
     #[arg(long)]
     pub destination: xdr::AccountId,
     /// Initial balance in stroops of the account, default 1 XLM
-    #[arg(long, default_value = "10_000_000")]
+    #[arg(long, default_value = "10000000")]
     pub starting_balance: i64,
 }
 


### PR DESCRIPTION
The default value parser failed when the string contained underscores.

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
