### PR TITLE
keys: add command warns on poor key practices

### DIFF
--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -106,3 +106,4 @@ create_print_functions!(save, saveln, "💾");
 create_print_functions!(search, searchln, "🔎");
 create_print_functions!(warn, warnln, "⚠️");
 create_print_functions!(exclaim, exclaimln, "❗️");
+create_print_functions!(kb, kbln, "⌨️");


### PR DESCRIPTION
### What

Output a warning if word count is less than 24 when accepting seed phrases as a new key.

Also changed how the output of the add command is displayed to use the Print functionality to normalize the output like other newer commands.

### Why

Close #1806

### Known limitations

[TODO or N/A]
