### PR TITLE
Increase TS timeouts

### DIFF
--- a/cmd/crates/soroban-spec-typescript/ts-tests/package.json
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "lint": "eslint src/*",
     "postinstall": "./initialize.sh",
-    "test": "npm run lint && ava"
+    "test": "npm run lint && ava --timeout=30s"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",


### PR DESCRIPTION
### What

Increases timeout for TS tests to 30 seconds

### Why

The default timeout is not enough. Running tests in CI with default timeout fails 3 tests (locally 1), with 30 seconds all tests pass
 
### Known limitations
N/A