### PR TITLE
build: update js-sdk to 13.0.0

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
@@ -8,7 +8,7 @@
       "name": "test_custom_types",
       "version": "0.0.0",
       "dependencies": {
-        "@stellar/stellar-sdk": "12.3.0",
+        "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
       },
       "devDependencies": {
@@ -22,9 +22,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+      "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stellar/js-xdr": "^3.1.2",
@@ -35,19 +35,20 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+        "sodium-native": "^4.3.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
+      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.1",
+        "@stellar/stellar-base": "^13.0.1",
         "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.20",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
@@ -156,6 +157,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
+      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -214,6 +224,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -236,9 +258,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -292,9 +314,9 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.0.tgz",
-      "integrity": "sha512-OcMgoS0NJx+4yVUlhvL9uZsVZfmyHZ2RpSXkiIoOHMglqvJDeGwn1rUigPrvcNTq3m9hPXtt6syxQbF3vvwmRQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "12.3.0",
+    "@stellar/stellar-sdk": "13.0.0",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "12.3.0",
+    "@stellar/stellar-sdk": "13.0.0",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/ts-tests/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "devDependencies": {
         "@ava/typescript": "^4.1.0",
-        "@stellar/stellar-sdk": "12.3.0",
+        "@stellar/stellar-sdk": "13.0.0",
         "@types/node": "^20.4.9",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
@@ -206,9 +206,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+      "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -220,20 +220,21 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+        "sodium-native": "^4.3.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
+      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.1",
+        "@stellar/stellar-base": "^13.0.1",
         "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.20",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
@@ -1590,6 +1591,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
+      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/figures": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
@@ -2040,6 +2051,19 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -2316,9 +2340,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2983,11 +3007,10 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.2.0.tgz",
-      "integrity": "sha512-rdJRAf/RE/IRFUUoUsz10slNAQDTGz5ChpIeR1Ti0BtGYstl6Uok4hHALPBdnFcLml6qXJ2pDd0/De09mPa6mg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/cmd/crates/soroban-spec-typescript/ts-tests/package.json
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
-    "@stellar/stellar-sdk": "12.3.0",
+    "@stellar/stellar-sdk": "13.0.0",
     "@types/node": "^20.4.9",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",


### PR DESCRIPTION
### What

Update js-sdk to 13.0.0

### Why

Make sure everything works (tests pass) with the latest js-sdk

### Known limitations

- The js-sdk is not yet released, so we are using the release candidate. We can keep this PR around and update to the final release once it is available.