### PR TITLE
Add support for returning seed phrases on `stellar keys secret`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1116,6 +1116,7 @@ Output an identity's secret key
 
 ###### **Options:**
 
+* `--phrase` — Output seed phrase instead of private key
 * `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."

--- a/cmd/soroban-cli/src/commands/keys/secret.rs
+++ b/cmd/soroban-cli/src/commands/keys/secret.rs
@@ -1,6 +1,10 @@
 use clap::arg;
 
-use crate::config::{key, locator};
+use crate::config::{
+    key::{self, Key},
+    locator,
+    secret::Secret,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -9,6 +13,9 @@ pub enum Error {
 
     #[error(transparent)]
     Key(#[from] key::Error),
+
+    #[error("identity is not tied to a seed phrase")]
+    UnknownSeedPhrase,
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -18,8 +25,12 @@ pub struct Cmd {
     /// Name of identity to lookup, default is test identity
     pub name: String,
 
+    /// Output seed phrase instead of private key
+    #[arg(long, conflicts_with = "hd_path")]
+    pub phrase: bool,
+
     /// If identity is a seed phrase use this hd path, default is 0
-    #[arg(long)]
+    #[arg(long, conflicts_with = "phrase")]
     pub hd_path: Option<usize>,
 
     #[command(flatten)]
@@ -28,8 +39,23 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        println!("{}", self.private_key()?.to_string());
+        if self.phrase {
+            println!("{}", self.seed_phrase()?);
+        } else {
+            println!("{}", self.private_key()?);
+        }
+
         Ok(())
+    }
+
+    pub fn seed_phrase(&self) -> Result<String, Error> {
+        let key = self.locator.read_identity(&self.name)?;
+
+        if let Key::Secret(Secret::SeedPhrase { seed_phrase }) = key {
+            Ok(seed_phrase)
+        } else {
+            Err(Error::UnknownSeedPhrase)
+        }
     }
 
     pub fn private_key(&self) -> Result<stellar_strkey::ed25519::PrivateKey, Error> {


### PR DESCRIPTION
### What

Add support for returning seed phrases on `stellar keys secret`.

```console
$ stellar keys secret dapp --phrase
egg judge require window warfare odor uniform where relief mouse battle cattle

$ stellar keys secret dapp
SCA5R6VLL6OE3TIFV6XPY6Q6JR6ITZSLYZFONB6D34TUBK5L3NEZWSCT

$ stellar keys secret dapp --phrase --hd-path 0
error: the argument '--phrase' cannot be used with '--hd-path <HD_PATH>'

Usage: stellar keys secret --phrase <NAME>

For more information, try '--help'.

$ stellar keys secret sekret --phrase
❌ error: identity is not tied to a seed phrase
```

### Why

- Close #1055
- Close #1824
- Close #1828

### Known limitations

N/A
