### PR TITLE
Remove `network container` commands

### DIFF
--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -37,6 +37,7 @@ pub enum Cmd {
     /// ⚠️ Deprecated: use `stellar container stop` instead
     ///
     /// Stop a network started with `network start`. For example, if you ran `stellar network start local`, you can use `stellar network stop local` to stop it.
+    #[cfg(feature = "version_lt_23")]
     Stop(crate::commands::container::StopCmd),
 
     /// Set the default network that will be used on all commands.
@@ -70,7 +71,7 @@ pub enum Error {
     #[error(transparent)]
     Start(#[from] crate::commands::container::start::Error),
 
-    // TODO: remove once `network stop` is removed
+    #[cfg(feature = "version_lt_23")]
     #[error(transparent)]
     Stop(#[from] crate::commands::container::stop::Error),
 
@@ -108,7 +109,7 @@ impl Cmd {
                 eprintln!("⚠️ Warning: `network start` has been deprecated. Use `container start` instead");
                 cmd.run(global_args).await?;
             }
-            // TODO Remove this once `network stop` is removed
+            #[cfg(feature = "version_lt_23")]
             Cmd::Stop(cmd) => {
                 println!(
                     "⚠️ Warning: `network stop` has been deprecated. Use `container stop` instead"

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -31,6 +31,7 @@ pub enum Cmd {
     /// By default, when starting a testnet container, without any optional arguments, it will run the equivalent of the following docker command:
     ///
     /// `docker run --rm -p 8000:8000 --name stellar stellar/quickstart:testing --testnet --enable rpc,horizon`
+    #[cfg(feature = "version_lt_23")]
     Start(crate::commands::container::StartCmd),
 
     /// ⚠️ Deprecated: use `stellar container stop` instead
@@ -65,7 +66,7 @@ pub enum Error {
     #[error(transparent)]
     Ls(#[from] ls::Error),
 
-    // TODO: remove once `network start` is removed
+    #[cfg(feature = "version_lt_23")]
     #[error(transparent)]
     Start(#[from] crate::commands::container::start::Error),
 
@@ -102,7 +103,7 @@ impl Cmd {
             Cmd::Ls(cmd) => cmd.run()?,
             Cmd::Container(cmd) => cmd.run(global_args).await?,
 
-            // TODO Remove this once `network start` is removed
+            #[cfg(feature = "version_lt_23")]
             Cmd::Start(cmd) => {
                 eprintln!("⚠️ Warning: `network start` has been deprecated. Use `container start` instead");
                 cmd.run(global_args).await?;

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -49,6 +49,7 @@ pub enum Cmd {
     /// ⚠️ Deprecated: use `stellar container` instead
     ///
     /// Commands to start, stop and get logs for a quickstart container
+    #[cfg(feature = "version_lt_23")]
     #[command(subcommand)]
     Container(crate::commands::container::Cmd),
 }
@@ -75,6 +76,7 @@ pub enum Error {
     #[error(transparent)]
     Stop(#[from] crate::commands::container::stop::Error),
 
+    #[cfg(feature = "version_lt_23")]
     #[error(transparent)]
     Container(#[from] crate::commands::container::Error),
 
@@ -102,6 +104,7 @@ impl Cmd {
             Cmd::Add(cmd) => cmd.run()?,
             Cmd::Rm(new) => new.run()?,
             Cmd::Ls(cmd) => cmd.run()?,
+            #[cfg(feature = "version_lt_23")]
             Cmd::Container(cmd) => cmd.run(global_args).await?,
 
             #[cfg(feature = "version_lt_23")]


### PR DESCRIPTION
### What

Based on https://github.com/stellar/stellar-cli/pull/1863

Closes https://github.com/stellar/stellar-cli/issues/1363

Remove deprecated `network container` commands.

### Why

We moved container commands to the root, and have marked these as deprecated for a couple of major releases now, so it should be safe to remove them. 

### Known limitations

n/a