### PR TITLE
feat: Add a stellar contract info wasm-hash command

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/info.rs
+++ b/cmd/soroban-cli/src/commands/contract/info.rs
@@ -6,6 +6,7 @@ pub mod env_meta;
 pub mod interface;
 pub mod meta;
 pub mod shared;
+pub mod wasm_hash;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
@@ -49,6 +50,9 @@ pub enum Cmd {
     ///
     /// Outputs no data when no data is present in the contract.
     EnvMeta(env_meta::Cmd),
+
+    /// Get the wasm hash of a deployed contract
+    WasmHash(wasm_hash::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -59,6 +63,8 @@ pub enum Error {
     Meta(#[from] meta::Error),
     #[error(transparent)]
     EnvMeta(#[from] env_meta::Error),
+    #[error(transparent)]
+    WasmHash(#[from] wasm_hash::Error),
 }
 
 impl Cmd {
@@ -67,6 +73,7 @@ impl Cmd {
             Cmd::Interface(interface) => interface.run(global_args).await?,
             Cmd::Meta(meta) => meta.run(global_args).await?,
             Cmd::EnvMeta(env_meta) => env_meta.run(global_args).await?,
+            Cmd::WasmHash(cmd) => cmd.run(global_args).await?,
         };
         println!("{result}");
         Ok(())

--- a/cmd/soroban-cli/src/commands/contract/info/wasm_hash.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/wasm_hash.rs
@@ -1,0 +1,73 @@
+use clap::{arg, command, Command, ArgMatches};
+use soroban_rpc::client::Client;
+use soroban_xdr::{ScAddress, ScVal, DecodeError};
+use stellar_xdr::XdrCodec;
+use crate::config::Config;
+use crate::error::Result;
+use clap::Parser;
+use stellar_xdr::curr as xdr;
+
+use crate::commands::{config::network, global};
+use crate::config::locator;
+use crate::rpc;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    /// Contract ID to get the wasm hash for
+    #[arg(long = "contract-id")]
+    pub contract_id: stellar_strkey::Contract,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] locator::Error),
+    
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    
+    #[error(transparent)]
+    Rpc(#[from] rpc::Error),
+}
+
+impl Cmd {
+    pub async fn run(&self, _global_args: &global::Args) -> Result<(), Error> {
+        let network = self.network.get(&self.config_locator)?;
+        let client = network.get_client()?;
+
+        // Get the contract instance ledger entry
+        let key = xdr::LedgerKey::ContractData(xdr::LedgerKeyContractData {
+            contract: self.contract_id.clone().into(),
+            key: xdr::ScVal::LedgerKeyContractInstance,
+            durability: xdr::ContractDataDurability::Persistent,
+        });
+
+        let entry = client.get_ledger_entry(&key).await?;
+        
+        // Extract the wasm hash from the contract instance
+        if let xdr::LedgerEntryData::ContractData(data) = entry.data {
+            if let xdr::ScVal::ContractInstance(instance) = data.val {
+                if let xdr::ContractExecutable::Wasm(hash) = instance.executable {
+                    println!("{}", hex::encode(hash.0));
+                    return Ok(());
+                }
+            }
+        }
+
+        Err(rpc::Error::InvalidResponse("Contract instance not found".into()).into())
+    }
+}
+
+pub fn subcommand() -> Command {
+    command!("wasm-hash")
+        .about("Retrieve the wasm hash of a contract")
+        .arg(arg!(--network <NETWORK> "The network to connect to"))
+        .arg(arg!(--contract-id <CONTRACT_ID> "The contract ID"))
+}

--- a/cmd/soroban-cli/src/commands/contract/info/wasm_hash.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/wasm_hash.rs
@@ -21,7 +21,7 @@ pub struct Cmd {
     pub network: network::Args,
 
     /// Contract ID to get the wasm hash for
-    #[arg(long = "contract-id")]
+    #[arg(long)]
     pub contract_id: stellar_strkey::Contract,
 }
 
@@ -65,9 +65,3 @@ impl Cmd {
     }
 }
 
-pub fn subcommand() -> Command {
-    command!("wasm-hash")
-        .about("Retrieve the wasm hash of a contract")
-        .arg(arg!(--network <NETWORK> "The network to connect to"))
-        .arg(arg!(--contract-id <CONTRACT_ID> "The contract ID"))
-}

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -15,6 +15,7 @@ pub mod optimize;
 pub mod read;
 pub mod restore;
 pub mod upload;
+pub mod wasm_hash;
 
 use crate::{commands::global, print::Print};
 
@@ -91,6 +92,9 @@ pub enum Cmd {
     ///
     /// If no keys are specificed the contract itself is restored.
     Restore(restore::Cmd),
+
+    /// Get the wasm hash of a deployed contract
+    WasmHash(wasm_hash::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -142,6 +146,9 @@ pub enum Error {
 
     #[error(transparent)]
     Restore(#[from] restore::Error),
+
+    #[error(transparent)]
+    WasmHash(#[from] wasm_hash::Error),
 }
 
 impl Cmd {
@@ -169,6 +176,7 @@ impl Cmd {
             Cmd::Fetch(fetch) => fetch.run().await?,
             Cmd::Read(read) => read.run().await?,
             Cmd::Restore(restore) => restore.run().await?,
+            Cmd::WasmHash(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -15,7 +15,7 @@ pub mod optimize;
 pub mod read;
 pub mod restore;
 pub mod upload;
-pub mod wasm_hash;
+
 
 use crate::{commands::global, print::Print};
 
@@ -93,8 +93,6 @@ pub enum Cmd {
     /// If no keys are specificed the contract itself is restored.
     Restore(restore::Cmd),
 
-    /// Get the wasm hash of a deployed contract
-    WasmHash(wasm_hash::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -147,8 +145,6 @@ pub enum Error {
     #[error(transparent)]
     Restore(#[from] restore::Error),
 
-    #[error(transparent)]
-    WasmHash(#[from] wasm_hash::Error),
 }
 
 impl Cmd {
@@ -176,7 +172,6 @@ impl Cmd {
             Cmd::Fetch(fetch) => fetch.run().await?,
             Cmd::Read(read) => read.run().await?,
             Cmd::Restore(restore) => restore.run().await?,
-            Cmd::WasmHash(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
### What
Closes: #1877 
This PR adds a new command wasm-hash to the stellar contract CLI, allowing developers to retrieve the Wasm hash of a deployed contract directly from the command line.

### Why
Currently, developers have to rely on more complex methods, such as using RPC calls or parsing logs, to obtain the Wasm hash of a contract. This new command simplifies the process, making it more convenient and efficient for developers to access the Wasm hash directly. It enhances the usability of the CLI by providing a straightforward command that outputs the hash in a format suitable for scripting and automation.

Get the Wasm hash of a deployed contract.

#### Usage
```bash
stellar contract wasm-hash --network <NETWORK> --contract-id <CONTRACT_ID>
```

#### Arguments
- `--network`: The network to use (e.g., `testnet`, `futurenet`, `mainnet`, or custom URL)
- `--contract-id`: The ID of the deployed contract to get the Wasm hash for

#### Example
```bash
# Get the Wasm hash for a contract on testnet
stellar contract wasm-hash --network testnet --contract-id CDSJWGUPY2HFHYNLT3EZX7YGJ4X7YMWPQWHHGNKB6IVH6WRXAJFI7627

# Output:
283f8e42a3585aa3a511c06c7d09a94d66762773cdf493cc4afc455d7b68adcf
```

#### Notes
- The contract must be deployed on the specified network
- The hash is returned in hexadecimal format
- The command requires a network connection to retrieve the contract data
```


