### PR TITLE
Check seed phrase entropy and warn user when using a 12-word seed.

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -2,7 +2,12 @@ use clap::command;
 
 use crate::{
     commands::global,
-    config::{address::KeyName, key, locator, secret},
+    config::{
+        address::KeyName,
+        key::{self, Key},
+        locator,
+        secret::{self, Secret},
+    },
     print::Print,
 };
 
@@ -40,9 +45,21 @@ impl Cmd {
         } else {
             self.secrets.read_secret()?.into()
         };
+
         let print = Print::new(global_args.quiet);
         let path = self.config_locator.write_key(&self.name, &key)?;
+
+        if let Key::Secret(Secret::SeedPhrase { seed_phrase }) = key {
+            if seed_phrase.split_whitespace().count() < 24 {
+                print.warnln(format!("The provided seed phrase lacks sufficient entropy and should be avoided. Using a 24-word seed phrase is a safer option."));
+                print.warnln(format!(
+                    "To generate a new key, use the `stellar keys generate` command."
+                ));
+            }
+        }
+
         print.checkln(format!("Key saved with alias {:?} in {path:?}", self.name));
+
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -51,10 +51,10 @@ impl Cmd {
 
         if let Key::Secret(Secret::SeedPhrase { seed_phrase }) = key {
             if seed_phrase.split_whitespace().count() < 24 {
-                print.warnln(format!("The provided seed phrase lacks sufficient entropy and should be avoided. Using a 24-word seed phrase is a safer option."));
-                print.warnln(format!(
-                    "To generate a new key, use the `stellar keys generate` command."
-                ));
+                print.warnln("The provided seed phrase lacks sufficient entropy and should be avoided. Using a 24-word seed phrase is a safer option.".to_string());
+                print.warnln(
+                    "To generate a new key, use the `stellar keys generate` command.".to_string(),
+                );
             }
         }
 


### PR DESCRIPTION
### What

```
$ stellar keys add test --seed-phrase

Type a secret key or 12/24 word seed phrase:

⚠️ The provided seed phrase lacks sufficient entropy and should be avoided. Using a 24-word seed phrase is a safer option.
⚠️ To generate a new key, use the `stellar keys generate` command.
✅ Key saved with alias KeyName("test") in "/Users/fnando/Projects/stellar/hello/.stellar/identity/test.toml"
```

### Why

Close #1806

### Known limitations

N/A
