### PR TITLE
update cli doc url

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -18,7 +18,7 @@ For additional information see:
 
 - Stellar Docs: https://developers.stellar.org
 - Smart Contract Docs: https://developers.stellar.org/docs/build/smart-contracts/overview
-- CLI Docs: https://developers.stellar.org/docs/tools/stellar-cli
+- CLI Docs: https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli
 
 To get started generate a new identity:
 

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -38,7 +38,7 @@ For additional information see:
 
 - Stellar Docs: https://developers.stellar.org
 - Smart Contract Docs: https://developers.stellar.org/docs/build/smart-contracts/overview
-- CLI Docs: https://developers.stellar.org/docs/tools/stellar-cli";
+- CLI Docs: https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli";
 
 // long_about is shown when someone uses `--help`; short help when using `-h`
 const LONG_ABOUT: &str = "


### PR DESCRIPTION
### What

<img width="639" alt="Screenshot 2024-11-10 at 2 25 06 PM" src="https://github.com/user-attachments/assets/d08bfffd-b621-479d-84a2-92b30c00cf79">

- outdated url when running `stellar -h`

### Why

- broken link. it's outdated.

### Known limitations

N/A
