### PR TITLE
Add `stellar licenses` to display all dependencies' licenses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,7 +516,7 @@ checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -535,7 +541,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -594,6 +600,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -748,7 +773,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -869,7 +894,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1064,7 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1091,7 +1116,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1118,7 +1143,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1135,7 +1160,7 @@ checksum = "b45506e3c66512b0a65d291a6b452128b7b1dd9841e20d1e151addbd2c00ea50"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1159,7 +1184,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1170,7 +1195,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1242,7 +1267,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1337,7 +1362,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1464,7 +1489,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1600,7 +1625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
 ]
 
 [[package]]
@@ -1738,7 +1763,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2176,7 +2201,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2462,7 +2487,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2874,6 +2899,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "license-fetcher"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904bd80dd046aa1c625ddfd81c88a85a54ff3ca0ddcce0ca1ad9c8d7b6db185d"
+dependencies = [
+ "bincode",
+ "directories",
+ "log",
+ "miniz_oxide 0.8.3",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "simplelog",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,6 +3010,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -3099,7 +3150,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3142,6 +3193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3199,7 +3259,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3295,7 +3355,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.4",
  "structmeta",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3365,7 +3425,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3409,7 +3469,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3550,7 +3610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3857,7 +3917,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.77",
+ "syn 2.0.87",
  "walkdir",
 ]
 
@@ -4109,7 +4169,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4199,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -4219,13 +4279,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4236,16 +4296,17 @@ checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -4268,7 +4329,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4319,7 +4380,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4344,7 +4405,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4426,6 +4487,17 @@ name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -4510,7 +4582,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4548,6 +4620,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "keyring",
+ "license-fetcher",
  "mockito",
  "num-bigint",
  "open",
@@ -4679,7 +4752,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4739,7 +4812,7 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4780,7 +4853,7 @@ dependencies = [
  "sha2 0.10.8",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.77",
+ "syn 2.0.87",
  "thiserror",
 ]
 
@@ -5057,7 +5130,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5068,7 +5141,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5127,9 +5200,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5153,7 +5226,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5256,7 +5329,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5267,7 +5340,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "test-case-core",
 ]
 
@@ -5367,7 +5440,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5388,7 +5461,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5490,7 +5565,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5654,7 +5729,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5814,6 +5889,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,7 +5961,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -5914,7 +5995,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6359,7 +6440,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -6381,7 +6462,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6401,7 +6482,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -6422,7 +6503,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6444,5 +6525,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -2343,7 +2343,11 @@ Print version information
 
 Show dependency licenses
 
-**Usage:** `stellar licenses`
+**Usage:** `stellar licenses [OPTIONS]`
+
+###### **Options:**
+
+* `-v`, `--verbose` — Display the license text
 
 
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -55,6 +55,7 @@ Anything after the `--` double dash (the "slop") is parsed as arguments to the c
 * `completion` — Print shell completion code for the specified shell
 * `cache` — Cache for transactions and contract specs
 * `version` — Print version information
+* `licenses` — Show dependency licenses
 
 ###### **Options:**
 
@@ -2335,6 +2336,14 @@ Read cached action
 Print version information
 
 **Usage:** `stellar version`
+
+
+
+## `stellar licenses`
+
+Show dependency licenses
+
+**Usage:** `stellar licenses`
 
 
 

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -128,10 +128,12 @@ wasm-gen = "0.1.4"
 zeroize = "1.8.1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 whoami = "1.5.2"
+license-fetcher = "0.5.0"
 
 
 [build-dependencies]
 crate-git-revision = "0.0.6"
+license-fetcher = { version = "0.5.0", features = ["build"] }
 serde.workspace = true
 thiserror.workspace = true
 

--- a/cmd/soroban-cli/build.rs
+++ b/cmd/soroban-cli/build.rs
@@ -1,3 +1,10 @@
+use license_fetcher::build_script::generate_package_list_with_licenses;
+
 fn main() {
     crate_git_revision::init();
+
+    generate_package_list_with_licenses().write();
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=Cargo.lock");
+    println!("cargo::rerun-if-changed=Cargo.toml");
 }

--- a/cmd/soroban-cli/src/commands/licenses.rs
+++ b/cmd/soroban-cli/src/commands/licenses.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use std::fmt::Debug;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd;
+
+impl Cmd {
+    #[allow(clippy::unused_self)]
+    pub fn run(&self) {
+        println!("show licenses");
+    }
+}

--- a/cmd/soroban-cli/src/commands/licenses.rs
+++ b/cmd/soroban-cli/src/commands/licenses.rs
@@ -5,7 +5,11 @@ use license_fetcher::get_package_list_macro;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
-pub struct Cmd;
+pub struct Cmd {
+    /// Display the license text.
+    #[arg(long, short)]
+    pub verbose: bool,
+}
 
 impl Cmd {
     #[allow(clippy::unused_self)]
@@ -29,6 +33,13 @@ impl Cmd {
 
             if let Some(url) = pkg.homepage.clone() {
                 println!("URL: {url}");
+            }
+
+            if self.verbose {
+                if let Some(text) = pkg.license_text.clone() {
+                    println!("{text}");
+                    println!("———");
+                }
             }
 
             println!();

--- a/cmd/soroban-cli/src/commands/licenses.rs
+++ b/cmd/soroban-cli/src/commands/licenses.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use std::fmt::Debug;
 
+use license_fetcher::get_package_list_macro;
+
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd;
@@ -8,6 +10,28 @@ pub struct Cmd;
 impl Cmd {
     #[allow(clippy::unused_self)]
     pub fn run(&self) {
-        println!("show licenses");
+        let package_list = get_package_list_macro!();
+
+        package_list.iter().for_each(|pkg| {
+            println!(
+                "Name: {name}\nVersion: {version}\nLicense: {license}",
+                name = pkg.name,
+                version = pkg.version,
+                license = pkg
+                    .license_identifier
+                    .clone()
+                    .unwrap_or("Unknown".to_string()),
+            );
+
+            if let Some(repo) = pkg.repository.clone() {
+                println!("Repo: {repo}");
+            }
+
+            if let Some(url) = pkg.homepage.clone() {
+                println!("URL: {url}");
+            }
+
+            println!();
+        });
     }
 }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod env;
 pub mod events;
 pub mod global;
 pub mod keys;
+pub mod licenses;
 pub mod network;
 pub mod plugin;
 pub mod snapshot;
@@ -117,6 +118,7 @@ impl Root {
             Cmd::Container(container) => container.run(&self.global_args).await?,
             Cmd::Snapshot(snapshot) => snapshot.run(&self.global_args).await?,
             Cmd::Version(version) => version.run(),
+            Cmd::Licenses(licenses) => licenses.run(),
             Cmd::Keys(id) => id.run(&self.global_args).await?,
             Cmd::Tx(tx) => tx.run(&self.global_args).await?,
             Cmd::Cache(cache) => cache.run()?,
@@ -184,6 +186,9 @@ pub enum Cmd {
 
     /// Print version information
     Version(version::Cmd),
+
+    /// Show dependency licenses
+    Licenses(licenses::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/deny.toml
+++ b/deny.toml
@@ -112,6 +112,7 @@ allow = [
     "BSD-2-Clause",
     "CC0-1.0",
     "Unicode-3.0",
+    "BSL-1.0",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -313,6 +314,8 @@ skip = [
     { crate = "bitflags", reason = "too many", version = "=1.3.2" },
 
     { crate = "socket2", reason = "too many", version = "=0.4.10" },
+
+    { crate = "miniz_oxide", reason = "too many", version = "=0.7.4" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
### What

Add `stellar licenses` to display all dependencies' licenses.

```console
$ cargo run licenses
Name: soroban-cli
Version: 22.2.0
License: Apache-2.0
Repo: https://github.com/stellar/stellar-cli
URL: https://github.com/stellar/stellar-cli

Name: adler
Version: 1.0.2
License: 0BSD OR MIT OR Apache-2.0
Repo: https://github.com/jonas-schievink/adler.git

Name: adler2
Version: 2.0.0
License: 0BSD OR MIT OR Apache-2.0
Repo: https://github.com/oyvindln/adler2

Name: ahash
Version: 0.8.11
License: MIT OR Apache-2.0
Repo: https://github.com/tkaitchuck/ahash

Name: aho-corasick
Version: 1.1.3
License: Unlicense OR MIT
Repo: https://github.com/BurntSushi/aho-corasick
URL: https://github.com/BurntSushi/aho-corasick

Name: android-tzdata
Version: 0.1.1
License: MIT OR Apache-2.0
Repo: https://github.com/RumovZ/android-tzdata

Name: android_system_properties
Version: 0.1.5
License: MIT/Apache-2.0
Repo: https://github.com/nical/android_system_properties
URL: https://github.com/nical/android_system_properties

Name: anstream
Version: 0.6.15
License: MIT OR Apache-2.0
Repo: https://github.com/rust-cli/anstyle.git
URL: https://github.com/rust-cli/anstyle

Name: anstyle
Version: 1.0.8
License: MIT OR Apache-2.0
Repo: https://github.com/rust-cli/anstyle.git
URL: https://github.com/rust-cli/anstyle

Name: anstyle-parse
Version: 0.2.5
License: MIT OR Apache-2.0
Repo: https://github.com/rust-cli/anstyle.git
URL: https://github.com/rust-cli/anstyle

Name: anstyle-query
Version: 1.1.1
License: MIT OR Apache-2.0
Repo: https://github.com/rust-cli/anstyle

Name: anstyle-wincon
Version: 3.0.4
License: MIT OR Apache-2.0
Repo: https://github.com/rust-cli/anstyle.git
URL: https://github.com/rust-cli/anstyle

Name: anyhow
Version: 1.0.86
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/anyhow

Name: arbitrary
Version: 1.3.2
License: MIT OR Apache-2.0
Repo: https://github.com/rust-fuzz/arbitrary/

Name: ark-bls12-381
Version: 0.4.0
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/curves
URL: https://arkworks.rs

Name: ark-ec
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-ff
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-ff-asm
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-ff-macros
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-poly
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-serialize
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-serialize-derive
Version: 0.4.2
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/algebra
URL: https://arkworks.rs

Name: ark-std
Version: 0.4.0
License: MIT/Apache-2.0
Repo: https://github.com/arkworks-rs/std
URL: https://arkworks.rs

Name: async-compression
Version: 0.4.12
License: MIT OR Apache-2.0
Repo: https://github.com/Nullus157/async-compression

Name: async-trait
Version: 0.1.76
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/async-trait

Name: atomic-waker
Version: 1.1.2
License: Apache-2.0 OR MIT
Repo: https://github.com/smol-rs/atomic-waker

Name: backtrace
Version: 0.3.69
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/backtrace-rs
URL: https://github.com/rust-lang/backtrace-rs

Name: base16ct
Version: 0.2.0
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/base16ct

Name: base32
Version: 0.4.0
License: MIT OR Apache-2.0
Repo: https://github.com/andreasots/base32

Name: base64
Version: 0.13.1
License: MIT/Apache-2.0
Repo: https://github.com/marshallpierce/rust-base64

Name: base64
Version: 0.21.7
License: MIT OR Apache-2.0
Repo: https://github.com/marshallpierce/rust-base64

Name: base64
Version: 0.22.1
License: MIT OR Apache-2.0
Repo: https://github.com/marshallpierce/rust-base64

Name: base64ct
Version: 1.6.0
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/base64ct

Name: beef
Version: 0.5.2
License: MIT OR Apache-2.0
Repo: https://github.com/maciejhirsz/beef

Name: bincode
Version: 2.0.0-rc.3
License: MIT
Repo: https://github.com/bincode-org/bincode

Name: bincode_derive
Version: 2.0.0-rc.3
License: MIT
Repo: https://github.com/bincode-org/bincode

Name: bitflags
Version: 2.6.0
License: MIT OR Apache-2.0
Repo: https://github.com/bitflags/bitflags
URL: https://github.com/bitflags/bitflags

Name: block-buffer
Version: 0.9.0
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/utils

Name: block-buffer
Version: 0.10.4
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/utils

Name: bollard
Version: 0.16.1
License: Apache-2.0
Repo: https://github.com/fussybeaver/bollard
URL: https://github.com/fussybeaver/bollard

Name: bollard-stubs
Version: 1.44.0-rc.2
License: Apache-2.0

Name: bumpalo
Version: 3.16.0
License: MIT OR Apache-2.0
Repo: https://github.com/fitzgen/bumpalo

Name: byteorder
Version: 0.5.3
License: Unlicense/MIT
Repo: https://github.com/BurntSushi/byteorder
URL: https://github.com/BurntSushi/byteorder

Name: byteorder
Version: 1.5.0
License: Unlicense OR MIT
Repo: https://github.com/BurntSushi/byteorder
URL: https://github.com/BurntSushi/byteorder

Name: bytes
Version: 1.7.1
License: MIT
Repo: https://github.com/tokio-rs/bytes

Name: bytes-lit
Version: 0.0.5
License: Apache-2.0
Repo: https://github.com/stellar/bytes-lit
URL: https://github.com/stellar/bytes-lit

Name: bytesize
Version: 1.3.0
License: Apache-2.0
Repo: https://github.com/hyunsik/bytesize/
URL: https://github.com/hyunsik/bytesize/

Name: camino
Version: 1.1.7
License: MIT OR Apache-2.0
Repo: https://github.com/camino-rs/camino

Name: cargo-platform
Version: 0.1.6
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/cargo
URL: https://github.com/rust-lang/cargo

Name: cargo_metadata
Version: 0.18.1
License: MIT
Repo: https://github.com/oli-obk/cargo_metadata

Name: cfg-if
Version: 1.0.0
License: MIT/Apache-2.0
Repo: https://github.com/alexcrichton/cfg-if
URL: https://github.com/alexcrichton/cfg-if

Name: chrono
Version: 0.4.38
License: MIT OR Apache-2.0
Repo: https://github.com/chronotope/chrono
URL: https://github.com/chronotope/chrono

Name: clap
Version: 4.5.14
License: MIT OR Apache-2.0
Repo: https://github.com/clap-rs/clap

Name: clap_builder
Version: 4.5.14
License: MIT OR Apache-2.0
Repo: https://github.com/clap-rs/clap

Name: clap_complete
Version: 4.5.13
License: MIT OR Apache-2.0
Repo: https://github.com/clap-rs/clap

Name: clap_derive
Version: 4.5.13
License: MIT OR Apache-2.0
Repo: https://github.com/clap-rs/clap

Name: clap_lex
Version: 0.7.2
License: MIT OR Apache-2.0
Repo: https://github.com/clap-rs/clap

Name: colorchoice
Version: 1.0.2
License: MIT OR Apache-2.0
Repo: https://github.com/rust-cli/anstyle

Name: const-oid
Version: 0.9.6
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/const-oid

Name: core-foundation
Version: 0.9.4
License: MIT OR Apache-2.0
Repo: https://github.com/servo/core-foundation-rs
URL: https://github.com/servo/core-foundation-rs

Name: core-foundation-sys
Version: 0.8.6
License: MIT OR Apache-2.0
Repo: https://github.com/servo/core-foundation-rs
URL: https://github.com/servo/core-foundation-rs

Name: cpufeatures
Version: 0.2.12
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/utils

Name: crc32fast
Version: 1.4.2
License: MIT OR Apache-2.0
Repo: https://github.com/srijs/rust-crc32fast

Name: crossbeam-channel
Version: 0.5.13
License: MIT OR Apache-2.0
Repo: https://github.com/crossbeam-rs/crossbeam
URL: https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel

Name: crossbeam-utils
Version: 0.8.20
License: MIT OR Apache-2.0
Repo: https://github.com/crossbeam-rs/crossbeam
URL: https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils

Name: crypto-bigint
Version: 0.5.5
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/crypto-bigint

Name: crypto-common
Version: 0.1.6
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/traits

Name: crypto-mac
Version: 0.9.1
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/traits

Name: csv
Version: 1.3.0
License: Unlicense/MIT
Repo: https://github.com/BurntSushi/rust-csv
URL: https://github.com/BurntSushi/rust-csv

Name: csv-core
Version: 0.1.11
License: Unlicense/MIT
Repo: https://github.com/BurntSushi/rust-csv
URL: https://github.com/BurntSushi/rust-csv

Name: ctor
Version: 0.2.9
License: Apache-2.0 OR MIT
Repo: https://github.com/mmastrac/rust-ctor

Name: curve25519-dalek
Version: 4.1.3
License: BSD-3-Clause
Repo: https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek
URL: https://github.com/dalek-cryptography/curve25519-dalek

Name: curve25519-dalek-derive
Version: 0.1.1
License: MIT/Apache-2.0
Repo: https://github.com/dalek-cryptography/curve25519-dalek
URL: https://github.com/dalek-cryptography/curve25519-dalek

Name: darling
Version: 0.20.10
License: MIT
Repo: https://github.com/TedDriggs/darling

Name: darling_core
Version: 0.20.10
License: MIT
Repo: https://github.com/TedDriggs/darling

Name: darling_macro
Version: 0.20.10
License: MIT
Repo: https://github.com/TedDriggs/darling

Name: data-encoding
Version: 2.6.0
License: MIT
Repo: https://github.com/ia0/data-encoding

Name: dbus
Version: 0.9.7
License: Apache-2.0/MIT
Repo: https://github.com/diwic/dbus-rs

Name: dbus-secret-service
Version: 4.0.3
License: MIT OR Apache-2.0
Repo: https://github.com/brotskydotcom/dbus-secret-service.git
URL: https://github.com/brotskydotcom/dbus-secret-service

Name: der
Version: 0.7.9
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/der

Name: deranged
Version: 0.3.11
License: MIT OR Apache-2.0
Repo: https://github.com/jhpratt/deranged

Name: derivative
Version: 2.2.0
License: MIT/Apache-2.0
Repo: https://github.com/mcarton/rust-derivative

Name: derive_arbitrary
Version: 1.3.2
License: MIT/Apache-2.0
Repo: https://github.com/rust-fuzz/arbitrary

Name: digest
Version: 0.9.0
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/traits

Name: digest
Version: 0.10.7
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/traits

Name: directories
Version: 5.0.1
License: MIT OR Apache-2.0
Repo: https://github.com/soc/directories-rs

Name: dirs-sys
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/dirs-dev/dirs-sys-rs

Name: dotenvy
Version: 0.15.7
License: MIT
Repo: https://github.com/allan2/dotenvy
URL: https://github.com/allan2/dotenvy

Name: downcast-rs
Version: 1.2.1
License: MIT/Apache-2.0
Repo: https://github.com/marcianx/downcast-rs

Name: dyn-clone
Version: 1.0.17
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/dyn-clone

Name: ecdsa
Version: 0.16.9
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/signatures/tree/master/ecdsa

Name: ed25519
Version: 2.2.3
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/signatures/tree/master/ed25519

Name: ed25519-dalek
Version: 2.1.1
License: BSD-3-Clause
Repo: https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek
URL: https://github.com/dalek-cryptography/curve25519-dalek

Name: either
Version: 1.13.0
License: MIT OR Apache-2.0
Repo: https://github.com/rayon-rs/either

Name: elliptic-curve
Version: 0.13.8
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/traits/tree/master/elliptic-curve

Name: encoding_rs
Version: 0.8.34
License: (Apache-2.0 OR MIT) AND BSD-3-Clause
Repo: https://github.com/hsivonen/encoding_rs
URL: https://docs.rs/encoding_rs/

Name: enum-as-inner
Version: 0.6.1
License: MIT/Apache-2.0
Repo: https://github.com/bluejekyll/enum-as-inner

Name: equivalent
Version: 1.0.1
License: Apache-2.0 OR MIT
Repo: https://github.com/cuviper/equivalent

Name: errno
Version: 0.3.9
License: MIT OR Apache-2.0
Repo: https://github.com/lambda-fairy/rust-errno

Name: escape-bytes
Version: 0.1.1
License: Apache-2.0
Repo: https://github.com/stellar/escape-bytes
URL: https://github.com/stellar/escape-bytes

Name: ethnum
Version: 1.5.0
License: MIT OR Apache-2.0
Repo: https://github.com/nlordell/ethnum-rs
URL: https://github.com/nlordell/ethnum-rs

Name: fastrand
Version: 2.1.0
License: Apache-2.0 OR MIT
Repo: https://github.com/smol-rs/fastrand

Name: ff
Version: 0.13.0
License: MIT/Apache-2.0
Repo: https://github.com/zkcrypto/ff
URL: https://github.com/zkcrypto/ff

Name: fiat-crypto
Version: 0.2.9
License: MIT OR Apache-2.0 OR BSD-1-Clause
Repo: https://github.com/mit-plv/fiat-crypto
URL: https://github.com/mit-plv/fiat-crypto

Name: flate2
Version: 1.0.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/flate2-rs
URL: https://github.com/rust-lang/flate2-rs

Name: fnv
Version: 1.0.7
License: Apache-2.0 / MIT
Repo: https://github.com/servo/rust-fnv

Name: foreign-types
Version: 0.3.2
License: MIT/Apache-2.0
Repo: https://github.com/sfackler/foreign-types

Name: foreign-types-shared
Version: 0.1.1
License: MIT/Apache-2.0
Repo: https://github.com/sfackler/foreign-types

Name: form_urlencoded
Version: 1.2.1
License: MIT OR Apache-2.0
Repo: https://github.com/servo/rust-url

Name: fqdn
Version: 0.3.12
License: MIT
Repo: https://github.com/Orange-OpenSource/fqdn

Name: futures
Version: 0.3.30
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-channel
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-core
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-executor
Version: 0.3.30
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-io
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-macro
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-sink
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-task
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: futures-util
Version: 0.3.31
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/futures-rs
URL: https://rust-lang.github.io/futures-rs

Name: generic-array
Version: 0.14.7
License: MIT
Repo: https://github.com/fizyk20/generic-array.git

Name: getrandom
Version: 0.2.11
License: MIT OR Apache-2.0
Repo: https://github.com/rust-random/getrandom

Name: gimli
Version: 0.28.1
License: MIT OR Apache-2.0
Repo: https://github.com/gimli-rs/gimli

Name: glob
Version: 0.3.1
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/glob
URL: https://github.com/rust-lang/glob

Name: group
Version: 0.13.0
License: MIT/Apache-2.0
Repo: https://github.com/zkcrypto/group
URL: https://github.com/zkcrypto/group

Name: h2
Version: 0.3.26
License: MIT
Repo: https://github.com/hyperium/h2

Name: h2
Version: 0.4.6
License: MIT
Repo: https://github.com/hyperium/h2

Name: hashbrown
Version: 0.12.3
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/hashbrown

Name: hashbrown
Version: 0.13.2
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/hashbrown

Name: hashbrown
Version: 0.14.5
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/hashbrown

Name: heck
Version: 0.3.3
License: MIT OR Apache-2.0
Repo: https://github.com/withoutboats/heck
URL: https://github.com/withoutboats/heck

Name: heck
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/withoutboats/heck
URL: https://github.com/withoutboats/heck

Name: heck
Version: 0.5.0
License: MIT OR Apache-2.0
Repo: https://github.com/withoutboats/heck

Name: hermit-abi
Version: 0.3.9
License: MIT OR Apache-2.0
Repo: https://github.com/hermit-os/hermit-rs

Name: hex
Version: 0.4.3
License: MIT OR Apache-2.0
Repo: https://github.com/KokaKiwi/rust-hex

Name: hex-literal
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/utils

Name: hickory-proto
Version: 0.24.1
License: MIT OR Apache-2.0
Repo: https://github.com/hickory-dns/hickory-dns
URL: https://hickory-dns.org/

Name: hickory-resolver
Version: 0.24.1
License: MIT OR Apache-2.0
Repo: https://github.com/hickory-dns/hickory-dns
URL: https://hickory-dns.org/

Name: hmac
Version: 0.9.0
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/MACs

Name: hmac
Version: 0.12.1
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/MACs

Name: home
Version: 0.5.9
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/cargo

Name: hostname
Version: 0.3.1
License: MIT
Repo: https://github.com/svartalf/hostname

Name: http
Version: 0.2.12
License: MIT OR Apache-2.0
Repo: https://github.com/hyperium/http

Name: http
Version: 1.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/hyperium/http

Name: http-body
Version: 0.4.6
License: MIT
Repo: https://github.com/hyperium/http-body

Name: http-body
Version: 1.0.1
License: MIT
Repo: https://github.com/hyperium/http-body

Name: http-body-util
Version: 0.1.2
License: MIT
Repo: https://github.com/hyperium/http-body

Name: httparse
Version: 1.9.4
License: MIT OR Apache-2.0
Repo: https://github.com/seanmonstar/httparse

Name: httpdate
Version: 1.0.3
License: MIT OR Apache-2.0
Repo: https://github.com/pyfisch/httpdate

Name: humantime
Version: 2.1.0
License: MIT/Apache-2.0
Repo: https://github.com/tailhook/humantime
URL: https://github.com/tailhook/humantime

Name: hyper
Version: 0.14.30
License: MIT
Repo: https://github.com/hyperium/hyper
URL: https://hyper.rs

Name: hyper
Version: 1.4.1
License: MIT
Repo: https://github.com/hyperium/hyper
URL: https://hyper.rs

Name: hyper-named-pipe
Version: 0.1.0
License: Apache-2.0
Repo: https://github.com/fussybeaver/hyper-named-pipe
URL: https://github.com/fussybeaver/hyper-named-pipe

Name: hyper-rustls
Version: 0.24.2
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/hyper-rustls
URL: https://github.com/rustls/hyper-rustls

Name: hyper-rustls
Version: 0.26.0
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/hyper-rustls
URL: https://github.com/rustls/hyper-rustls

Name: hyper-rustls
Version: 0.27.3
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/hyper-rustls
URL: https://github.com/rustls/hyper-rustls

Name: hyper-tls
Version: 0.6.0
License: MIT/Apache-2.0
Repo: https://github.com/hyperium/hyper-tls
URL: https://hyper.rs

Name: hyper-util
Version: 0.1.7
License: MIT
Repo: https://github.com/hyperium/hyper-util
URL: https://hyper.rs

Name: hyperlocal-next
Version: 0.9.0
License: MIT
Repo: https://github.com/softprops/hyperlocal
URL: https://github.com/softprops/hyperlocal

Name: iana-time-zone
Version: 0.1.60
License: MIT OR Apache-2.0
Repo: https://github.com/strawlab/iana-time-zone

Name: iana-time-zone-haiku
Version: 0.1.2
License: MIT OR Apache-2.0
Repo: https://github.com/strawlab/iana-time-zone

Name: ident_case
Version: 1.0.1
License: MIT/Apache-2.0
Repo: https://github.com/TedDriggs/ident_case

Name: idna
Version: 0.4.0
License: MIT OR Apache-2.0
Repo: https://github.com/servo/rust-url/

Name: idna
Version: 0.5.0
License: MIT OR Apache-2.0
Repo: https://github.com/servo/rust-url/

Name: include_dir
Version: 0.7.4
License: MIT
Repo: https://github.com/Michael-F-Bryan/include_dir

Name: include_dir_macros
Version: 0.7.4
License: MIT
Repo: https://github.com/Michael-F-Bryan/include_dir

Name: indexmap
Version: 1.9.3
License: Apache-2.0 OR MIT
Repo: https://github.com/bluss/indexmap

Name: indexmap
Version: 2.3.0
License: Apache-2.0 OR MIT
Repo: https://github.com/indexmap-rs/indexmap

Name: indexmap-nostd
Version: 0.4.0
License: Apache-2.0
Repo: https://github.com/robbepop/indexmap-nostd

Name: ipconfig
Version: 0.3.2
License: MIT/Apache-2.0
Repo: https://github.com/liranringel/ipconfig
URL: https://github.com/liranringel/ipconfig

Name: ipnet
Version: 2.9.0
License: MIT OR Apache-2.0
Repo: https://github.com/krisprice/ipnet

Name: is-docker
Version: 0.2.0
License: MIT
Repo: https://github.com/TheLarkInn/is-docker

Name: is-wsl
Version: 0.4.0
License: MIT
Repo: https://github.com/TheLarkInn/is-wsl

Name: is_terminal_polyfill
Version: 1.70.1
License: MIT OR Apache-2.0
Repo: https://github.com/polyfill-rs/is_terminal_polyfill

Name: itertools
Version: 0.10.5
License: MIT/Apache-2.0
Repo: https://github.com/rust-itertools/itertools

Name: itoa
Version: 1.0.11
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/itoa

Name: js-sys
Version: 0.3.69
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys
URL: https://rustwasm.github.io/wasm-bindgen/

Name: jsonrpsee-core
Version: 0.20.3
License: MIT
Repo: https://github.com/paritytech/jsonrpsee
URL: https://www.parity.io/

Name: jsonrpsee-http-client
Version: 0.20.3
License: MIT
Repo: https://github.com/paritytech/jsonrpsee
URL: https://www.parity.io/

Name: jsonrpsee-types
Version: 0.20.3
License: MIT
Repo: https://github.com/paritytech/jsonrpsee
URL: https://www.parity.io/

Name: k256
Version: 0.13.4
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/elliptic-curves/tree/master/k256

Name: keccak
Version: 0.1.5
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/sponges/tree/master/keccak

Name: keyring
Version: 3.3.0
License: MIT OR Apache-2.0
Repo: https://github.com/hwchen/keyring-rs.git
URL: https://github.com/hwchen/keyring-rs

Name: lazy_static
Version: 1.5.0
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang-nursery/lazy-static.rs

Name: leb128
Version: 0.2.5
License: Apache-2.0/MIT
Repo: https://github.com/gimli-rs/leb128

Name: libc
Version: 0.2.155
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/libc
URL: https://github.com/rust-lang/libc

Name: libdbus-sys
Version: 0.2.5
License: Apache-2.0/MIT
Repo: https://github.com/diwic/dbus-rs

Name: libm
Version: 0.2.8
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/libm

Name: libredox
Version: 0.1.3
License: MIT
Repo: https://gitlab.redox-os.org/redox-os/libredox.git

Name: license-fetcher
Version: 0.5.0
License: BSL-1.0
Repo: https://github.com/WyvernIXTL/license-fetcher

Name: linked-hash-map
Version: 0.5.6
License: MIT/Apache-2.0
Repo: https://github.com/contain-rs/linked-hash-map
URL: https://github.com/contain-rs/linked-hash-map

Name: linux-raw-sys
Version: 0.4.14
License: Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
Repo: https://github.com/sunfishcode/linux-raw-sys

Name: lock_api
Version: 0.4.12
License: MIT OR Apache-2.0
Repo: https://github.com/Amanieu/parking_lot

Name: log
Version: 0.4.22
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/log

Name: lru-cache
Version: 0.1.2
License: MIT/Apache-2.0
Repo: https://github.com/contain-rs/lru-cache
URL: https://github.com/contain-rs/lru-cache

Name: match_cfg
Version: 0.1.0
License: MIT/Apache-2.0
Repo: https://github.com/gnzlbg/match_cfg
URL: https://github.com/gnzlbg/match_cfg

Name: matchers
Version: 0.1.0
License: MIT
Repo: https://github.com/hawkw/matchers
URL: https://github.com/hawkw/matchers

Name: memchr
Version: 2.7.4
License: Unlicense OR MIT
Repo: https://github.com/BurntSushi/memchr
URL: https://github.com/BurntSushi/memchr

Name: mime
Version: 0.3.17
License: MIT OR Apache-2.0
Repo: https://github.com/hyperium/mime

Name: miniz_oxide
Version: 0.7.4
License: MIT OR Zlib OR Apache-2.0
Repo: https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide
URL: https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide

Name: miniz_oxide
Version: 0.8.3
License: MIT OR Zlib OR Apache-2.0
Repo: https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide
URL: https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide

Name: mio
Version: 1.0.1
License: MIT
Repo: https://github.com/tokio-rs/mio
URL: https://github.com/tokio-rs/mio

Name: native-tls
Version: 0.2.12
License: MIT OR Apache-2.0
Repo: https://github.com/sfackler/rust-native-tls

Name: nu-ansi-term
Version: 0.46.0
License: MIT
Repo: https://github.com/nushell/nu-ansi-term

Name: num
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num
URL: https://github.com/rust-num/num

Name: num-bigint
Version: 0.4.4
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-bigint
URL: https://github.com/rust-num/num-bigint

Name: num-complex
Version: 0.4.5
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-complex
URL: https://github.com/rust-num/num-complex

Name: num-conv
Version: 0.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/jhpratt/num-conv

Name: num-derive
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-derive
URL: https://github.com/rust-num/num-derive

Name: num-integer
Version: 0.1.45
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-integer
URL: https://github.com/rust-num/num-integer

Name: num-iter
Version: 0.1.44
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-iter
URL: https://github.com/rust-num/num-iter

Name: num-rational
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-rational
URL: https://github.com/rust-num/num-rational

Name: num-traits
Version: 0.2.17
License: MIT OR Apache-2.0
Repo: https://github.com/rust-num/num-traits
URL: https://github.com/rust-num/num-traits

Name: num_threads
Version: 0.1.7
License: MIT OR Apache-2.0
Repo: https://github.com/jhpratt/num_threads

Name: object
Version: 0.32.2
License: Apache-2.0 OR MIT
Repo: https://github.com/gimli-rs/object

Name: once_cell
Version: 1.19.0
License: MIT OR Apache-2.0
Repo: https://github.com/matklad/once_cell

Name: opaque-debug
Version: 0.3.1
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/utils

Name: open
Version: 5.3.0
License: MIT
Repo: https://github.com/Byron/open-rs

Name: openssl
Version: 0.10.68
License: Apache-2.0
Repo: https://github.com/sfackler/rust-openssl

Name: openssl-macros
Version: 0.1.1
License: MIT/Apache-2.0

Name: openssl-probe
Version: 0.1.5
License: MIT/Apache-2.0
Repo: https://github.com/alexcrichton/openssl-probe
URL: https://github.com/alexcrichton/openssl-probe

Name: openssl-sys
Version: 0.9.104
License: MIT
Repo: https://github.com/sfackler/rust-openssl

Name: option-ext
Version: 0.2.0
License: MPL-2.0
Repo: https://github.com/soc/option-ext.git
URL: https://github.com/soc/option-ext

Name: overload
Version: 0.1.1
License: MIT
Repo: https://github.com/danaugrs/overload

Name: p256
Version: 0.13.2
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/elliptic-curves/tree/master/p256

Name: parking_lot
Version: 0.12.3
License: MIT OR Apache-2.0
Repo: https://github.com/Amanieu/parking_lot

Name: parking_lot_core
Version: 0.9.10
License: MIT OR Apache-2.0
Repo: https://github.com/Amanieu/parking_lot

Name: paste
Version: 1.0.15
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/paste

Name: pathdiff
Version: 0.2.1
License: MIT/Apache-2.0
Repo: https://github.com/Manishearth/pathdiff

Name: pbkdf2
Version: 0.11.0
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2

Name: percent-encoding
Version: 2.3.1
License: MIT OR Apache-2.0
Repo: https://github.com/servo/rust-url/

Name: phf
Version: 0.11.2
License: MIT
Repo: https://github.com/rust-phf/rust-phf

Name: phf_generator
Version: 0.11.2
License: MIT
Repo: https://github.com/rust-phf/rust-phf

Name: phf_macros
Version: 0.11.2
License: MIT
Repo: https://github.com/rust-phf/rust-phf

Name: phf_shared
Version: 0.11.2
License: MIT
Repo: https://github.com/rust-phf/rust-phf

Name: pin-project
Version: 1.1.5
License: Apache-2.0 OR MIT
Repo: https://github.com/taiki-e/pin-project

Name: pin-project-internal
Version: 1.1.5
License: Apache-2.0 OR MIT
Repo: https://github.com/taiki-e/pin-project

Name: pin-project-lite
Version: 0.2.14
License: Apache-2.0 OR MIT
Repo: https://github.com/taiki-e/pin-project-lite

Name: pin-utils
Version: 0.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang-nursery/pin-utils

Name: pkcs8
Version: 0.10.2
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/pkcs8

Name: powerfmt
Version: 0.2.0
License: MIT OR Apache-2.0
Repo: https://github.com/jhpratt/powerfmt

Name: ppv-lite86
Version: 0.2.20
License: MIT/Apache-2.0
Repo: https://github.com/cryptocorrosion/cryptocorrosion

Name: prettyplease
Version: 0.2.15
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/prettyplease

Name: primeorder
Version: 0.13.6
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/elliptic-curves/tree/master/primeorder

Name: proc-macro2
Version: 1.0.86
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/proc-macro2

Name: quick-error
Version: 1.2.3
License: MIT/Apache-2.0
Repo: http://github.com/tailhook/quick-error
URL: http://github.com/tailhook/quick-error

Name: quinn
Version: 0.11.5
License: MIT OR Apache-2.0
Repo: https://github.com/quinn-rs/quinn

Name: quinn-proto
Version: 0.11.8
License: MIT OR Apache-2.0
Repo: https://github.com/quinn-rs/quinn

Name: quinn-udp
Version: 0.5.4
License: MIT OR Apache-2.0
Repo: https://github.com/quinn-rs/quinn

Name: quote
Version: 1.0.37
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/quote

Name: rand
Version: 0.8.5
License: MIT OR Apache-2.0
Repo: https://github.com/rust-random/rand
URL: https://rust-random.github.io/book

Name: rand_chacha
Version: 0.3.1
License: MIT OR Apache-2.0
Repo: https://github.com/rust-random/rand
URL: https://rust-random.github.io/book

Name: rand_core
Version: 0.6.4
License: MIT OR Apache-2.0
Repo: https://github.com/rust-random/rand
URL: https://rust-random.github.io/book

Name: redox_syscall
Version: 0.5.3
License: MIT
Repo: https://gitlab.redox-os.org/redox-os/syscall

Name: redox_users
Version: 0.4.5
License: MIT
Repo: https://gitlab.redox-os.org/redox-os/users

Name: regex
Version: 1.10.6
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/regex
URL: https://github.com/rust-lang/regex

Name: regex-automata
Version: 0.1.10
License: Unlicense/MIT
Repo: https://github.com/BurntSushi/regex-automata
URL: https://github.com/BurntSushi/regex-automata

Name: regex-automata
Version: 0.4.7
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/regex/tree/master/regex-automata

Name: regex-syntax
Version: 0.6.29
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/regex
URL: https://github.com/rust-lang/regex

Name: regex-syntax
Version: 0.8.4
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/regex/tree/master/regex-syntax

Name: reqwest
Version: 0.12.7
License: MIT OR Apache-2.0
Repo: https://github.com/seanmonstar/reqwest

Name: resolv-conf
Version: 0.7.0
License: MIT/Apache-2.0
Repo: http://github.com/tailhook/resolv-conf
URL: http://github.com/tailhook/resolv-conf

Name: rfc6979
Version: 0.4.0
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/signatures/tree/master/rfc6979

Name: ring
Version: 0.17.8
License: Unknown
Repo: https://github.com/briansmith/ring

Name: rpassword
Version: 7.3.1
License: Apache-2.0
Repo: https://github.com/conradkleinespel/rpassword
URL: https://github.com/conradkleinespel/rpassword

Name: rtoolbox
Version: 0.0.2
License: Apache-2.0

Name: rust-embed
Version: 8.5.0
License: MIT
Repo: https://github.com/pyros2097/rust-embed

Name: rust-embed-impl
Version: 8.5.0
License: MIT
Repo: https://github.com/pyros2097/rust-embed

Name: rust-embed-utils
Version: 8.5.0
License: MIT
Repo: https://github.com/pyros2097/rust-embed

Name: rustc-demangle
Version: 0.1.24
License: MIT/Apache-2.0
Repo: https://github.com/rust-lang/rustc-demangle
URL: https://github.com/rust-lang/rustc-demangle

Name: rustc-hash
Version: 1.1.0
License: Apache-2.0/MIT
Repo: https://github.com/rust-lang-nursery/rustc-hash

Name: rustc-hash
Version: 2.0.0
License: Apache-2.0/MIT
Repo: https://github.com/rust-lang/rustc-hash

Name: rustix
Version: 0.38.34
License: Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
Repo: https://github.com/bytecodealliance/rustix

Name: rustls
Version: 0.21.12
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/rustls
URL: https://github.com/rustls/rustls

Name: rustls
Version: 0.22.4
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/rustls
URL: https://github.com/rustls/rustls

Name: rustls
Version: 0.23.12
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/rustls
URL: https://github.com/rustls/rustls

Name: rustls-native-certs
Version: 0.6.3
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/ctz/rustls-native-certs
URL: https://github.com/ctz/rustls-native-certs

Name: rustls-native-certs
Version: 0.7.3
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/rustls-native-certs
URL: https://github.com/rustls/rustls-native-certs

Name: rustls-native-certs
Version: 0.8.0
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/rustls-native-certs
URL: https://github.com/rustls/rustls-native-certs

Name: rustls-pemfile
Version: 1.0.4
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/pemfile
URL: https://github.com/rustls/pemfile

Name: rustls-pemfile
Version: 2.1.3
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/pemfile
URL: https://github.com/rustls/pemfile

Name: rustls-pki-types
Version: 1.8.0
License: MIT OR Apache-2.0
Repo: https://github.com/rustls/pki-types
URL: https://github.com/rustls/pki-types

Name: rustls-webpki
Version: 0.101.7
License: ISC
Repo: https://github.com/rustls/webpki

Name: rustls-webpki
Version: 0.102.6
License: ISC
Repo: https://github.com/rustls/webpki

Name: ryu
Version: 1.0.18
License: Apache-2.0 OR BSL-1.0
Repo: https://github.com/dtolnay/ryu

Name: same-file
Version: 1.0.6
License: Unlicense/MIT
Repo: https://github.com/BurntSushi/same-file
URL: https://github.com/BurntSushi/same-file

Name: schannel
Version: 0.1.23
License: MIT
Repo: https://github.com/steffengy/schannel-rs

Name: schemars
Version: 0.8.21
License: MIT
Repo: https://github.com/GREsau/schemars
URL: https://graham.cool/schemars/

Name: schemars_derive
Version: 0.8.21
License: MIT
Repo: https://github.com/GREsau/schemars
URL: https://graham.cool/schemars/

Name: scopeguard
Version: 1.2.0
License: MIT OR Apache-2.0
Repo: https://github.com/bluss/scopeguard

Name: sct
Version: 0.7.1
License: Apache-2.0 OR ISC OR MIT
Repo: https://github.com/rustls/sct.rs
URL: https://github.com/rustls/sct.rs

Name: sec1
Version: 0.7.2
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/sec1

Name: security-framework
Version: 2.11.1
License: MIT OR Apache-2.0
Repo: https://github.com/kornelski/rust-security-framework
URL: https://lib.rs/crates/security_framework

Name: security-framework-sys
Version: 2.11.1
License: MIT OR Apache-2.0
Repo: https://github.com/kornelski/rust-security-framework
URL: https://lib.rs/crates/security-framework-sys

Name: semver
Version: 1.0.20
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/semver

Name: sep5
Version: 0.0.4
License: Apache-2.0
Repo: https://github.com/ahalabs/rs-sep5
URL: https://github.com/ahalabs/rs-sep5

Name: serde
Version: 1.0.217
License: MIT OR Apache-2.0
Repo: https://github.com/serde-rs/serde
URL: https://serde.rs

Name: serde-aux
Version: 4.5.0
License: MIT
Repo: https://github.com/iddm/serde-aux

Name: serde_derive
Version: 1.0.217
License: MIT OR Apache-2.0
Repo: https://github.com/serde-rs/serde
URL: https://serde.rs

Name: serde_derive_internals
Version: 0.29.0
License: MIT OR Apache-2.0
Repo: https://github.com/serde-rs/serde
URL: https://serde.rs

Name: serde_json
Version: 1.0.135
License: MIT OR Apache-2.0
Repo: https://github.com/serde-rs/json

Name: serde_repr
Version: 0.1.17
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/serde-repr

Name: serde_spanned
Version: 0.6.7
License: MIT OR Apache-2.0
Repo: https://github.com/toml-rs/toml
URL: https://github.com/toml-rs/toml

Name: serde_urlencoded
Version: 0.7.1
License: MIT/Apache-2.0
Repo: https://github.com/nox/serde_urlencoded

Name: serde_with
Version: 3.9.0
License: MIT OR Apache-2.0
Repo: https://github.com/jonasbb/serde_with/

Name: serde_with_macros
Version: 3.9.0
License: MIT OR Apache-2.0
Repo: https://github.com/jonasbb/serde_with/

Name: sha2
Version: 0.9.9
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/hashes

Name: sha2
Version: 0.10.8
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/hashes

Name: sha3
Version: 0.10.8
License: MIT OR Apache-2.0
Repo: https://github.com/RustCrypto/hashes

Name: sharded-slab
Version: 0.1.7
License: MIT
Repo: https://github.com/hawkw/sharded-slab
URL: https://github.com/hawkw/sharded-slab

Name: shell-escape
Version: 0.1.5
License: MIT/Apache-2.0
Repo: https://github.com/sfackler/shell-escape

Name: shlex
Version: 1.3.0
License: MIT OR Apache-2.0
Repo: https://github.com/comex/rust-shlex

Name: signal-hook-registry
Version: 1.4.2
License: Apache-2.0/MIT
Repo: https://github.com/vorner/signal-hook

Name: signature
Version: 2.1.0
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/traits/tree/master/signature

Name: simplelog
Version: 0.12.2
License: MIT OR Apache-2.0
Repo: https://github.com/drakulix/simplelog.rs

Name: siphasher
Version: 0.3.11
License: MIT/Apache-2.0
Repo: https://github.com/jedisct1/rust-siphash
URL: https://docs.rs/siphasher

Name: slab
Version: 0.4.9
License: MIT
Repo: https://github.com/tokio-rs/slab

Name: slipped10
Version: 0.4.6
License: MIT
Repo: https://github.com/dj8yfo/slipped10
URL: https://github.com/dj8yfo/slipped10

Name: smallvec
Version: 1.13.2
License: MIT OR Apache-2.0
Repo: https://github.com/servo/rust-smallvec

Name: socket2
Version: 0.5.7
License: MIT OR Apache-2.0
Repo: https://github.com/rust-lang/socket2
URL: https://github.com/rust-lang/socket2

Name: soroban-builtin-sdk-macros
Version: 22.1.2
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-env
URL: https://github.com/stellar/rs-soroban-env

Name: addr2line
Version: 0.21.0
License: Apache-2.0 OR MIT
Repo: https://github.com/gimli-rs/addr2line

Name: soroban-env-common
Version: 22.1.2
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-env
URL: https://github.com/stellar/rs-soroban-env

Name: soroban-env-guest
Version: 22.1.2
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-env
URL: https://github.com/stellar/rs-soroban-env

Name: soroban-env-host
Version: 22.1.2
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-env
URL: https://github.com/stellar/rs-soroban-env

Name: soroban-env-macros
Version: 22.1.2
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-env
URL: https://github.com/stellar/rs-soroban-env

Name: soroban-ledger-snapshot
Version: 22.0.4
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-sdk
URL: https://github.com/stellar/rs-soroban-sdk

Name: soroban-sdk
Version: 22.0.4
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-sdk
URL: https://github.com/stellar/rs-soroban-sdk

Name: soroban-sdk-macros
Version: 22.0.4
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-sdk
URL: https://github.com/stellar/rs-soroban-sdk

Name: soroban-spec
Version: 22.0.4
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-sdk
URL: https://github.com/stellar/rs-soroban-sdk

Name: soroban-spec-json
Version: 22.2.0
License: Apache-2.0
Repo: https://github.com/stellar/soroban-tools
URL: https://github.com/stellar/soroban-tools

Name: soroban-spec-rust
Version: 22.0.4
License: Apache-2.0
Repo: https://github.com/stellar/rs-soroban-sdk
URL: https://github.com/stellar/rs-soroban-sdk

Name: soroban-spec-tools
Version: 22.2.0
License: Apache-2.0
Repo: https://github.com/stellar/soroban-tools
URL: https://github.com/stellar/soroban-tools

Name: soroban-spec-typescript
Version: 22.2.0
License: Apache-2.0
Repo: https://github.com/stellar/soroban-tools
URL: https://github.com/stellar/soroban-tools

Name: soroban-wasmi
Version: 0.31.1-soroban.20.0.1
License: MIT/Apache-2.0
Repo: https://github.com/stellar/wasmi

Name: spin
Version: 0.9.8
License: MIT
Repo: https://github.com/mvdnes/spin-rs.git

Name: spki
Version: 0.7.3
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/formats/tree/master/spki

Name: static_assertions
Version: 1.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/nvzqz/static-assertions-rs
URL: https://github.com/nvzqz/static-assertions-rs

Name: stellar-rpc-client
Version: 22.0.0
License: Apache-2.0
Repo: https://github.com/stellar/soroban-rpc
URL: https://github.com/stellar/soroban-rpc

Name: stellar-strkey
Version: 0.0.8
License: Apache-2.0
Repo: https://github.com/stellar/rs-stellar-strkey
URL: https://github.com/stellar/rs-stellar-strkey

Name: stellar-strkey
Version: 0.0.9
License: Apache-2.0
Repo: https://github.com/stellar/rs-stellar-strkey
URL: https://github.com/stellar/rs-stellar-strkey

Name: stellar-strkey
Version: 0.0.11
License: Apache-2.0
Repo: https://github.com/stellar/rs-stellar-strkey
URL: https://github.com/stellar/rs-stellar-strkey

Name: stellar-xdr
Version: 22.1.0
License: Apache-2.0
Repo: https://github.com/stellar/rs-stellar-xdr
URL: https://github.com/stellar/rs-stellar-xdr

Name: strsim
Version: 0.11.1
License: MIT
Repo: https://github.com/rapidfuzz/strsim-rs
URL: https://github.com/rapidfuzz/strsim-rs

Name: strum
Version: 0.17.1
License: MIT
URL: https://github.com/Peternator7/strum

Name: strum_macros
Version: 0.17.1
License: MIT
URL: https://github.com/Peternator7/strum

Name: subtle
Version: 2.6.1
License: BSD-3-Clause
Repo: https://github.com/dalek-cryptography/subtle
URL: https://dalek.rs/

Name: syn
Version: 1.0.109
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/syn

Name: syn
Version: 2.0.87
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/syn

Name: sync_wrapper
Version: 1.0.1
License: Apache-2.0
Repo: https://github.com/Actyx/sync_wrapper
URL: https://docs.rs/sync_wrapper

Name: system-configuration
Version: 0.6.1
License: MIT OR Apache-2.0
Repo: https://github.com/mullvad/system-configuration-rs

Name: system-configuration-sys
Version: 0.6.0
License: MIT OR Apache-2.0
Repo: https://github.com/mullvad/system-configuration-rs

Name: tempfile
Version: 3.12.0
License: MIT OR Apache-2.0
Repo: https://github.com/Stebalien/tempfile
URL: https://stebalien.com/projects/tempfile-rs/

Name: termcolor
Version: 1.4.1
License: Unlicense OR MIT
Repo: https://github.com/BurntSushi/termcolor
URL: https://github.com/BurntSushi/termcolor

Name: termcolor_output
Version: 1.0.1
License: MIT

Name: termcolor_output_impl
Version: 1.0.0
License: MIT

Name: thiserror
Version: 1.0.64
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/thiserror

Name: thiserror-impl
Version: 1.0.64
License: MIT OR Apache-2.0
Repo: https://github.com/dtolnay/thiserror

Name: thread_local
Version: 1.1.8
License: MIT OR Apache-2.0
Repo: https://github.com/Amanieu/thread_local-rs

Name: time
Version: 0.3.36
License: MIT OR Apache-2.0
Repo: https://github.com/time-rs/time
URL: https://time-rs.github.io

Name: time-core
Version: 0.1.2
License: MIT OR Apache-2.0
Repo: https://github.com/time-rs/time

Name: time-macros
Version: 0.2.18
License: MIT OR Apache-2.0
Repo: https://github.com/time-rs/time

Name: tiny-bip39
Version: 1.0.0
License: MIT OR Apache-2.0
Repo: https://github.com/maciejhirsz/tiny-bip39/
URL: https://github.com/maciejhirsz/tiny-bip39/

Name: tinyvec
Version: 1.8.0
License: Zlib OR Apache-2.0 OR MIT
Repo: https://github.com/Lokathor/tinyvec

Name: tinyvec_macros
Version: 0.1.1
License: MIT OR Apache-2.0 OR Zlib
Repo: https://github.com/Soveu/tinyvec_macros

Name: tokio
Version: 1.39.2
License: MIT
Repo: https://github.com/tokio-rs/tokio
URL: https://tokio.rs

Name: tokio-macros
Version: 2.4.0
License: MIT
Repo: https://github.com/tokio-rs/tokio
URL: https://tokio.rs

Name: tokio-native-tls
Version: 0.3.1
License: MIT
Repo: https://github.com/tokio-rs/tls
URL: https://tokio.rs

Name: tokio-rustls
Version: 0.24.1
License: MIT/Apache-2.0
Repo: https://github.com/rustls/tokio-rustls
URL: https://github.com/rustls/tokio-rustls

Name: tokio-rustls
Version: 0.25.0
License: MIT/Apache-2.0
Repo: https://github.com/rustls/tokio-rustls
URL: https://github.com/rustls/tokio-rustls

Name: tokio-rustls
Version: 0.26.0
License: MIT/Apache-2.0
Repo: https://github.com/rustls/tokio-rustls
URL: https://github.com/rustls/tokio-rustls

Name: tokio-util
Version: 0.7.11
License: MIT
Repo: https://github.com/tokio-rs/tokio
URL: https://tokio.rs

Name: toml
Version: 0.8.19
License: MIT OR Apache-2.0
Repo: https://github.com/toml-rs/toml
URL: https://github.com/toml-rs/toml

Name: toml_datetime
Version: 0.6.8
License: MIT OR Apache-2.0
Repo: https://github.com/toml-rs/toml
URL: https://github.com/toml-rs/toml

Name: toml_edit
Version: 0.22.20
License: MIT OR Apache-2.0
Repo: https://github.com/toml-rs/toml

Name: tower
Version: 0.4.13
License: MIT
Repo: https://github.com/tower-rs/tower
URL: https://github.com/tower-rs/tower

Name: tower-layer
Version: 0.3.2
License: MIT
Repo: https://github.com/tower-rs/tower
URL: https://github.com/tower-rs/tower

Name: tower-service
Version: 0.3.2
License: MIT
Repo: https://github.com/tower-rs/tower
URL: https://github.com/tower-rs/tower

Name: tracing
Version: 0.1.40
License: MIT
Repo: https://github.com/tokio-rs/tracing
URL: https://tokio.rs

Name: tracing-appender
Version: 0.2.3
License: MIT
Repo: https://github.com/tokio-rs/tracing
URL: https://tokio.rs

Name: tracing-attributes
Version: 0.1.27
License: MIT
Repo: https://github.com/tokio-rs/tracing
URL: https://tokio.rs

Name: tracing-core
Version: 0.1.32
License: MIT
Repo: https://github.com/tokio-rs/tracing
URL: https://tokio.rs

Name: tracing-log
Version: 0.2.0
License: MIT
Repo: https://github.com/tokio-rs/tracing
URL: https://tokio.rs

Name: tracing-subscriber
Version: 0.3.18
License: MIT
Repo: https://github.com/tokio-rs/tracing
URL: https://tokio.rs

Name: try-lock
Version: 0.2.5
License: MIT
Repo: https://github.com/seanmonstar/try-lock
URL: https://github.com/seanmonstar/try-lock

Name: typenum
Version: 1.17.0
License: MIT OR Apache-2.0
Repo: https://github.com/paholg/typenum

Name: ulid
Version: 1.1.3
License: MIT
Repo: https://github.com/dylanhart/ulid-rs

Name: unicode-bidi
Version: 0.3.15
License: MIT OR Apache-2.0
Repo: https://github.com/servo/unicode-bidi

Name: unicode-ident
Version: 1.0.12
License: (MIT OR Apache-2.0) AND Unicode-DFS-2016
Repo: https://github.com/dtolnay/unicode-ident

Name: unicode-normalization
Version: 0.1.23
License: MIT/Apache-2.0
Repo: https://github.com/unicode-rs/unicode-normalization
URL: https://github.com/unicode-rs/unicode-normalization

Name: unicode-segmentation
Version: 1.11.0
License: MIT/Apache-2.0
Repo: https://github.com/unicode-rs/unicode-segmentation
URL: https://github.com/unicode-rs/unicode-segmentation

Name: untrusted
Version: 0.9.0
License: ISC
Repo: https://github.com/briansmith/untrusted

Name: url
Version: 2.5.2
License: MIT OR Apache-2.0
Repo: https://github.com/servo/rust-url

Name: utf8parse
Version: 0.2.2
License: Apache-2.0 OR MIT
Repo: https://github.com/alacritty/vte

Name: valuable
Version: 0.1.0
License: MIT
Repo: https://github.com/tokio-rs/valuable

Name: value-bag
Version: 1.9.0
License: Apache-2.0 OR MIT
Repo: https://github.com/sval-rs/value-bag

Name: virtue
Version: 0.0.13
License: MIT
Repo: https://github.com/bincode-org/virtue

Name: walkdir
Version: 2.5.0
License: Unlicense/MIT
Repo: https://github.com/BurntSushi/walkdir
URL: https://github.com/BurntSushi/walkdir

Name: want
Version: 0.3.1
License: MIT
Repo: https://github.com/seanmonstar/want

Name: wasi
Version: 0.11.0+wasi-snapshot-preview1
License: Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
Repo: https://github.com/bytecodealliance/wasi

Name: wasite
Version: 0.1.0
License: Apache-2.0 OR BSL-1.0 OR MIT
Repo: https://github.com/ardaku/wasite
URL: https://github.com/ardaku/wasite/blob/stable/CHANGELOG.md

Name: wasm-bindgen
Version: 0.2.92
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen
URL: https://rustwasm.github.io/

Name: wasm-bindgen-backend
Version: 0.2.92
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend
URL: https://rustwasm.github.io/wasm-bindgen/

Name: wasm-bindgen-futures
Version: 0.4.42
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures
URL: https://rustwasm.github.io/wasm-bindgen/

Name: wasm-bindgen-macro
Version: 0.2.92
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro
URL: https://rustwasm.github.io/wasm-bindgen/

Name: wasm-bindgen-macro-support
Version: 0.2.92
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support
URL: https://rustwasm.github.io/wasm-bindgen/

Name: wasm-bindgen-shared
Version: 0.2.92
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared
URL: https://rustwasm.github.io/wasm-bindgen/

Name: wasm-gen
Version: 0.1.4
License: MIT
Repo: https://github.com/xtuc/wasm-gen

Name: wasm-streams
Version: 0.4.1
License: MIT OR Apache-2.0
Repo: https://github.com/MattiasBuelens/wasm-streams/

Name: wasmi_arena
Version: 0.4.1
License: MIT/Apache-2.0
Repo: https://github.com/paritytech/wasmi

Name: wasmi_core
Version: 0.13.0
License: MIT/Apache-2.0
Repo: https://github.com/paritytech/wasmi

Name: wasmparser
Version: 0.116.1
License: Apache-2.0 WITH LLVM-exception
Repo: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
URL: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser

Name: wasmparser-nostd
Version: 0.100.2
License: Apache-2.0 WITH LLVM-exception
Repo: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
URL: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser

Name: web-sys
Version: 0.3.69
License: MIT OR Apache-2.0
Repo: https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys
URL: https://rustwasm.github.io/wasm-bindgen/web-sys/index.html

Name: web-time
Version: 1.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/daxpedda/web-time

Name: webpki-roots
Version: 0.26.3
License: MPL-2.0
Repo: https://github.com/rustls/webpki-roots
URL: https://github.com/rustls/webpki-roots

Name: which
Version: 4.4.2
License: MIT
Repo: https://github.com/harryfei/which-rs.git

Name: whoami
Version: 1.5.2
License: Apache-2.0 OR BSL-1.0 OR MIT
Repo: https://github.com/ardaku/whoami
URL: https://github.com/ardaku/whoami/blob/v1/CHANGELOG.md

Name: widestring
Version: 1.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/starkat99/widestring-rs

Name: winapi
Version: 0.3.9
License: MIT/Apache-2.0
Repo: https://github.com/retep998/winapi-rs

Name: winapi-i686-pc-windows-gnu
Version: 0.4.0
License: MIT/Apache-2.0
Repo: https://github.com/retep998/winapi-rs

Name: winapi-util
Version: 0.1.9
License: Unlicense OR MIT
Repo: https://github.com/BurntSushi/winapi-util
URL: https://github.com/BurntSushi/winapi-util

Name: winapi-x86_64-pc-windows-gnu
Version: 0.4.0
License: MIT/Apache-2.0
Repo: https://github.com/retep998/winapi-rs

Name: windows-core
Version: 0.52.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-registry
Version: 0.2.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-result
Version: 0.2.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-strings
Version: 0.1.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-sys
Version: 0.48.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-sys
Version: 0.52.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-sys
Version: 0.59.0
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-targets
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows-targets
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_aarch64_gnullvm
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_aarch64_gnullvm
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_aarch64_msvc
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_aarch64_msvc
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_i686_gnu
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_i686_gnu
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_i686_gnullvm
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_i686_msvc
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_i686_msvc
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_x86_64_gnu
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_x86_64_gnu
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_x86_64_gnullvm
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_x86_64_gnullvm
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_x86_64_msvc
Version: 0.48.5
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: windows_x86_64_msvc
Version: 0.52.6
License: MIT OR Apache-2.0
Repo: https://github.com/microsoft/windows-rs

Name: winnow
Version: 0.6.18
License: MIT
Repo: https://github.com/winnow-rs/winnow

Name: winreg
Version: 0.50.0
License: MIT
Repo: https://github.com/gentoo90/winreg-rs

Name: zerocopy
Version: 0.7.35
License: BSD-2-Clause OR Apache-2.0 OR MIT
Repo: https://github.com/google/zerocopy

Name: zerocopy-derive
Version: 0.7.35
License: BSD-2-Clause OR Apache-2.0 OR MIT
Repo: https://github.com/google/zerocopy

Name: zeroize
Version: 1.8.1
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/utils/tree/master/zeroize

Name: zeroize_derive
Version: 1.4.2
License: Apache-2.0 OR MIT
Repo: https://github.com/RustCrypto/utils/tree/master/zeroize/derive
```

### Why

Some licenses requires you to carry it on with docs and/or final build.

### Known limitations

N/A
