### PR TITLE
Update openssl to 0.10.70 per cargo deny advisories suggestion

### DIFF
--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -23,6 +23,6 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - name: install libudev-dev
       run: |
-        sudo apt install -y libudev-dev
+        sudo apt update && sudo apt install -y libudev-dev
     - run: |
         cargo test --manifest-path cmd/crates/stellar-ledger/Cargo.toml --features "emulator-tests" -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -3210,9 +3210,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
### What

Update openssl to 0.10.70

### Why

`cargo deny check advisories` is currently failing with the following vulnerability error:
```
error[vulnerability]: ssl::select_next_proto use after free
    ┌─ /stellar/stellar-cli/Cargo.lock:289:1
    │
289 │ openssl 0.10.68 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2025-0004
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0004
    = In `openssl` versions before `0.10.70`, `ssl::select_next_proto` can return a slice pointing into the `server` argument's buffer but with a lifetime bound to the `client` argument. In situations where the `server` buffer's lifetime is shorter than the `client` buffer's, this can cause a use after free. This could cause the server to crash or to return arbitrary memory contents to the client.
...
    = Announcement: https://github.com/sfackler/rust-openssl/security/advisories/GHSA-rpmj-rpgj-qmpm
    = Solution: Upgrade to >=0.10.70 (try `cargo update -p openssl`)
    = openssl v0.10.68
      └── native-tls v0.2.12
          ├── hyper-tls v0.6.0
          │   └── reqwest v0.12.7
          │       ├── soroban-cli v22.2.0
          │       │   ├── soroban-test v22.2.0
          │       │   └── stellar-cli v22.2.0
          │       ├── stellar-ledger v22.2.0
          │       └── testcontainers v0.20.1
          │           └── (dev) stellar-ledger v22.2.0 (*)
          ├── reqwest v0.12.7 (*)
          └── tokio-native-tls v0.3.1
              ├── hyper-tls v0.6.0 (*)
              └── reqwest v0.12.7 (*)
```

### Known limitations

[TODO or N/A]
