### PR TITLE
Add Python bindings generation command

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -258,6 +258,7 @@ Generate code client bindings for a contract
 * `json` — Generate Json Bindings
 * `rust` — Generate Rust bindings
 * `typescript` — Generate a TypeScript / JavaScript package
+* `python` — Generate Python bindings
 
 
 
@@ -303,6 +304,14 @@ Generate a TypeScript / JavaScript package
 * `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config
+
+
+
+## `stellar contract bindings python`
+
+Generate Python bindings
+
+**Usage:** `stellar contract bindings python`
 
 
 

--- a/cmd/soroban-cli/src/commands/contract/bindings.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings.rs
@@ -1,4 +1,5 @@
 pub mod json;
+pub mod python;
 pub mod rust;
 pub mod typescript;
 
@@ -12,6 +13,9 @@ pub enum Cmd {
 
     /// Generate a TypeScript / JavaScript package
     Typescript(typescript::Cmd),
+
+    /// Generate Python bindings
+    Python(python::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -24,6 +28,9 @@ pub enum Error {
 
     #[error(transparent)]
     Typescript(#[from] typescript::Error),
+
+    #[error(transparent)]
+    Python(#[from] python::Error),
 }
 
 impl Cmd {
@@ -32,6 +39,7 @@ impl Cmd {
             Cmd::Json(json) => json.run()?,
             Cmd::Rust(rust) => rust.run()?,
             Cmd::Typescript(ts) => ts.run().await?,
+            Cmd::Python(python) => python.run()?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/bindings/python.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/python.rs
@@ -1,0 +1,21 @@
+use std::fmt::Debug;
+
+use clap::Parser;
+use soroban_spec_json;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("generate json from file: {0}")]
+    GenerateJsonFromFile(soroban_spec_json::GenerateFromFileError),
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        println!("Python bindings are provided by external library: https://github.com/lightsail-network/stellar-contract-bindings");
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/bindings/python.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/python.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use clap::Parser;
-use soroban_spec_json;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -9,13 +8,12 @@ pub struct Cmd {}
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("generate json from file: {0}")]
-    GenerateJsonFromFile(soroban_spec_json::GenerateFromFileError),
+    #[error("python binding generation is not implemented in the stellar-cli, but is available via the tool located here: https://github.com/lightsail-network/stellar-contract-bindings")]
+    NotImplemented,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        println!("Python bindings are provided by external library: https://github.com/lightsail-network/stellar-contract-bindings");
-        Ok(())
+        Err(Error::NotImplemented)
     }
 }


### PR DESCRIPTION
### What

See https://github.com/stellar/stellar-cli/issues/1633#issuecomment-2500765235

### Why

If this link can be provided in the CLI, it may be easier for users to find it; otherwise, they might not know that Python bindings can be generated.

### Known limitations

N/A
