### PR TITLE
Add a stale CI workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Stale Issues / PRs'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * *' # approx 9:30am daily
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          debug-only: false
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
+          stale-issue-label: stale
+          stale-pr-label: stale
+          remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,8 +14,10 @@ jobs:
           debug-only: false
           days-before-stale: 30
           days-before-close: 30
-          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
+          stale-issue-message: 'This issue is stale because it has been assigned for 30 days with no activity. It will be closed in 30 days unless the stale label is removed, and the assignee is removed or updated.'
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
           stale-issue-label: stale
           stale-pr-label: stale
           remove-stale-when-updated: true
+          delete-branch: true
+          include-only-assigned: true


### PR DESCRIPTION
### What

Add a stale CI workflow that closes old pull requests and issues.

Pull requests are closed if they have been idle for more than 30 days. They can be preserved by pushing an update or removing the stale label.

Issues are closed if they've been assigned to someone for more than 30 days with no activity. They can be preserved by updating the assignee either to another person or to no one, or the stale label removed.

### Why

Keep the repo fresh.
