### PR TITLE
Add tx decode subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ path = "./cmd/crates/soroban-spec-tools"
 
 # Dependencies from the rs-stellar-xdr repo:
 [workspace.dependencies.stellar-xdr]
-version = "=22.0.0-rc.1.1"
+version = "22.0.0-rc.1.1"
 default-features = true
 
 # Dependencies from the rs-soroban-sdk repo:

--- a/cmd/soroban-cli/src/commands/tx/decode.rs
+++ b/cmd/soroban-cli/src/commands/tx/decode.rs
@@ -1,0 +1,30 @@
+use stellar_xdr::cli::{decode::OutputFormat, Channel};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Cli(#[from] stellar_xdr::cli::decode::Error),
+}
+
+/// Command to simulate a transaction envelope via rpc
+/// e.g. `cat file.txt | soroban tx simulate`
+#[derive(Debug, clap::Parser, Clone, Default)]
+#[group(skip)]
+pub struct Cmd {
+    // Output format
+    #[arg(long, value_enum, default_value_t)]
+    pub output: OutputFormat,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        let cmd = stellar_xdr::cli::decode::Cmd {
+            files: vec![],
+            r#type: "TransactionEnvelope".to_string(),
+            input: stellar_xdr::cli::decode::InputFormat::SingleBase64,
+            output: self.output,
+        };
+        cmd.run(&Channel::Curr)?;
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -1,6 +1,7 @@
 use super::global;
 
 pub mod args;
+pub mod decode;
 pub mod hash;
 pub mod help;
 pub mod new;
@@ -28,6 +29,8 @@ pub enum Cmd {
     Sign(sign::Cmd),
     /// Simulate a transaction envelope from stdin
     Simulate(simulate::Cmd),
+    /// Decode a transaction envelope to JSON
+    Decode(decode::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -44,6 +47,8 @@ pub enum Error {
     Sign(#[from] sign::Error),
     #[error(transparent)]
     Simulate(#[from] simulate::Error),
+    #[error(transparent)]
+    Decode(#[from] decode::Error),
 }
 
 impl Cmd {
@@ -55,6 +60,7 @@ impl Cmd {
             Cmd::Send(cmd) => cmd.run(global_args).await?,
             Cmd::Sign(cmd) => cmd.run(global_args).await?,
             Cmd::Simulate(cmd) => cmd.run(global_args).await?,
+            Cmd::Decode(cmd) => cmd.run()?,
         };
         Ok(())
     }


### PR DESCRIPTION
### What
Add tx decode subcommand

### Why
To make decoding tx's to JSON more discoverable and convenient. It's the most common XDR to want to decode.