### PR TITLE
Shorten the long env help

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -45,7 +45,7 @@ Anything after the `--` double dash (the "slop") is parsed as arguments to the c
 
 * `contract` — Tools for smart contract developers
 * `events` — Watch the network for contract events
-* `env` — Prints the current environment variables or defaults to the stdout, in a format that can be used as .env file. Environment variables have precedency over defaults
+* `env` — Prints the current environment variables
 * `keys` — Create and manage identities including keys and addresses
 * `network` — Configure connection to networks
 * `container` — Start local networks in containers
@@ -915,7 +915,9 @@ Watch the network for contract events
 
 ## `stellar env`
 
-Prints the current environment variables or defaults to the stdout, in a format that can be used as .env file. Environment variables have precedency over defaults
+Prints the current environment variables.
+
+Prints the current environment variables or defaults to the stdout, in a format that can be used as .env file. Environment variables have precedency over defaults.
 
 **Usage:** `stellar env [OPTIONS]`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -45,7 +45,7 @@ Anything after the `--` double dash (the "slop") is parsed as arguments to the c
 
 * `contract` — Tools for smart contract developers
 * `events` — Watch the network for contract events
-* `env` — Prints the current environment variables
+* `env` — Prints the environment variables
 * `keys` — Create and manage identities including keys and addresses
 * `network` — Configure connection to networks
 * `container` — Start local networks in containers
@@ -915,9 +915,11 @@ Watch the network for contract events
 
 ## `stellar env`
 
-Prints the current environment variables.
+Prints the environment variables
 
-Prints the current environment variables or defaults to the stdout, in a format that can be used as .env file. Environment variables have precedency over defaults.
+Prints to stdout in a format that can be used as .env file. Environment variables have precedence over defaults.
+
+If there are no environment variables in use, prints the defaults.
 
 **Usage:** `stellar env [OPTIONS]`
 

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -143,11 +143,12 @@ pub enum Cmd {
     /// Watch the network for contract events
     Events(events::Cmd),
 
-    /// Prints the current environment variables.
+    /// Prints the environment variables
     ///
-    /// Prints the current environment variables or defaults to the stdout, in a
-    /// format that can be used as .env file. Environment variables have
-    /// precedency over defaults.
+    /// Prints to stdout in a format that can be used as .env file. Environment
+    /// variables have precedence over defaults.
+    ///
+    /// If there are no environment variables in use, prints the defaults.
     Env(env::Cmd),
 
     /// Create and manage identities including keys and addresses

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -143,8 +143,10 @@ pub enum Cmd {
     /// Watch the network for contract events
     Events(events::Cmd),
 
-    /// Prints the current environment variables or defaults to the stdout, in
-    /// a format that can be used as .env file. Environment variables have
+    /// Prints the current environment variables.
+    ///
+    /// Prints the current environment variables or defaults to the stdout, in a
+    /// format that can be used as .env file. Environment variables have
     /// precedency over defaults.
     Env(env::Cmd),
 


### PR DESCRIPTION
### What
Shorten the long env help.

#### Before
<img width="765" alt="Screenshot 2024-12-13 at 5 38 59 pm" src="https://github.com/user-attachments/assets/3c3a9777-2e42-4da2-97fe-66ee4a86cf93" />

#### After
<img width="765" alt="Screenshot 2024-12-13 at 5 35 53 pm" src="https://github.com/user-attachments/assets/80a481d5-cf7e-4cb0-b261-f16394d70516" />


### Why
It's sooo long it messes up the default help a bit. Moving the long version into the long description makes it available whne doing `stellar env --help` while the shorter version will be displayed in `stellar --help`.