### PR TITLE
Fix/deploy events order

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -288,11 +288,12 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(txn));
         }
 
-        print.globeln("Submitting deploy transaction…");
         print.log_transaction(&txn, &network, true)?;
+        let signed_txn = &config.sign_with_local_key(*txn).await?;
+        print.globeln("Submitting deploy transaction…");
 
         let get_txn_resp = client
-            .send_transaction_polling(&config.sign_with_local_key(*txn).await?)
+            .send_transaction_polling(signed_txn)
             .await?
             .try_into()?;
 

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -192,11 +192,10 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(txn));
         }
 
-        print.globeln("Submitting install transaction…");
+        let signed_txn = &self.config.sign_with_local_key(*txn).await?;
 
-        let txn_resp = client
-            .send_transaction_polling(&self.config.sign_with_local_key(*txn).await?)
-            .await?;
+        print.globeln("Submitting install transaction…");
+        let txn_resp = client.send_transaction_polling(signed_txn).await?;
 
         if args.map_or(true, |a| !a.no_cache) {
             data::write(txn_resp.clone().try_into().unwrap(), &network.rpc_uri()?)?;


### PR DESCRIPTION
### What

Closes https://github.com/stellar/stellar-cli/issues/1777

### Why

Deploy logs were out of order, printing `simulate, submit, sign` instead of `simulate, sign, submit`. 

before:
```
ℹ️ Simulating install transaction…
🌎 Submitting install transaction…
ℹ️ Signing transaction: 95cf4cc442c3120164b9fc9d4cdc8ce338edb0f56ecac7da769f89e645bcaa9a
ℹ️ Using wasm hash 13ec865cd0787ae6c94e44d3cbad2c9a7ae2c546bca4de26d43d923dde2e12fd
ℹ️ Simulating deploy transaction…
🌎 Submitting deploy transaction…
ℹ️ Transaction hash is 4ac86408a0303326efaaaa0087de6738018e39952709ebb9d264a0e9759b054c
🔗 https://stellar.expert/explorer/testnet/tx/4ac86408a0303326efaaaa0087de6738018e39952709ebb9d264a0e9759b054c
ℹ️ Signing transaction: 4ac86408a0303326efaaaa0087de6738018e39952709ebb9d264a0e9759b054c
🔗 https://stellar.expert/explorer/testnet/contract/CDUWDZHBWZX3JKLZ2ZKDIRZWXBEOKG2UOG4HP3IQN4CZ2FBQOVBJAO2C
✅ Deployed!
CDUWDZHBWZX3JKLZ2ZKDIRZWXBEOKG2UOG4HP3IQN4CZ2FBQOVBJAO2C
```

after:
```
ℹ️ Simulating install transaction…
ℹ️ Signing transaction: 333c86094ba60d45a90da2c713fab4aa3c25383c19007ec16f373f813cf9c916
🌎 Submitting install transaction…
ℹ️ Using wasm hash 0cc7651ec2be3ec2ab45b5f42aa52478e28ea6ae04e63af4684e2ad88bf56032
ℹ️ Simulating deploy transaction…
ℹ️ Transaction hash is 4ebba74956ae1b9f58c6d038209c6e1977e36d3e2f6a2cc7bba58e63e608e0c5
🔗 https://stellar.expert/explorer/testnet/tx/4ebba74956ae1b9f58c6d038209c6e1977e36d3e2f6a2cc7bba58e63e608e0c5
ℹ️ Signing transaction: 4ebba74956ae1b9f58c6d038209c6e1977e36d3e2f6a2cc7bba58e63e608e0c5
🌎 Submitting deploy transaction…
🔗 https://stellar.expert/explorer/testnet/contract/CBDBUXT3GOFMKLM5KIEETRU32CJNGV5YBALIDYIZ2XX4VYEKLBLGS37Z
✅ Deployed!
**CBDBUXT3GOFMKLM5KIEETRU32CJNGV5YBALIDYIZ2XX4VYEKLBLGS37Z**
```

### Known limitations

N/A
