### PR TITLE
update deprecated note for 'stellar network start'

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1099,7 +1099,7 @@ Start and configure networks
 * `add` — Add a new network
 * `rm` — Remove a network
 * `ls` — List networks
-* `start` — ⚠️ Deprecated: use `stellar container start` instead
+- `start` — ⚠️ Deprecated: use `stellar network container start` instead
 * `stop` — ⚠️ Deprecated: use `stellar container stop` instead
 * `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
 * `container` — Commands to start, stop and get logs for a quickstart container

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1099,8 +1099,8 @@ Start and configure networks
 * `add` — Add a new network
 * `rm` — Remove a network
 * `ls` — List networks
-- `start` — ⚠️ Deprecated: use `stellar network container start` instead
-* `stop` — ⚠️ Deprecated: use `stellar container stop` instead
+* `start` — ⚠️ Deprecated: use `stellar network container start` instead
+* `stop` — ⚠️ Deprecated: use `stellar network container stop` instead
 * `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
 * `container` — Commands to start, stop and get logs for a quickstart container
 
@@ -1159,7 +1159,7 @@ List networks
 
 ## `stellar network start`
 
-⚠️ Deprecated: use `stellar container start` instead
+⚠️ Deprecated: use `stellar network container start` instead
 
 Start network
 
@@ -1195,7 +1195,7 @@ By default, when starting a testnet container, without any optional arguments, i
 
 ## `stellar network stop`
 
-⚠️ Deprecated: use `stellar container stop` instead
+⚠️ Deprecated: use `stellar network container stop` instead
 
 Stop a network started with `network start`. For example, if you ran `stellar network start local`, you can use `stellar network stop local` to stop it.
 

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -21,7 +21,7 @@ pub enum Cmd {
     /// List networks
     Ls(ls::Cmd),
 
-    /// ⚠️ Deprecated: use `stellar container start` instead
+    /// ⚠️ Deprecated: use `stellar network container start` instead
     ///
     /// Start network
     ///
@@ -34,7 +34,7 @@ pub enum Cmd {
     /// `docker run --rm -p 8000:8000 --name stellar stellar/quickstart:testing --testnet --enable rpc,horizon`
     Start(container::StartCmd),
 
-    /// ⚠️ Deprecated: use `stellar container stop` instead
+    /// ⚠️ Deprecated: use `stellar network container stop` instead
     ///
     /// Stop a network started with `network start`. For example, if you ran `stellar network start local`, you can use `stellar network stop local` to stop it.
     Stop(container::StopCmd),


### PR DESCRIPTION
### What

Update the deprecated note for `stellar network start` on [this cli manual page](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli#stellar-network-start). It should be `stellar network container start`

### Why

It had a wrong command and made me confused. Slack thread [here](https://stellarfoundation.slack.com/archives/C06KTGUULUF/p1730922525695449).

### Known limitations

N/A
