### PR TITLE
Add support exporting seed phrases

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -52,10 +52,23 @@ pub struct Cmd {
     /// Fund generated key pair
     #[arg(long, default_value = "false")]
     pub fund: bool,
+
+    /// Export seed phrase
+    #[arg(long)]
+    pub export_seed: bool,
 }
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        if self.export_seed {
+            // Handle export case
+            let secret = self.config_locator.read_identity(&self.name)?;
+            if let Ok(seed_phrase) = secret.export_seed_phrase() {
+                println!("{}", seed_phrase);
+                return Ok(());
+            }
+            return Err(Error::Secret(secret::Error::InvalidSecretOrSeedPhrase));
+        }
         if !self.fund {
             Print::new(global_args.quiet).warnln(
                 "Behavior of `generate` will change in the \

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -27,6 +27,8 @@ pub enum Error {
     InvalidAddress(String),
     #[error(transparent)]
     Signer(#[from] signer::Error),
+    #[error("Cannot export seed phrase from a secret key")]
+    InvalidSecretOrSeedPhrase,
 }
 
 #[derive(Debug, clap::Args, Clone)]
@@ -154,9 +156,20 @@ impl Secret {
     pub fn test_seed_phrase() -> Result<Self, Error> {
         Self::from_seed(Some("0000000000000000"))
     }
+
+    pub fn export_seed_phrase(&self) -> Result<String, Error> {
+        match self {
+            Secret::SeedPhrase { seed_phrase } => Ok(seed_phrase.clone()),
+            _ => Err(Error::InvalidSecretOrSeedPhrase),
+        }
+    }
 }
 
 fn read_password() -> Result<String, Error> {
     std::io::stdout().flush().map_err(|_| Error::PasswordRead)?;
     rpassword::read_password().map_err(|_| Error::PasswordRead)
+}
+
+pub fn export_seed_phrase(secret: &Secret) -> Result<String, Error> {
+    secret.export_seed_phrase()
 }


### PR DESCRIPTION
issue: #1824 
### What

Add functionality to export seed phrases in the CLI.

### Why

To allow users to securely export their seed phrases for backup and recovery purposes.

### Known limitations

[ N/A]
