### PR TITLE
Add global config for default network and identity.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -45,7 +45,7 @@ Anything after the `--` double dash (the "slop") is parsed as arguments to the c
 
 * `contract` — Tools for smart contract developers
 * `events` — Watch the network for contract events
-* `env` — Show current environment
+* `env` — Prints the current environment variables or defaults to the stdout, in a format that can be used as .env file. Environment variables have precedency over defaults
 * `keys` — Create and manage identities including keys and addresses
 * `network` — Start and configure networks
 * `snapshot` — Download a snapshot of a ledger from an archive
@@ -900,7 +900,7 @@ Watch the network for contract events
 
 ## `stellar env`
 
-Show current environment
+Prints the current environment variables or defaults to the stdout, in a format that can be used as .env file. Environment variables have precedency over defaults
 
 **Usage:** `stellar env [OPTIONS]`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -45,6 +45,7 @@ Anything after the `--` double dash (the "slop") is parsed as arguments to the c
 
 * `contract` — Tools for smart contract developers
 * `events` — Watch the network for contract events
+* `env` — Show current environment
 * `keys` — Create and manage identities including keys and addresses
 * `network` — Start and configure networks
 * `snapshot` — Download a snapshot of a ledger from an archive
@@ -897,6 +898,19 @@ Watch the network for contract events
 
 
 
+## `stellar env`
+
+Show current environment
+
+**Usage:** `stellar env [OPTIONS]`
+
+###### **Options:**
+
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
+
+
+
 ## `stellar keys`
 
 Create and manage identities including keys and addresses
@@ -912,6 +926,7 @@ Create and manage identities including keys and addresses
 * `ls` — List identities
 * `rm` — Remove an identity
 * `show` — Given an identity return its private key
+* `use` — Set the default identity that will be used on all commands. This allows you to skip `--source-account` or setting a environment variable, while reusing this value in all commands that require it
 
 
 
@@ -1052,6 +1067,23 @@ Given an identity return its private key
 
 
 
+## `stellar keys use`
+
+Set the default identity that will be used on all commands. This allows you to skip `--source-account` or setting a environment variable, while reusing this value in all commands that require it
+
+**Usage:** `stellar keys use [OPTIONS] <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Set the default network name
+
+###### **Options:**
+
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
+
+
+
 ## `stellar network`
 
 Start and configure networks
@@ -1065,6 +1097,7 @@ Start and configure networks
 * `ls` — List networks
 * `start` — ⚠️ Deprecated: use `stellar container start` instead
 * `stop` — ⚠️ Deprecated: use `stellar container stop` instead
+* `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
 * `container` — Commands to start, stop and get logs for a quickstart container
 
 
@@ -1171,6 +1204,23 @@ Stop a network started with `network start`. For example, if you ran `stellar ne
 ###### **Options:**
 
 * `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
+
+
+
+## `stellar network use`
+
+Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
+
+**Usage:** `stellar network use [OPTIONS] <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Set the default network name
+
+###### **Options:**
+
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
 
 
 

--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -340,3 +340,56 @@ fn config_dirs_precedence() {
         ))
         .stdout("SAQMV6P3OWM2SKCK3OEWNXSRYWK5RNNUL5CPHQGIJF2WVT4EI2BZ63GG\n");
 }
+
+#[test]
+fn set_default_identity() {
+    let sandbox = TestEnv::default();
+
+    sandbox
+        .new_assert_cmd("keys")
+        .env(
+            "SOROBAN_SECRET_KEY",
+            "SC4ZPYELVR7S7EE7KZDZN3ETFTNQHHLTUL34NUAAWZG5OK2RGJ4V2U3Z",
+        )
+        .arg("add")
+        .arg("alice")
+        .assert()
+        .success();
+
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("use")
+        .arg("alice")
+        .assert()
+        .stderr(predicate::str::contains(
+            "The default source account is set to `alice`",
+        ))
+        .success();
+
+    sandbox
+        .new_assert_cmd("env")
+        .assert()
+        .stdout(predicate::str::contains("identity=alice"))
+        .success();
+}
+
+#[test]
+fn set_default_network() {
+    let sandbox = TestEnv::default();
+
+    sandbox
+        .new_assert_cmd("network")
+        .arg("use")
+        .arg("testnet")
+        .assert()
+        .stderr(predicate::str::contains(
+            "The default network is set to `testnet`",
+        ))
+        .success();
+
+    sandbox
+        .new_assert_cmd("env")
+        .assert()
+        .stdout(predicate::str::contains("network=testnet"))
+        .success();
+}

--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -369,7 +369,7 @@ fn set_default_identity() {
     sandbox
         .new_assert_cmd("env")
         .assert()
-        .stdout(predicate::str::contains("identity=alice"))
+        .stdout(predicate::str::contains("STELLAR_ACCOUNT=alice"))
         .success();
 }
 
@@ -390,6 +390,6 @@ fn set_default_network() {
     sandbox
         .new_assert_cmd("env")
         .assert()
-        .stdout(predicate::str::contains("network=testnet"))
+        .stdout(predicate::str::contains("STELLAR_NETWORK=testnet"))
         .success();
 }

--- a/cmd/soroban-cli/src/commands/env/mod.rs
+++ b/cmd/soroban-cli/src/commands/env/mod.rs
@@ -1,6 +1,9 @@
 use crate::{
     commands::global,
-    config::locator::{self, config},
+    config::{
+        locator::{self},
+        Config,
+    },
 };
 use clap::Parser;
 
@@ -21,7 +24,7 @@ pub enum Error {
 
 impl Cmd {
     pub fn run(&self, _global_args: &global::Args) -> Result<(), Error> {
-        let config = config()?;
+        let config = Config::new()?;
         let mut lines: Vec<(String, String)> = Vec::new();
 
         if let Some(data) = get("STELLAR_NETWORK", config.defaults.network) {

--- a/cmd/soroban-cli/src/commands/env/mod.rs
+++ b/cmd/soroban-cli/src/commands/env/mod.rs
@@ -1,0 +1,37 @@
+use crate::{
+    commands::global,
+    config::locator::{self, config, config_file},
+};
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Locator(#[from] locator::Error),
+}
+
+impl Cmd {
+    pub fn run(&self, _global_args: &global::Args) -> Result<(), Error> {
+        let config = config()?;
+
+        println!("config_file={}", config_file()?.to_string_lossy());
+
+        println!(
+            "network={}",
+            config.defaults.network.unwrap_or("(unset)".to_string())
+        );
+
+        println!(
+            "identity={}",
+            config.defaults.identity.unwrap_or("(unset)".to_string())
+        );
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/keys/default.rs
+++ b/cmd/soroban-cli/src/commands/keys/default.rs
@@ -1,0 +1,35 @@
+use clap::command;
+
+use crate::{commands::global, config::locator, print::Print};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] locator::Error),
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// Set the default network name.
+    pub name: String,
+
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+}
+
+impl Cmd {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let printer = Print::new(global_args.quiet);
+        let _ = self.config_locator.read_identity(&self.name)?;
+
+        self.config_locator.write_default_identity(&self.name)?;
+
+        printer.infoln(format!(
+            "The default source account is set to `{}`",
+            self.name,
+        ));
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/keys/mod.rs
+++ b/cmd/soroban-cli/src/commands/keys/mod.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 
 pub mod add;
 pub mod address;
+pub mod default;
 pub mod fund;
 pub mod generate;
 pub mod ls;
@@ -13,18 +14,30 @@ pub mod show;
 pub enum Cmd {
     /// Add a new identity (keypair, ledger, macOS keychain)
     Add(add::Cmd),
+
     /// Given an identity return its address (public key)
     Address(address::Cmd),
+
     /// Fund an identity on a test network
     Fund(fund::Cmd),
+
     /// Generate a new identity with a seed phrase, currently 12 words
     Generate(generate::Cmd),
+
     /// List identities
     Ls(ls::Cmd),
+
     /// Remove an identity
     Rm(rm::Cmd),
+
     /// Given an identity return its private key
     Show(show::Cmd),
+
+    /// Set the default identity that will be used on all commands.
+    /// This allows you to skip `--source-account` or setting a environment
+    /// variable, while reusing this value in all commands that require it.
+    #[command(name = "use")]
+    Default(default::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -34,18 +47,24 @@ pub enum Error {
 
     #[error(transparent)]
     Address(#[from] address::Error),
+
     #[error(transparent)]
     Fund(#[from] fund::Error),
 
     #[error(transparent)]
     Generate(#[from] generate::Error),
+
     #[error(transparent)]
     Rm(#[from] rm::Error),
+
     #[error(transparent)]
     Ls(#[from] ls::Error),
 
     #[error(transparent)]
     Show(#[from] show::Error),
+
+    #[error(transparent)]
+    Default(#[from] default::Error),
 }
 
 impl Cmd {
@@ -58,6 +77,7 @@ impl Cmd {
             Cmd::Ls(cmd) => cmd.run()?,
             Cmd::Rm(cmd) => cmd.run()?,
             Cmd::Show(cmd) => cmd.run()?,
+            Cmd::Default(cmd) => cmd.run(global_args)?,
         };
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ use crate::config;
 pub mod cache;
 pub mod completion;
 pub mod contract;
+pub mod env;
 pub mod events;
 pub mod global;
 pub mod keys;
@@ -116,7 +117,8 @@ impl Root {
             Cmd::Version(version) => version.run(),
             Cmd::Keys(id) => id.run(&self.global_args).await?,
             Cmd::Tx(tx) => tx.run(&self.global_args).await?,
-            Cmd::Cache(data) => data.run()?,
+            Cmd::Cache(cache) => cache.run()?,
+            Cmd::Env(env) => env.run(&self.global_args)?,
         };
         Ok(())
     }
@@ -135,8 +137,12 @@ pub enum Cmd {
     /// Tools for smart contract developers
     #[command(subcommand)]
     Contract(contract::Cmd),
+
     /// Watch the network for contract events
     Events(events::Cmd),
+
+    /// Show current environment
+    Env(env::Cmd),
 
     /// Create and manage identities including keys and addresses
     #[command(subcommand)]
@@ -160,9 +166,11 @@ pub enum Cmd {
     /// Print shell completion code for the specified shell.
     #[command(long_about = completion::LONG_ABOUT)]
     Completion(completion::Cmd),
+
     /// Cache for transactions and contract specs
     #[command(subcommand)]
     Cache(cache::Cmd),
+
     /// Print version information
     Version(version::Cmd),
 }
@@ -172,24 +180,36 @@ pub enum Error {
     // TODO: stop using Debug for displaying errors
     #[error(transparent)]
     Contract(#[from] contract::Error),
+
     #[error(transparent)]
     Events(#[from] events::Error),
+
     #[error(transparent)]
     Keys(#[from] keys::Error),
+
     #[error(transparent)]
     Xdr(#[from] stellar_xdr::cli::Error),
+
     #[error(transparent)]
     Clap(#[from] clap::error::Error),
+
     #[error(transparent)]
     Plugin(#[from] plugin::Error),
+
     #[error(transparent)]
     Network(#[from] network::Error),
+
     #[error(transparent)]
     Snapshot(#[from] snapshot::Error),
+
     #[error(transparent)]
     Tx(#[from] tx::Error),
+
     #[error(transparent)]
     Cache(#[from] cache::Error),
+
+    #[error(transparent)]
+    Env(#[from] env::Error),
 }
 
 #[async_trait]

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -141,7 +141,9 @@ pub enum Cmd {
     /// Watch the network for contract events
     Events(events::Cmd),
 
-    /// Show current environment
+    /// Prints the current environment variables or defaults to the stdout, in
+    /// a format that can be used as .env file. Environment variables have
+    /// precedency over defaults.
     Env(env::Cmd),
 
     /// Create and manage identities including keys and addresses

--- a/cmd/soroban-cli/src/commands/network/default.rs
+++ b/cmd/soroban-cli/src/commands/network/default.rs
@@ -1,0 +1,34 @@
+use clap::command;
+
+use crate::{commands::global, print::Print};
+
+use super::locator;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] locator::Error),
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// Set the default network name.
+    pub name: String,
+
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+}
+
+impl Cmd {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let printer = Print::new(global_args.quiet);
+        let _ = self.config_locator.read_network(&self.name)?;
+
+        self.config_locator.write_default_network(&self.name)?;
+
+        printer.infoln(format!("The default network is set to `{}`", self.name));
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use std::{
     ffi::OsStr,
     fmt::Display,
-    fs::{self, create_dir_all, File, OpenOptions},
+    fs::{self, create_dir_all, OpenOptions},
     io::{self, Write},
     path::{Path, PathBuf},
     str::FromStr,
@@ -168,27 +168,11 @@ impl Args {
     }
 
     pub fn write_default_network(&self, name: &str) -> Result<(), Error> {
-        let mut config = config()?;
-
-        config.defaults.network = Some(name.to_string());
-
-        let toml_string = toml::to_string(&config)?;
-        let mut file = File::create(config_file()?)?;
-        file.write_all(toml_string.as_bytes())?;
-
-        Ok(())
+        Config::new()?.set_network(name).save()
     }
 
     pub fn write_default_identity(&self, name: &str) -> Result<(), Error> {
-        let mut config = config()?;
-
-        config.defaults.identity = Some(name.to_string());
-
-        let toml_string = toml::to_string(&config)?;
-        let mut file = File::create(config_file()?)?;
-        file.write_all(toml_string.as_bytes())?;
-
-        Ok(())
+        Config::new()?.set_identity(name).save()
     }
 
     pub fn list_identities(&self) -> Result<Vec<String>, Error> {
@@ -543,6 +527,6 @@ pub fn config() -> Result<Config, Error> {
 
         Ok(config)
     } else {
-        Ok(Config::new())
+        Ok(Config::new()?)
     }
 }

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -517,16 +517,3 @@ pub fn global_config_path() -> Result<PathBuf, Error> {
 pub fn config_file() -> Result<PathBuf, Error> {
     Ok(global_config_path()?.join("config.toml"))
 }
-
-pub fn config() -> Result<Config, Error> {
-    let path = config_file()?;
-
-    if path.exists() {
-        let data = fs::read(&path).map_err(|_| Error::FileRead { path })?;
-        let config: Config = toml::from_slice(data.as_slice())?;
-
-        Ok(config)
-    } else {
-        Ok(Config::new()?)
-    }
-}

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -4,9 +4,8 @@ use serde::de::DeserializeOwned;
 use std::{
     ffi::OsStr,
     fmt::Display,
-    fs::{self, create_dir_all, OpenOptions},
-    io,
-    io::Write,
+    fs::{self, create_dir_all, File, OpenOptions},
+    io::{self, Write},
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -18,10 +17,13 @@ use super::{
     alias,
     network::{self, Network},
     secret::Secret,
+    Config,
 };
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    TomlSerialize(#[from] toml::ser::Error),
     #[error("Failed to find home directory")]
     HomeDirNotFound,
     #[error("Failed read current directory")]
@@ -34,6 +36,8 @@ pub enum Error {
     SecretFileRead { path: PathBuf },
     #[error("Failed to read network file: {path};\nProbably need to use `stellar network add`")]
     NetworkFileRead { path: PathBuf },
+    #[error("Failed to read file: {path}")]
+    FileRead { path: PathBuf },
     #[error(transparent)]
     Toml(#[from] toml::de::Error),
     #[error("Secret file failed to deserialize")]
@@ -161,6 +165,30 @@ impl Args {
 
     pub fn write_network(&self, name: &str, network: &Network) -> Result<(), Error> {
         KeyType::Network.write(name, network, &self.config_dir()?)
+    }
+
+    pub fn write_default_network(&self, name: &str) -> Result<(), Error> {
+        let mut config = config()?;
+
+        config.defaults.network = Some(name.to_string());
+
+        let toml_string = toml::to_string(&config)?;
+        let mut file = File::create(config_file()?)?;
+        file.write_all(toml_string.as_bytes())?;
+
+        Ok(())
+    }
+
+    pub fn write_default_identity(&self, name: &str) -> Result<(), Error> {
+        let mut config = config()?;
+
+        config.defaults.identity = Some(name.to_string());
+
+        let toml_string = toml::to_string(&config)?;
+        let mut file = File::create(config_file()?)?;
+        file.write_all(toml_string.as_bytes())?;
+
+        Ok(())
     }
 
     pub fn list_identities(&self) -> Result<Vec<String>, Error> {
@@ -344,6 +372,12 @@ impl Args {
     }
 }
 
+impl Pwd for Args {
+    fn set_pwd(&mut self, pwd: &Path) {
+        self.config_dir = Some(pwd.to_path_buf());
+    }
+}
+
 pub fn ensure_directory(dir: PathBuf) -> Result<PathBuf, Error> {
     let parent = dir.parent().ok_or(Error::HomeDirNotFound)?;
     std::fs::create_dir_all(parent).map_err(|_| dir_creation_failed(parent))?;
@@ -496,8 +530,19 @@ pub fn global_config_path() -> Result<PathBuf, Error> {
     Ok(stellar_dir)
 }
 
-impl Pwd for Args {
-    fn set_pwd(&mut self, pwd: &Path) {
-        self.config_dir = Some(pwd.to_path_buf());
+pub fn config_file() -> Result<PathBuf, Error> {
+    Ok(global_config_path()?.join("config.toml"))
+}
+
+pub fn config() -> Result<Config, Error> {
+    let path = config_file()?;
+
+    if path.exists() {
+        let data = fs::read(&path).map_err(|_| Error::FileRead { path })?;
+        let config: Config = toml::from_slice(data.as_slice())?;
+
+        Ok(config)
+    } else {
+        Ok(Config::new())
     }
 }

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -125,9 +125,6 @@ impl Pwd for Args {
     }
 }
 
-#[derive(Default, Serialize, Deserialize)]
-pub struct Config {}
-
 #[derive(Debug, clap::Args, Clone, Default)]
 #[group(skip)]
 pub struct ArgsLocatorAndNetwork {
@@ -141,5 +138,33 @@ pub struct ArgsLocatorAndNetwork {
 impl ArgsLocatorAndNetwork {
     pub fn get_network(&self) -> Result<Network, Error> {
         Ok(self.network.get(&self.locator)?)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Config {
+    pub defaults: Defaults,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Defaults {
+    pub network: Option<String>,
+    pub identity: Option<String>,
+}
+
+impl Config {
+    pub fn new() -> Config {
+        Config {
+            defaults: Defaults {
+                network: None,
+                identity: None,
+            },
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
### What

This pr introduces a global config file called `~/.stellar/config.toml`. Right now, it contains a new section called `defaults`, which can hold the values set by the new commands `stellar keys use NAME` and `stellar network use NAME`. An upcoming pr will use this values by default, when available.

```console
$ stellar network use testnet
ℹ️ The default network is set to `testnet`

$ stellar keys use alice
ℹ️ The default source account is set to `alice`

$ stellar env
STELLAR_NETWORK=testnet # default
STELLAR_ACCOUNT=alice   # default

$ cat ~/.config/stellar/config.toml
[defaults]
network = "testnet"
identity = "alice"
```

### Why

This is the first step to implement #1396.

### Known limitations

N/A
