### PR TITLE
Add bitflags to deny and mark deny ban and licenses as required

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         check: [advisories, bans, licenses, sources]
-    continue-on-error: ${{ matrix.check == 'advisories' || matrix.check == 'bans' || matrix.check == 'licenses' }}
+    continue-on-error: ${{ matrix.check == 'advisories' }}
     steps:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@b01e7a8cfb1f496c52d77361e84c1840d8246393

--- a/deny.toml
+++ b/deny.toml
@@ -308,9 +308,7 @@ skip = [
     # testcontainers
     { crate = "idna", reason = "temp", version = "0.5.0" },
 
-
-    # { name = "hashbrown", version = "=0.13.2" },
-    # { name = "syn", version = "=1.0.109" },
+    { crate = "bitflags", reason = "too many", version = "=1.3.2" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
### What

Add bitflags to deny and mark deny ban and licenses as required.

### Why

Looks like just after we fixed the deny bans we missed marking it as required and it broke again. Fixing it in this change, and marking it as required from now on. Also, the licenses check can be required too and isn't, so marking it as such as well.
