### PR TITLE
Cleanup unit testing/add ARM support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,16 +45,16 @@ jobs:
       matrix:
         rust: [msrv, latest]
         sys:
-        - os: ubuntu-latest-16-cores
-          target: x86_64-unknown-linux-gnu
+#        - os: ubuntu-latest-16-cores
+#          target: x86_64-unknown-linux-gnu
         - os: ubuntu-latest-16-cores
           target: aarch64-unknown-linux-gnu
-        - os: macos-latest
-          target: x86_64-apple-darwin
-        - os: macos-latest
-          target: aarch64-apple-darwin
-        - os: windows-latest-8-cores
-          target: x86_64-pc-windows-msvc
+#        - os: macos-latest
+#          target: x86_64-apple-darwin
+#        - os: macos-latest
+#          target: aarch64-apple-darwin
+#        - os: windows-latest-8-cores
+#          target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.sys.os }}
     env:
       CI_TESTS: true
@@ -78,7 +78,9 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
       run: |
-        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:armhf
+        cat /etc/apt/sources.list
+        sudo dpkg --add-architecture arm64
+        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
       CI_TESTS: true
     steps:
     - uses: actions/checkout@v4
-    - uses: stellar/actions/rust-cache@2e6d2ccfe3c07260044cbc5261ed61dff3a897d1
+    - uses: stellar/actions/rust-cache@3de70bce21ab18ada0a52dd9aca8651bf6a9521a
     - name: Use the minimum supported Rust version
       if: matrix.rust == 'msrv'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,6 @@ jobs:
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
-        ssl_dir=`openssl version -d | sed -e 's/OPENSSLDIR: \"\(.*\)\"/\1/g'`
-        echo "OPENSSL_DIR=${ssl_dir}" >> $GITHUB_ENV
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
     - if: runner.os == 'Linux'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         sys:
 #        - os: ubuntu-latest-16-cores
 #          target: x86_64-unknown-linux-gnu
-        - os: ubuntu-latest-16-cores
+        - os: ubuntu-jammy-16-cores-arm64
           target: aarch64-unknown-linux-gnu
 #        - os: macos-latest
 #          target: x86_64-apple-darwin
@@ -78,27 +78,27 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - if: matrix.sys.target == 'aarch64-unknown-linux-gnu'
       run: |
-        echo "
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
-        
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
-        
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy universe
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates universe
-        
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy multiverse
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates multiverse
-        
-        deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
-        " | sudo tee -a /etc/apt/sources.list >/dev/null
-        
-        sudo dpkg --add-architecture arm64
+#        echo "
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
+#
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
+#
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy universe
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates universe
+#
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy multiverse
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates multiverse
+#
+#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
+#        " | sudo tee -a /etc/apt/sources.list >/dev/null
+#
+#        sudo dpkg --add-architecture arm64
         sudo apt update && sudo apt upgrade
         
-        sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev:arm64 pkg-config libssl-dev:arm64
-        cfg_path=`pkg-config --variable pc_path pkg-config`
-        echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
-        echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
+        sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+#        cfg_path=`pkg-config --variable pc_path pkg-config`
+#        echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
+#        echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
       run: |
-        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
+        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,9 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
+      env:
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        CARGO_BUILD_TARGET: ${{ matrix.sys.target }}
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,10 +77,7 @@ jobs:
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
-      run: |
-        sudo apt update && sudo apt upgrade
-        
-        sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+      run: sudo apt update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
       run: |
-        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,29 +76,11 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - if: matrix.sys.target == 'aarch64-unknown-linux-gnu'
+    - if: runner.os == 'Linux'
       run: |
-#        echo "
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
-#
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
-#
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy universe
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates universe
-#
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy multiverse
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates multiverse
-#
-#        deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
-#        " | sudo tee -a /etc/apt/sources.list >/dev/null
-#
-#        sudo dpkg --add-architecture arm64
         sudo apt update && sudo apt upgrade
         
         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
-#        cfg_path=`pkg-config --variable pc_path pkg-config`
-#        echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
-#        echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
       CI_TESTS: true
     steps:
     - uses: actions/checkout@v4
-    - uses: stellar/actions/rust-cache@3de70bce21ab18ada0a52dd9aca8651bf6a9521a
+    - uses: stellar/actions/rust-cache@main
     - name: Use the minimum supported Rust version
       if: matrix.rust == 'msrv'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,17 +72,13 @@ jobs:
       # Rust will frequently add new warnings and checks.
       if: matrix.rust == 'msrv'
       run: echo RUSTFLAGS='-Dwarnings -Dclippy::all -Dclippy::pedantic' >> $GITHUB_ENV
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
     - if: matrix.sys.target == 'aarch64-unknown-linux-gnu'
       run: |
-        sudo cat >> /etc/apt/sources.list << EOF
+        echo "
         deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
         
         deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
@@ -94,9 +90,7 @@ jobs:
         deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates multiverse
         
         deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
-        EOF
-        
-        cat /etc/apt/sources.list
+        " | sudo tee -a /etc/apt/sources.list >/dev/null
         
         sudo dpkg --add-architecture arm64
         sudo apt update && sudo apt upgrade

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,16 +45,16 @@ jobs:
       matrix:
         rust: [msrv, latest]
         sys:
-#        - os: ubuntu-latest-16-cores
-#          target: x86_64-unknown-linux-gnu
+        - os: ubuntu-latest-16-cores
+          target: x86_64-unknown-linux-gnu
         - os: ubuntu-jammy-16-cores-arm64
           target: aarch64-unknown-linux-gnu
-#        - os: macos-latest
-#          target: x86_64-apple-darwin
-#        - os: macos-latest
-#          target: aarch64-apple-darwin
-#        - os: windows-latest-8-cores
-#          target: x86_64-pc-windows-msvc
+        - os: macos-latest
+          target: x86_64-apple-darwin
+        - os: macos-latest
+          target: aarch64-apple-darwin
+        - os: windows-latest-8-cores
+          target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.sys.os }}
     env:
       CI_TESTS: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
         sudo dpkg --add-architecture arm64
         sudo apt update && sudo apt upgrade
         
-        sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
+        sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev:arm64 pkg-config libssl-dev:arm64
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,7 @@ jobs:
         sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
+        echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
     - if: runner.os == 'Linux'
       run: |
         pkg-config --variable pc_path pkg-config

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,7 @@ jobs:
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
+        ls -la /usr/include/
     - if: runner.os == 'Linux'
       run: |
         pkg-config --variable pc_path pkg-config

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,8 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+    - if: runner.os == 'Linux'
+      run: openssl version -d
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,8 @@ jobs:
       run: |
         cat /etc/apt/sources.list
         sudo dpkg --add-architecture arm64
-        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
+        sudo apt update && sudo apt upgrade
+        sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
       CI_TESTS: true
     steps:
     - uses: actions/checkout@v4
-    - uses: stellar/actions/rust-cache@main
+    - uses: stellar/actions/rust-cache@2e6d2ccfe3c07260044cbc5261ed61dff3a897d1
     - name: Use the minimum supported Rust version
       if: matrix.rust == 'msrv'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,9 +77,15 @@ jobs:
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+      run: |
+        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+        ssl_dir=`openssl version -d | sed -e 's/OPENSSLDIR: \"\(.*\)\"/\1/g'`
+        echo "OPENSSL_DIR=${ssl_dir}" >> $GITHUB_ENV
+        cfg_path=`pkg-config --variable pc_path pkg-config`
+        echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
     - if: runner.os == 'Linux'
-      run: openssl version -d
+      run: |
+        pkg-config --variable pc_path pkg-config
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,12 +78,11 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
       run: |
-        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
+        sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:armhf
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
-        sudo ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h
-        sudo ln -s /usr/include/x86_64-linux-gnu/openssl/configuration.h /usr/include/openssl/configuration.h
+        ls -la  /usr/include/
     - if: runner.os == 'Linux'
       run: |
         pkg-config --variable pc_path pkg-config

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,14 +79,14 @@ jobs:
     - if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
-    - run: make build-test
+    - run: make test
       # TODO: enable ARM linux
-    - if: startsWith(matrix.sys.target, 'x86_64') || runner.os == 'macOS'
-      # specify directories explicitly (otherwise it will fail with missing symbols)
-      run: |
-        for I in cmd/soroban-cli cmd/crates/* cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world ; do
-          cargo test --target ${{ matrix.sys.target }} --manifest-path $I/Cargo.toml
-        done
+#    - if: startsWith(matrix.sys.target, 'x86_64') || runner.os == 'macOS'
+#      # specify directories explicitly (otherwise it will fail with missing symbols)
+#      run: |
+#        for I in cmd/soroban-cli cmd/crates/* cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world ; do
+#          cargo test --target ${{ matrix.sys.target }} --manifest-path $I/Cargo.toml
+#        done
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,6 +72,10 @@ jobs:
       # Rust will frequently add new warnings and checks.
       if: matrix.rust == 'msrv'
       run: echo RUSTFLAGS='-Dwarnings -Dclippy::all -Dclippy::pedantic' >> $GITHUB_ENV
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,19 +80,31 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - if: runner.os == 'Linux'
+    - if: matrix.sys.target == 'aarch64-unknown-linux-gnu'
       run: |
+        sudo cat >> /etc/apt/sources.list << EOF
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
+        
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
+        
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy universe
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates universe
+        
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy multiverse
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates multiverse
+        
+        deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse
+        EOF
+        
         cat /etc/apt/sources.list
+        
         sudo dpkg --add-architecture arm64
         sudo apt update && sudo apt upgrade
+        
         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev pkg-config libssl-dev:arm64
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
-        ls -la  /usr/include/
-    - if: runner.os == 'Linux'
-      run: |
-        pkg-config --variable pc_path pkg-config
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,8 @@ jobs:
         cfg_path=`pkg-config --variable pc_path pkg-config`
         echo "PKG_CONFIG_PATH=${cfg_path}" >>  $GITHUB_ENV
         echo "PKG_CONFIG_SYSROOT_DIR=/home/runner/.local/sysroot" >>  $GITHUB_ENV
-        ls -la /usr/include/
+        sudo ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h
+        sudo ln -s /usr/include/x86_64-linux-gnu/openssl/configuration.h /usr/include/openssl/configuration.h
     - if: runner.os == 'Linux'
       run: |
         pkg-config --variable pc_path pkg-config

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,13 +80,6 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
-      # TODO: enable ARM linux
-#    - if: startsWith(matrix.sys.target, 'x86_64') || runner.os == 'macOS'
-#      # specify directories explicitly (otherwise it will fail with missing symbols)
-#      run: |
-#        for I in cmd/soroban-cli cmd/crates/* cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world ; do
-#          cargo test --target ${{ matrix.sys.target }} --manifest-path $I/Cargo.toml
-#        done
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
     - if: runner.os == 'Linux'
-      run: sudo apt update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}
     - run: make test
       env:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ generate-full-help-doc:
 	cargo run --bin doc-gen --features clap-markdown
 
 test: build-test
-	cargo test
+	cargo test --workspace
 
 e2e-test:
 	cargo test --features it --test it -- integration

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/swap/src/test.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/swap/src/test.rs
@@ -11,7 +11,9 @@ use token::Client as TokenClient;
 use token::StellarAssetClient as TokenAdminClient;
 
 fn create_token_contract<'a>(e: &Env, admin: &Address) -> (TokenClient<'a>, TokenAdminClient<'a>) {
-    let contract_address = e.register_stellar_asset_contract(admin.clone());
+    let contract_address = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     (
         TokenClient::new(e, &contract_address),
         TokenAdminClient::new(e, &contract_address),


### PR DESCRIPTION
### What

Update GH workflow to use Makefile and re-enabled ARM tests. Makefile was also updated to run all workspace tests, that included 4 tests that were previously not run with the job's for loop. Switched instance for ARM Linux tests from X86-64 Ubuntu to ARM Ubuntu. 
Note: binaries for distribution are still build on x86-64 (Ubuntu 20) in order to use an older glibc

### Why

Pipeline improvements 

### Known limitations

N/A