### PR TITLE
Allow stellar-ledger to be published

### DIFF
--- a/cmd/crates/stellar-ledger/Cargo.toml
+++ b/cmd/crates/stellar-ledger/Cargo.toml
@@ -10,11 +10,6 @@ version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 
-# This crate has not yet ever been published. Skip publishing until these
-# security issues are addressed:
-# https://github.com/stellar/stellar-cli/issues/1706
-publish = false
-
 [dependencies]
 thiserror = "1.0.32"
 serde = "1.0.82"


### PR DESCRIPTION
### What

Publish stellar-ledger crate. 

### Why

- without publishing this crate, we are seeing a failure in the publish-dry-run workflow because stellar-ledger isn't included in the vendor file, and needs to be there in order to be packaged in soroban-cli
- we had held off publishing stellar-ledger because of a dependency vulnerability, but that has now been handled: https://github.com/stellar/stellar-cli/issues/1706

### Known limitations

I'm not sure familiar with the release process/ rust packaging, so maybe there is another way to handle this, but just wanted to get a PR up to get some eyes on the issue.