### PR TITLE
Update template contract to be the same as soroban-examples

### DIFF
--- a/cmd/soroban-cli/src/utils/contract-template/src/lib.rs
+++ b/cmd/soroban-cli/src/utils/contract-template/src/lib.rs
@@ -2,7 +2,7 @@
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
-pub struct Contract;
+pub struct HelloContract;
 
 // This is a sample contract. Replace this placeholder with your own contract logic.
 // A corresponding test example is available in `test.rs`.
@@ -14,7 +14,7 @@ pub struct Contract;
 // Refer to the official documentation:
 // <https://developers.stellar.org/docs/build/smart-contracts/overview>.
 #[contractimpl]
-impl Contract {
+impl HelloContract {
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
     }

--- a/cmd/soroban-cli/src/utils/contract-template/src/test.rs
+++ b/cmd/soroban-cli/src/utils/contract-template/src/test.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{vec, Env, String};
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
+    let contract_id = env.register(HelloContract, ());
+    let client = HelloContractClient::new(&env, &contract_id);
 
     let words = client.hello(&String::from_str(&env, "Dev"));
     assert_eq!(


### PR DESCRIPTION
### What

This is an update to the Hello World contract that is created on `stellar contract init` to be more simliar to what is in [soroban-examples](https://github.com/stellar/soroban-examples/tree/main/hello_world).

### Why

After reviewing the Getting Started guide in the docs, I noticed that the contract that we're creating when running `stellar contract init` is different than what is in soroban-examples and perhaps it would be less confusing for users if these were the same.

### Known limitations

Related PR: https://github.com/stellar/stellar-docs/pull/1239
