### PR TITLE
Fix which macOS arch is used for binary builds

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -33,9 +33,9 @@ jobs:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
           - os: macos-14
-            target: x86_64-apple-darwin
-          - os: macos-12
             target: aarch64-apple-darwin
+          - os: macos-12
+            target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ext: .exe


### PR DESCRIPTION
### What
Change the macOS binary builds so that the x86 build is done on macos-12 and the arm64 build is done on macos-14.

### Why
The builds are currently configured in reverse, with x86 building on macos-14 and arm64 building on macos-12. This was a mistake, because macos-14's arch is arm64 and macos-12's arch is x86.

The builds run slower too than what they would if they were run on their native archs.

### Example

#### Before
<img width="516" alt="Screenshot 2024-11-06 at 10 59 15 PM" src="https://github.com/user-attachments/assets/b53615ef-4e1a-4b15-9a1f-f2e7a264579f">

#### After
<img width="515" alt="Screenshot 2024-11-06 at 11 30 22 PM" src="https://github.com/user-attachments/assets/d48d5531-a2fc-44f1-b28f-57ae1936c09e">
