### PR TITLE
docs: Fix typo and redundant word Update README.md

### DIFF
--- a/cmd/crates/soroban-test/README.md
+++ b/cmd/crates/soroban-test/README.md
@@ -53,7 +53,7 @@ fn invoke() {
 }
 ```
 
-Itegration tests in Crate
+Integration tests in Crate
 ==============
 
-Currently all tests that require an RPC server are hidden behind a `it` feature, [found here](./tests/it/integration). To allow Rust-Analyzer to see the tests in vscode, `.vscode/settings.json`. Without RA, you can't follow through definitions and more importantly see errors before running tests tests.
+Currently all tests that require an RPC server are hidden behind a `it` feature, [found here](./tests/it/integration). To allow Rust-Analyzer to see the tests in vscode, `.vscode/settings.json`. Without RA, you can't follow through definitions and more importantly see errors before running tests.


### PR DESCRIPTION
### What

I noticed a typo in the section title where "Itegration" was misspelled. I corrected it to "Integration."
Additionally, there was a redundant repetition of the word "tests" in the last sentence. I’ve fixed that as well.

### Why

Because I love this project and I’m here to save the day, one typo at a time!
