### PR TITLE
Rollback rust toolchain to 1.81.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
             openssl
             pkg-config
             jq
-            (rust-bin.stable.latest.default.override {
+            (rust-bin.stable."1.81.0".default.override {
               extensions = [ "rust-src" ];
               targets = [ "wasm32-unknown-unknown" ];
             })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.81.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What

Rolling back toolchain to 1.81.0

### Why

Clippy emits false positives on 1.82.0

### Known limitations

N/A