### PR TITLE
fix: remove clap from enforcing network args and update error message

### DIFF
--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -102,11 +102,10 @@ impl Args {
             self.network_passphrase.clone(),
         ) {
             (None, None, None) => Err(Error::Network),
-            (Some(_), Some(_), Some(_)) => Err(Error::CannotUseBothRpcAndNetwork),
             (_, Some(_), None) => Err(Error::MissingNetworkPassphrase),
             (_, None, Some(_)) => Err(Error::MissingRpcUrl),
-            (Some(network), _, _) => Ok(locator.read_network(network)?),
-            (None, Some(rpc_url), Some(network_passphrase)) => Ok(Network {
+            (Some(network), None, None) => Ok(locator.read_network(network)?),
+            (_, Some(rpc_url), Some(network_passphrase)) => Ok(Network {
                 rpc_url,
                 rpc_headers: self.rpc_headers.clone(),
                 network_passphrase,

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -22,7 +22,12 @@ pub mod passphrase;
 pub enum Error {
     #[error(transparent)]
     Config(#[from] locator::Error),
-    #[error("network arg or rpc url and network passphrase are required if using the network")]
+    #[error(
+        r#"Access to the network is required
+`--network` or `--rpc-url` and `--network-passphrase` are required if using the network.
+Alternatively you can use their corresponding environment variables:
+STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE"#
+    )]
     Network,
     #[error(transparent)]
     Rpc(#[from] rpc::Error),
@@ -48,8 +53,6 @@ pub struct Args {
     /// RPC server endpoint
     #[arg(
         long = "rpc-url",
-        requires = "network_passphrase",
-        required_unless_present = "network",
         env = "STELLAR_RPC_URL",
         help_heading = HEADING_RPC,
     )]
@@ -68,8 +71,6 @@ pub struct Args {
     /// Network passphrase to sign the transaction sent to the rpc server
     #[arg(
         long = "network-passphrase",
-        requires = "rpc_url",
-        required_unless_present = "network",
         env = "STELLAR_NETWORK_PASSPHRASE",
         help_heading = HEADING_RPC,
     )]
@@ -77,8 +78,6 @@ pub struct Args {
     /// Name of network to use from config
     #[arg(
         long,
-        required_unless_present = "rpc_url",
-        required_unless_present = "network_passphrase",
         env = "STELLAR_NETWORK",
         help_heading = HEADING_RPC,
     )]


### PR DESCRIPTION
Now the error of missing network args is deferred to when the network is resolved.