### PR TITLE
Fix the version of SDK generated with contract init

### DIFF
--- a/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
+++ b/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = "22"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What
Update the version of SDK included in code generated by contract init to v22.

### Why
It's the latest version of the SDK that is released, and the soroban-examples and embedded hello-world example use SDK v22 now.

Close #1797