### PR TITLE
Fix cargo-deny issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,9 +1963,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
+checksum = "2ad3d6d98c648ed628df039541a5577bee1a7c83e9e16fe3dbedeea4cdfeb971"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2176,7 +2176,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/deny.toml
+++ b/deny.toml
@@ -131,7 +131,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "deny"
+multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "deny"
 allow-wildcard-paths = true

--- a/deny.toml
+++ b/deny.toml
@@ -131,7 +131,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
+multiple-versions = "deny"
 # Lint level for when a crate version requirement is `*`
 wildcards = "deny"
 allow-wildcard-paths = true
@@ -241,6 +241,9 @@ skip = [
 
     # wasm-gen update
     { crate = "byteorder", reason = "temp", version = "1.5.0" },
+    
+    # async libraries depend on the older version (async-io and hyper)
+    { crate = "socket2", reason = "temp", version = "0.4.10" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
### What

* Update hickory version
* Allow [multiple dependency versions](https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-multiple-versions-field-optional) (set to `warn` -- default config)

### Why

https://rustsec.org/advisories/RUSTSEC-2025-0006

### Known limitations

N/A
