### PR TITLE
Print old contract when overriding existing alias.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/asset.rs
@@ -1,3 +1,5 @@
+use crate::commands::global;
+
 use super::{deploy, id};
 
 #[derive(Debug, clap::Subcommand)]
@@ -17,10 +19,10 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match &self {
             Cmd::Id(id) => id.run()?,
-            Cmd::Deploy(asset) => asset.run().await?,
+            Cmd::Deploy(asset) => asset.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -23,7 +23,7 @@ pub enum Error {
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match &self {
-            Cmd::Asset(asset) => asset.run().await?,
+            Cmd::Asset(asset) => asset.run(global_args).await?,
             Cmd::Wasm(wasm) => wasm.run(global_args).await?,
         }
         Ok(())

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -1,4 +1,5 @@
 use crate::config::locator;
+use crate::print::Print;
 use crate::xdr::{
     Asset, ContractDataDurability, ContractExecutable, ContractIdPreimage, CreateContractArgs,
     Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, LedgerKey::ContractData,
@@ -81,6 +82,17 @@ impl Cmd {
                 let network = self.config.get_network()?;
 
                 if let Some(alias) = self.alias.clone() {
+                    if let Some(existing_contract) = self
+                        .config
+                        .locator
+                        .get_contract_id(&alias, &network.network_passphrase)?
+                    {
+                        let print = Print::new(false);
+                        print.warnln(format!(
+                            "Overwriting existing contract id: {existing_contract}"
+                        ));
+                    };
+
                     self.config.locator.save_contract_id(
                         &network.network_passphrase,
                         &contract,

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -74,7 +74,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let res = self.run_against_rpc_server(None, None).await?.to_envelope();
         match res {
             TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
@@ -87,7 +87,7 @@ impl Cmd {
                         .locator
                         .get_contract_id(&alias, &network.network_passphrase)?
                     {
-                        let print = Print::new(false);
+                        let print = Print::new(global_args.quiet);
                         print.warnln(format!(
                             "Overwriting existing contract id: {existing_contract}"
                         ));

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -143,7 +143,7 @@ impl Cmd {
                         .locator
                         .get_contract_id(&alias, &network.network_passphrase)?
                     {
-                        let print = Print::new(false);
+                        let print = Print::new(global_args.quiet);
                         print.warnln(format!(
                             "Overwriting existing contract id: {existing_contract}"
                         ));

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -138,6 +138,17 @@ impl Cmd {
                 let network = self.config.get_network()?;
 
                 if let Some(alias) = self.alias.clone() {
+                    if let Some(existing_contract) = self
+                        .config
+                        .locator
+                        .get_contract_id(&alias, &network.network_passphrase)?
+                    {
+                        let print = Print::new(false);
+                        print.warnln(format!(
+                            "Overwriting existing contract id: {existing_contract}"
+                        ));
+                    };
+
                     self.config.locator.save_contract_id(
                         &network.network_passphrase,
                         &contract,

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -144,7 +144,7 @@ pub enum Error {
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match &self {
-            Cmd::Asset(asset) => asset.run().await?,
+            Cmd::Asset(asset) => asset.run(global_args).await?,
             Cmd::Bindings(bindings) => bindings.run().await?,
             Cmd::Build(build) => build.run(global_args)?,
             Cmd::Extend(extend) => extend.run().await?,


### PR DESCRIPTION
### What

Print old contract when overriding existing alias. Notice that we're bypassing the rich printer, because it can be silenced. Instead, we print the contract straight to stderr unconditionally.

```console
$ stellar contract deploy --wasm target/wasm32-unknown-unknown/release/hello_world.wasm --alias=hello
ℹ️ Skipping install because wasm already installed
ℹ️ Using wasm hash 89123eaa2902ec32e26db0141e2d0247e5e00846489f4d8b17d597a85466e863
ℹ️ Simulating deploy transaction…
🌎 Submitting deploy transaction…
ℹ️ Transaction hash is ab3a11357ef533134efd4685985ac19f464e48be86d9732fbc81abcdab6e8c56
🔗 https://stellar.expert/explorer/testnet/tx/ab3a11357ef533134efd4685985ac19f464e48be86d9732fbc81abcdab6e8c56
ℹ️ Signing transaction: ab3a11357ef533134efd4685985ac19f464e48be86d9732fbc81abcdab6e8c56
🔗 https://stellar.expert/explorer/testnet/contract/CCR3PGO7L4RVITA5OR3ZVL5542L53M73PFMJLDY4KY7L6S3ODVXQW6SB
✅ Deployed!
⚠️ Overwriting existing contract id: CAFY4HM4RZSNPQKEV5GDIQRMWO6SJJNMIPSCP4Z4KEP5IZRYCJJFJNBC
CCR3PGO7L4RVITA5OR3ZVL5542L53M73PFMJLDY4KY7L6S3ODVXQW6SB
```

With `--quiet`:

```console
$ stellar contract deploy --wasm target/wasm32-unknown-unknown/release/hello_world.wasm --alias=hello --quiet   
ℹ️  Signing transaction: 7f7a7d89321bdd17753d5a00c833c4861f4ff4d6eed654099b05ebd5939ca342
⚠️  Overwriting existing contract id: CBU4J2PH6JUVAF7BFSTWGIBFJUZBZ4V3YHFEIK7AFB4FM53FEGAJD3PP
CBA5HVEZ5O3V6ILGWPKDS3TNTMX7VZ3F5EJVIN7TEEPA7O2RNKZLR5JH
```

PS: Notice that the signing transaction logging is a bug; we're tracking it at #1840.

### Why

Close #1417.

### Known limitations

N/A
