### PR TITLE
Add features for guarding code based on the P23.

### DIFF
--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -36,6 +36,8 @@ doctest = false
 
 [features]
 default = []
+version_lt_23 = []
+version_gte_23 = []
 opt = ["dep:wasm-opt"]
 
 [dependencies]

--- a/cmd/soroban-cli/build.rs
+++ b/cmd/soroban-cli/build.rs
@@ -1,3 +1,22 @@
 fn main() {
     crate_git_revision::init();
+    set_protocol_features();
+}
+
+fn set_protocol_features() {
+    let version = env!("CARGO_PKG_VERSION");
+    let major_version: u32 = version
+        .split('.')
+        .next()
+        .unwrap_or("0")
+        .parse()
+        .unwrap_or(0);
+
+    if major_version < 23 {
+        println!("cargo:rustc-cfg=feature=\"version_lt_23\"");
+    }
+
+    if major_version >= 23 {
+        println!("cargo:rustc-cfg=feature=\"version_gte_23\"");
+    }
 }


### PR DESCRIPTION
### What

Add features for guarding code based on the P23.

### Why

The idea is to allow adding/removing code without having to keep a long running branch for either the current or next version.

This approach also allow us to easily enable features from the next protocol version when running tests, but using cargo hack.

### Known limitations

N/A
