### PR TITLE
fix setting of protocol version in created snapshots

### DIFF
--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -274,7 +274,13 @@ impl Cmd {
                         }
                         BucketEntry::Deadentry(k) => (k, None),
                         BucketEntry::Metaentry(m) => {
-                            snapshot.protocol_version = m.ledger_version;
+                            if m.ledger_version > snapshot.protocol_version {
+                                snapshot.protocol_version = m.ledger_version;
+                                print.infoln(format!(
+                                    "Protocol version: {}",
+                                    snapshot.protocol_version
+                                ));
+                            }
                             continue;
                         }
                     };


### PR DESCRIPTION
### What

Set the protocol version of the created snapshot to the latest protocol version of all the bucket lists.

### Why

The logic as is uses the protocol version of the last bucket, but the last bucket is the oldest and therefore the protocol version set in the snapshot file can be a previous protocol version after a network upgrade where newer buckets have new protocol versions and the oldest still has the previous.

cc @kalepail 