### PR TITLE
Fix arm cross compilation

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -45,8 +45,8 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
 
-    - if: matrix.sys.target == 'aarch64-unknown-linux-gnu'
-      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev libdbus-1-dev
+    - if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get -y install libudev-dev libdbus-1-dev
 
     - name: Setup vars
       run: |
@@ -66,11 +66,8 @@ jobs:
         echo "BUILD_WORKING_DIR=target/package/${{ matrix.crate.name }}-$VERSION" >> $GITHUB_ENV
 
     - name: Build
-      env:
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       working-directory: ${{ env.BUILD_WORKING_DIR }}
       run: |
-        sudo apt-get update && sudo apt-get -y install libdbus-1-dev
         cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
 
     - name: Build provenance for attestation (release only)

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -30,7 +30,7 @@ jobs:
         sys:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
+          - os: ubuntu-jammy-16-cores-arm64 # Use 22 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -30,7 +30,7 @@ jobs:
         sys:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-jammy-16-cores-arm64 # Use 22 to get an older version of glibc for increased compat
+          - os: ubuntu-22.04-arm # Use 22 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -30,7 +30,7 @@ jobs:
         sys:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04 # Use 22 to get an older version of glibc for increased compat
+          - os: ubuntu-22.04-arm # Use 22 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -30,7 +30,7 @@ jobs:
         sys:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04-arm # Use 22 to get an older version of glibc for increased compat
+          - os: ubuntu-22.04 # Use 22 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin


### PR DESCRIPTION
### What

Change instance of arm builder to `ubuntu-jammy-16-cores-arm64` 

### Why

Failing cross-compilation build on x64

### Known limitations

glibc will be updated to [2.35](https://packages.ubuntu.com/source/jammy/glibc) from [2.31](https://packages.ubuntu.com/source/focal/glibc) for ARM build
