### PR TITLE
Install libdbus-1-dev for dry run for ubuntu

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,7 @@ jobs:
         - os: ubuntu-latest-16-cores
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: --feature-powerset
-          additional-deb-packages: libudev-dev
+          additional-deb-packages: libudev-dev libdbus-1-dev
         # TODO: add back ARM support
         #- os: ubuntu-latest-16-cores
         #  target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
### What

Also include libdbus-1-dev for ubuntu dry run

### Why

libdbus-1-dev is a dependency for the keychain create we're using, keyring

### Known limitations

[TODO or N/A]
