### PR TITLE
Fix pre push hook

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ex
 
-echo '+cargo fmt --check'
 cargo fmt --check || (cargo fmt && exit 1)
-
-echo '+cargo run --bin doc-gen --features clap-markdown'
 cargo run --bin doc-gen --features clap-markdown

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,20 +1,14 @@
 #!/bin/sh
 
-set -e
+set -ex
 
-echo '+cargo fmt --check'
 cargo fmt --check || (cargo fmt && exit 1)
 
-echo "unstaged changes"
-echo 'git diff-index --quiet HEAD --'
 git diff-index --quiet HEAD --
 
-echo '+cargo clippy -- -Dwarnings -Dclippy::all -Dclippy::pedantic'
 cargo clippy --all -- -Dwarnings
 
-echo '+cargo test --all'
 cargo build
 cargo test --all || (echo "might need to rebuild make build-snapshot" && exit 1)
 
-echo '+cargo run --bin doc-gen --features clap-markdown'
 cargo run --bin doc-gen --features clap-markdown

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -69,8 +69,9 @@ jobs:
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       working-directory: ${{ env.BUILD_WORKING_DIR }}
-      run: sudo apt-get update && sudo apt-get -y install libdbus-1-dev
-      run: cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
+      run: |
+        sudo apt-get update && sudo apt-get -y install libdbus-1-dev
+        cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
 
     - name: Build provenance for attestation (release only)
       if: github.event_name == 'release'

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/swap/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/swap/src/lib.rs
@@ -3,6 +3,7 @@
 //! off-chain.
 //! This example demonstrates how multi-party authorization can be implemented.
 #![no_std]
+#![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, IntoVal};
 
@@ -14,7 +15,6 @@ impl AtomicSwapContract {
     // Swap token A for token B atomically. Settle for the minimum requested price
     // for each party (this is an arbitrary choice; both parties could have
     // received the full amount as well).
-    #[allow(clippy::too_many_arguments)]
     pub fn swap(
         env: Env,
         a: Address,


### PR DESCRIPTION
### What

`#[allow(clippy::too_many_arguments)]` was being ignored, so let's use a module rule instead.

### Why

So pre-commit hook works as expected.

### Known limitations

N/A
