### PR TITLE
Change default network in typescript bindings to testnet

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -125,8 +125,8 @@ impl NetworkRunnable for Cmd {
             ..
         } = self.network.get(&self.locator).ok().unwrap_or_else(|| {
             network::DEFAULTS
-                .get("futurenet")
-                .expect("why did we remove the default futurenet network?")
+                .get("testnet")
+                .expect("why did we remove the default testnet network?")
                 .into()
         });
         let absolute_path = self.output_dir.canonicalize()?;


### PR DESCRIPTION
### What
Change default network in typescript bindings to testnet

### Why
Testnet is the most likely network to be using when developing and testing. Futurenet is unstable.

Futurenet was only used here because back when this functionality was first added Soroban was not yet on Testnet.