### PR TITLE
Print KeyName string instead of struct

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -61,7 +61,7 @@ impl Cmd {
 
         let path = self.config_locator.write_key(&self.name, &key)?;
 
-        print.checkln(format!("Key saved with alias {:?} in {path:?}", self.name));
+        print.checkln(format!("Key saved with alias {} in {path:?}", self.name));
 
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -96,7 +96,7 @@ impl Cmd {
         }
         let secret = self.secret(&print)?;
         let path = self.config_locator.write_identity(&self.name, &secret)?;
-        print.checkln(format!("Key saved with alias {:?} in {path:?}", self.name));
+        print.checkln(format!("Key saved with alias {} in {path:?}", self.name));
 
         if !self.no_fund {
             let addr = secret.public_key(self.hd_path)?;


### PR DESCRIPTION
### What
Closes https://github.com/stellar/stellar-cli/issues/1844

### Why

We should print out the key name (or alias) instead of the full struct for `stellar keys add` and `stellar keys generate`.
### Known limitations

[TODO or N/A]
