### PR TITLE
Make `stellar keys public-key` available.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -941,7 +941,7 @@ Create and manage identities including keys and addresses
 ###### **Subcommands:**
 
 * `add` — Add a new identity (keypair, ledger, OS specific secure store)
-* `public-key` — Given an identity return its address (public key)
+* `public-key` — Given an identity return its address (public key). Alias: `stellar key address`
 * `fund` — Fund an identity on a test network
 * `generate` — Generate a new identity using a 24-word seed phrase
 * `ls` — List identities
@@ -973,7 +973,7 @@ Add a new identity (keypair, ledger, OS specific secure store)
 
 ## `stellar keys public-key`
 
-Given an identity return its address (public key)
+Given an identity return its address (public key). Alias: `stellar key address`
 
 **Usage:** `stellar keys public-key [OPTIONS] <NAME>`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -941,7 +941,7 @@ Create and manage identities including keys and addresses
 ###### **Subcommands:**
 
 * `add` — Add a new identity (keypair, ledger, OS specific secure store)
-* `public-key` — Given an identity return its address (public key). Alias: `stellar key address`
+* `public-key` — Given an identity return its address (public key). Alias: `stellar keys address`
 * `fund` — Fund an identity on a test network
 * `generate` — Generate a new identity using a 24-word seed phrase
 * `ls` — List identities
@@ -973,7 +973,7 @@ Add a new identity (keypair, ledger, OS specific secure store)
 
 ## `stellar keys public-key`
 
-Given an identity return its address (public key). Alias: `stellar key address`
+Given an identity return its address (public key). Alias: `stellar keys address`
 
 **Usage:** `stellar keys public-key [OPTIONS] <NAME>`
 

--- a/cmd/soroban-cli/src/commands/keys/mod.rs
+++ b/cmd/soroban-cli/src/commands/keys/mod.rs
@@ -15,8 +15,8 @@ pub enum Cmd {
     /// Add a new identity (keypair, ledger, OS specific secure store)
     Add(add::Cmd),
 
-    /// Given an identity return its address (public key)
-    #[command(visible_alias = "address")]
+    /// Given an identity return its address (public key). Alias: `stellar key address`
+    #[command(alias = "address")]
     PublicKey(public_key::Cmd),
 
     /// Fund an identity on a test network

--- a/cmd/soroban-cli/src/commands/keys/mod.rs
+++ b/cmd/soroban-cli/src/commands/keys/mod.rs
@@ -15,7 +15,7 @@ pub enum Cmd {
     /// Add a new identity (keypair, ledger, OS specific secure store)
     Add(add::Cmd),
 
-    /// Given an identity return its address (public key). Alias: `stellar key address`
+    /// Given an identity return its address (public key). Alias: `stellar keys address`
     #[command(alias = "address")]
     PublicKey(public_key::Cmd),
 


### PR DESCRIPTION
### What

Make `stellar keys public-key` available. Also update doc to state that `address` is an alias.

```console
$ stellar keys -h
Create and manage identities including keys and addresses

Usage: stellar keys [OPTIONS] <COMMAND>

Commands:
  add         Add a new identity (keypair, ledger, OS specific secure store)
  public-key  Given an identity return its address (public key). Alias: `stellar keys address`
  fund        Fund an identity on a test network
  generate    Generate a new identity using a 24-word seed phrase
  ls          List identities
  rm          Remove an identity
  secret      Output an identity's secret key
  use         Set the default identity that will be used on all commands. This allows you to skip `--source-account` or setting a environment variable, while reusing this value in all commands that require it

Options:
  -h, --help  Print help

Options (Global):
      --global                     Use global config
      --config-dir <CONFIG_DIR>    Location of config directory, default is "."
  -f, --filter-logs <FILTER_LOGS>  Filter logs output. To turn on `stellar_cli::log::footprint=debug` or off `=off`. Can also use env var `RUST_LOG`
  -q, --quiet                      Do not write logs to stderr including `INFO`
  -v, --verbose                    Log DEBUG events
      --very-verbose               Log DEBUG and TRACE events [aliases: vv]
      --no-cache                   Do not cache your simulations and transactions [env: STELLAR_NO_CACHE=]

$ stellar keys address me
GBLIKM4JRVIENS3XVFXPO5AXQ6B76UUYKGFXHAXLNGRX4FS5U5HOC5MK

$ stellar keys public-key me
GBLIKM4JRVIENS3XVFXPO5AXQ6B76UUYKGFXHAXLNGRX4FS5U5HOC5MK

```

### Why

Close #1768

### Known limitations

N/A