### PR TITLE
Typo Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ changes quickly.
 
 ## Setting up development environment
 
-There are 2 ways to being developing stellar-cli:
+There are 2 ways to begin developing stellar-cli:
 
 ### Installing all required dependencies 
 


### PR DESCRIPTION
**Description:**  
This pull request fixes a typo in the **"Setting up development environment"** section of the Stellar CLI documentation. The original text stated:  
> "There are 2 ways to **being** developing stellar-cli"  

The word **"being"** has been corrected to **"begin"**, so the revised text now reads:  
> "There are 2 ways to **begin** developing stellar-cli"  

---

**Why is this important?**  
Clear and accurate documentation is critical for fostering collaboration and ensuring new contributors can easily set up their development environment. Typos in setup instructions may lead to confusion and diminish the professional appearance of the project. Fixing this typo enhances the overall quality and accessibility of the documentation.

---

**Checklist:**  
- [x] The typo has been corrected.  
- [x] All other parts of the documentation remain intact and unaffected by this change.  

---

**Testing:**  
This is a documentation-only change and does not affect the codebase or functionality of the CLI.  

---

**Additional Notes:**  
If further improvements to the documentation are identified, I am happy to incorporate them into this or a future pull request.  
