### PR TITLE
Implement stellar tx to accept string/file as an input

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1519,11 +1519,11 @@ Sign, Simulate, and Send transactions
 
 Calculate the hash of a transaction envelope
 
-**Usage:** `stellar tx hash [OPTIONS] [INPUT]`
+**Usage:** `stellar tx hash [OPTIONS] [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1879,11 +1879,11 @@ https://developers.stellar.org/docs/learn/glossary#flags
 
 Transfers the XLM balance of an account to another account and removes the source account from the ledger
 
-**Usage:** `stellar tx operation add account-merge [OPTIONS] --source-account <SOURCE_ACCOUNT> --account <ACCOUNT> [INPUT]`
+**Usage:** `stellar tx operation add account-merge [OPTIONS] --source-account <SOURCE_ACCOUNT> --account <ACCOUNT> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1911,11 +1911,11 @@ Transfers the XLM balance of an account to another account and removes the sourc
 
 Bumps forward the sequence number of the source account to the given sequence number, invalidating any transaction with a smaller sequence number
 
-**Usage:** `stellar tx operation add bump-sequence [OPTIONS] --source-account <SOURCE_ACCOUNT> --bump-to <BUMP_TO> [INPUT]`
+**Usage:** `stellar tx operation add bump-sequence [OPTIONS] --source-account <SOURCE_ACCOUNT> --bump-to <BUMP_TO> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1945,11 +1945,11 @@ Creates, updates, or deletes a trustline
 Learn more about trustlines
 https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#trustlines
 
-**Usage:** `stellar tx operation add change-trust [OPTIONS] --source-account <SOURCE_ACCOUNT> --line <LINE> [INPUT]`
+**Usage:** `stellar tx operation add change-trust [OPTIONS] --source-account <SOURCE_ACCOUNT> --line <LINE> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1980,11 +1980,11 @@ https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/a
 
 Creates and funds a new account with the specified starting balance
 
-**Usage:** `stellar tx operation add create-account [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> [INPUT]`
+**Usage:** `stellar tx operation add create-account [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2017,11 +2017,11 @@ Sets, modifies, or deletes a data entry (name/value pair) that is attached to an
 Learn more about entries and subentries:
 https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#subentries
 
-**Usage:** `stellar tx operation add manage-data [OPTIONS] --source-account <SOURCE_ACCOUNT> --data-name <DATA_NAME> [INPUT]`
+**Usage:** `stellar tx operation add manage-data [OPTIONS] --source-account <SOURCE_ACCOUNT> --data-name <DATA_NAME> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2050,11 +2050,11 @@ https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/a
 
 Sends an amount in a specific asset to a destination account
 
-**Usage:** `stellar tx operation add payment [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> --amount <AMOUNT> [INPUT]`
+**Usage:** `stellar tx operation add payment [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> --amount <AMOUNT> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2092,11 +2092,11 @@ https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
 Learn more about signers operations and key weight:
 https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
 
-**Usage:** `stellar tx operation add set-options [OPTIONS] --source-account <SOURCE_ACCOUNT> [INPUT]`
+**Usage:** `stellar tx operation add set-options [OPTIONS] --source-account <SOURCE_ACCOUNT> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2143,11 +2143,11 @@ If you are modifying a trustline to a pool share, however, this is composed of t
 Learn more about flags:
 https://developers.stellar.org/docs/learn/glossary#flags
 
-**Usage:** `stellar tx operation add set-trustline-flags [OPTIONS] --source-account <SOURCE_ACCOUNT> --trustor <TRUSTOR> --asset <ASSET> [INPUT]`
+**Usage:** `stellar tx operation add set-trustline-flags [OPTIONS] --source-account <SOURCE_ACCOUNT> --trustor <TRUSTOR> --asset <ASSET> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2182,11 +2182,11 @@ https://developers.stellar.org/docs/learn/glossary#flags
 
 Send a transaction envelope to the network
 
-**Usage:** `stellar tx send [OPTIONS] [INPUT]`
+**Usage:** `stellar tx send [OPTIONS] [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2203,11 +2203,11 @@ Send a transaction envelope to the network
 
 Sign a transaction envelope appending the signature to the envelope
 
-**Usage:** `stellar tx sign [OPTIONS] [INPUT]`
+**Usage:** `stellar tx sign [OPTIONS] [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR, or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2228,11 +2228,11 @@ Sign a transaction envelope appending the signature to the envelope
 
 Simulate a transaction envelope from stdin
 
-**Usage:** `stellar tx simulate [OPTIONS] --source-account <SOURCE_ACCOUNT> [INPUT]`
+**Usage:** `stellar tx simulate [OPTIONS] --source-account <SOURCE_ACCOUNT> [TX_XDR]`
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1506,7 +1506,7 @@ Sign, Simulate, and Send transactions
 
 ###### **Subcommands:**
 
-* `hash` — Calculate the hash of a transaction envelope from stdin
+* `hash` — Calculate the hash of a transaction envelope
 * `new` — Create a new transaction
 * `operation` — Manipulate the operations in a transaction, including adding new operations
 * `send` — Send a transaction envelope to the network
@@ -1517,9 +1517,13 @@ Sign, Simulate, and Send transactions
 
 ## `stellar tx hash`
 
-Calculate the hash of a transaction envelope from stdin
+Calculate the hash of a transaction envelope
 
-**Usage:** `stellar tx hash [OPTIONS]`
+**Usage:** `stellar tx hash [OPTIONS] [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1875,7 +1879,11 @@ https://developers.stellar.org/docs/learn/glossary#flags
 
 Transfers the XLM balance of an account to another account and removes the source account from the ledger
 
-**Usage:** `stellar tx operation add account-merge [OPTIONS] --source-account <SOURCE_ACCOUNT> --account <ACCOUNT>`
+**Usage:** `stellar tx operation add account-merge [OPTIONS] --source-account <SOURCE_ACCOUNT> --account <ACCOUNT> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1903,7 +1911,11 @@ Transfers the XLM balance of an account to another account and removes the sourc
 
 Bumps forward the sequence number of the source account to the given sequence number, invalidating any transaction with a smaller sequence number
 
-**Usage:** `stellar tx operation add bump-sequence [OPTIONS] --source-account <SOURCE_ACCOUNT> --bump-to <BUMP_TO>`
+**Usage:** `stellar tx operation add bump-sequence [OPTIONS] --source-account <SOURCE_ACCOUNT> --bump-to <BUMP_TO> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1933,7 +1945,11 @@ Creates, updates, or deletes a trustline
 Learn more about trustlines
 https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#trustlines
 
-**Usage:** `stellar tx operation add change-trust [OPTIONS] --source-account <SOURCE_ACCOUNT> --line <LINE>`
+**Usage:** `stellar tx operation add change-trust [OPTIONS] --source-account <SOURCE_ACCOUNT> --line <LINE> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1964,7 +1980,11 @@ https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/a
 
 Creates and funds a new account with the specified starting balance
 
-**Usage:** `stellar tx operation add create-account [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION>`
+**Usage:** `stellar tx operation add create-account [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -1997,7 +2017,11 @@ Sets, modifies, or deletes a data entry (name/value pair) that is attached to an
 Learn more about entries and subentries:
 https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#subentries
 
-**Usage:** `stellar tx operation add manage-data [OPTIONS] --source-account <SOURCE_ACCOUNT> --data-name <DATA_NAME>`
+**Usage:** `stellar tx operation add manage-data [OPTIONS] --source-account <SOURCE_ACCOUNT> --data-name <DATA_NAME> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2026,7 +2050,11 @@ https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/a
 
 Sends an amount in a specific asset to a destination account
 
-**Usage:** `stellar tx operation add payment [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> --amount <AMOUNT>`
+**Usage:** `stellar tx operation add payment [OPTIONS] --source-account <SOURCE_ACCOUNT> --destination <DESTINATION> --amount <AMOUNT> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2064,7 +2092,11 @@ https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
 Learn more about signers operations and key weight:
 https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
 
-**Usage:** `stellar tx operation add set-options [OPTIONS] --source-account <SOURCE_ACCOUNT>`
+**Usage:** `stellar tx operation add set-options [OPTIONS] --source-account <SOURCE_ACCOUNT> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2111,7 +2143,11 @@ If you are modifying a trustline to a pool share, however, this is composed of t
 Learn more about flags:
 https://developers.stellar.org/docs/learn/glossary#flags
 
-**Usage:** `stellar tx operation add set-trustline-flags [OPTIONS] --source-account <SOURCE_ACCOUNT> --trustor <TRUSTOR> --asset <ASSET>`
+**Usage:** `stellar tx operation add set-trustline-flags [OPTIONS] --source-account <SOURCE_ACCOUNT> --trustor <TRUSTOR> --asset <ASSET> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2146,7 +2182,11 @@ https://developers.stellar.org/docs/learn/glossary#flags
 
 Send a transaction envelope to the network
 
-**Usage:** `stellar tx send [OPTIONS]`
+**Usage:** `stellar tx send [OPTIONS] [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2163,7 +2203,11 @@ Send a transaction envelope to the network
 
 Sign a transaction envelope appending the signature to the envelope
 
-**Usage:** `stellar tx sign [OPTIONS]`
+**Usage:** `stellar tx sign [OPTIONS] [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
@@ -2184,7 +2228,11 @@ Sign a transaction envelope appending the signature to the envelope
 
 Simulate a transaction envelope from stdin
 
-**Usage:** `stellar tx simulate [OPTIONS] --source-account <SOURCE_ACCOUNT>`
+**Usage:** `stellar tx simulate [OPTIONS] --source-account <SOURCE_ACCOUNT> [INPUT]`
+
+###### **Arguments:**
+
+* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 

--- a/cmd/soroban-cli/src/commands/tx/hash.rs
+++ b/cmd/soroban-cli/src/commands/tx/hash.rs
@@ -14,13 +14,13 @@ pub enum Error {
 }
 
 // Command to return the transaction hash submitted to a network
-/// e.g. `soroban tx hash file.txt`
+/// e.g. `stellar tx hash file.txt` or `cat file.txt | stellar tx hash`
 #[derive(Debug, clap::Parser, Clone, Default)]
 #[group(skip)]
 pub struct Cmd {
-    /// XDR or file containing XDR to decode, or stdin if empty
+    /// Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
     #[arg()]
-    pub input: Option<OsString>,
+    pub tx_xdr: Option<OsString>,
 
     #[clap(flatten)]
     pub network: network::Args,
@@ -28,7 +28,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.input)?)?;
+        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.tx_xdr)?)?;
         let network = &self.network.get(&global_args.locator)?;
         println!(
             "{}",

--- a/cmd/soroban-cli/src/commands/tx/hash.rs
+++ b/cmd/soroban-cli/src/commands/tx/hash.rs
@@ -1,4 +1,5 @@
 use hex;
+use std::ffi::OsString;
 
 use crate::{commands::global, config::network, utils::transaction_hash};
 
@@ -13,17 +14,21 @@ pub enum Error {
 }
 
 // Command to return the transaction hash submitted to a network
-/// e.g. `cat file.txt | soroban tx hash`
+/// e.g. `soroban tx hash file.txt`
 #[derive(Debug, clap::Parser, Clone, Default)]
 #[group(skip)]
 pub struct Cmd {
+    /// XDR or file containing XDR to decode, or stdin if empty
+    #[arg()]
+    pub input: Option<OsString>,
+
     #[clap(flatten)]
     pub network: network::Args,
 }
 
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_stdin()?)?;
+        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.input)?)?;
         let network = &self.network.get(&global_args.locator)?;
         println!(
             "{}",

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -14,7 +14,7 @@ pub use args::Args;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
-    /// Calculate the hash of a transaction envelope from stdin
+    /// Calculate the hash of a transaction envelope
     Hash(hash::Cmd),
     /// Create a new transaction
     #[command(subcommand)]

--- a/cmd/soroban-cli/src/commands/tx/op/add/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/args.rs
@@ -11,9 +11,9 @@ pub struct Args {
         env = "STELLAR_OPERATION_SOURCE_ACCOUNT"
     )]
     pub operation_source_account: Option<address::UnresolvedMuxedAccount>,
-    /// XDR or file containing XDR to decode, or stdin if empty
+    /// Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
     #[arg()]
-    pub input: Option<OsString>,
+    pub tx_xdr: Option<OsString>,
 }
 
 impl Args {

--- a/cmd/soroban-cli/src/commands/tx/op/add/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/args.rs
@@ -1,4 +1,5 @@
 use crate::config::address;
+use std::ffi::OsString;
 
 #[derive(Debug, clap::Args, Clone)]
 #[group(skip)]
@@ -10,6 +11,9 @@ pub struct Args {
         env = "STELLAR_OPERATION_SOURCE_ACCOUNT"
     )]
     pub operation_source_account: Option<address::UnresolvedMuxedAccount>,
+    /// XDR or file containing XDR to decode, or stdin if empty
+    #[arg()]
+    pub input: Option<OsString>,
 }
 
 impl Args {

--- a/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
@@ -68,42 +68,42 @@ impl Cmd {
         let res = match self {
             Cmd::AccountMerge(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::BumpSequence(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::ChangeTrust(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::CreateAccount(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::ManageData(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::Payment(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::SetOptions(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
             Cmd::SetTrustlineFlags(cmd) => cmd.op.tx.add_op(
                 op,
-                tx_envelope_from_input(&cmd.args.input)?,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
         }

--- a/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
@@ -1,4 +1,4 @@
-use super::super::{global, help, xdr::tx_envelope_from_stdin};
+use super::super::{global, help, xdr::tx_envelope_from_input};
 use crate::xdr::{OperationBody, WriteXdr};
 
 pub(crate) use super::super::new;
@@ -64,17 +64,48 @@ impl TryFrom<&Cmd> for OperationBody {
 
 impl Cmd {
     pub async fn run(&self, _: &global::Args) -> Result<(), Error> {
-        let tx_env = tx_envelope_from_stdin()?;
         let op = OperationBody::try_from(self)?;
         let res = match self {
-            Cmd::AccountMerge(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::BumpSequence(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::ChangeTrust(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::CreateAccount(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::ManageData(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::Payment(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::SetOptions(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
-            Cmd::SetTrustlineFlags(cmd) => cmd.op.tx.add_op(op, tx_env, cmd.args.source()),
+            Cmd::AccountMerge(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::BumpSequence(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::ChangeTrust(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::CreateAccount(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::ManageData(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::Payment(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::SetOptions(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
+            Cmd::SetTrustlineFlags(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.input)?,
+                cmd.args.source(),
+            ),
         }
         .await?;
         println!("{}", res.to_xdr_base64(crate::xdr::Limits::none())?);

--- a/cmd/soroban-cli/src/commands/tx/send.rs
+++ b/cmd/soroban-cli/src/commands/tx/send.rs
@@ -25,11 +25,11 @@ pub enum Error {
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
 /// Command to send a transaction envelope to the network
-/// e.g. `soroban tx send file.txt`
+/// e.g. `stellar tx send file.txt` or `cat file.txt | stellar tx send`
 pub struct Cmd {
-    /// XDR or file containing XDR to decode, or stdin if empty
+    /// Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
     #[arg()]
-    pub input: Option<OsString>,
+    pub tx_xdr: Option<OsString>,
     #[clap(flatten)]
     pub network: network::Args,
     #[clap(flatten)]
@@ -60,7 +60,7 @@ impl NetworkRunnable for Cmd {
             self.network.get(&self.locator)?
         };
         let client = network.rpc_client()?;
-        let tx_env = super::xdr::tx_envelope_from_input(&self.input)?;
+        let tx_env = super::xdr::tx_envelope_from_input(&self.tx_xdr)?;
 
         if let Ok(Ok(hash)) = super::xdr::unwrap_envelope_v1(tx_env.clone())
             .map(|tx| transaction_hash(&tx, &network.network_passphrase))

--- a/cmd/soroban-cli/src/commands/tx/send.rs
+++ b/cmd/soroban-cli/src/commands/tx/send.rs
@@ -1,6 +1,7 @@
 use crate::{print::Print, utils::transaction_hash};
 use async_trait::async_trait;
 use soroban_rpc::GetTransactionResponse;
+use std::ffi::OsString;
 
 use crate::{
     commands::{global, NetworkRunnable},
@@ -24,8 +25,11 @@ pub enum Error {
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
 /// Command to send a transaction envelope to the network
-/// e.g. `cat file.txt | soroban tx send`
+/// e.g. `soroban tx send file.txt`
 pub struct Cmd {
+    /// XDR or file containing XDR to decode, or stdin if empty
+    #[arg()]
+    pub input: Option<OsString>,
     #[clap(flatten)]
     pub network: network::Args,
     #[clap(flatten)]
@@ -56,7 +60,7 @@ impl NetworkRunnable for Cmd {
             self.network.get(&self.locator)?
         };
         let client = network.rpc_client()?;
-        let tx_env = super::xdr::tx_envelope_from_stdin()?;
+        let tx_env = super::xdr::tx_envelope_from_input(&self.input)?;
 
         if let Ok(Ok(hash)) = super::xdr::unwrap_envelope_v1(tx_env.clone())
             .map(|tx| transaction_hash(&tx, &network.network_passphrase))

--- a/cmd/soroban-cli/src/commands/tx/sign.rs
+++ b/cmd/soroban-cli/src/commands/tx/sign.rs
@@ -3,6 +3,7 @@ use crate::{
     config::{locator, network, sign_with},
     xdr::{self, Limits, WriteXdr},
 };
+use std::ffi::OsString;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -21,6 +22,9 @@ pub enum Error {
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
 pub struct Cmd {
+    /// XDR or file containing XDR to decode, or stdin if empty
+    #[arg()]
+    pub input: Option<OsString>,
     #[command(flatten)]
     pub sign_with: sign_with::Args,
     #[command(flatten)]
@@ -32,7 +36,7 @@ pub struct Cmd {
 impl Cmd {
     #[allow(clippy::unused_async)]
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let tx_env = super::xdr::tx_envelope_from_stdin()?;
+        let tx_env = super::xdr::tx_envelope_from_input(&self.input)?;
         let tx_env_signed = self
             .sign_with
             .sign_tx_env(

--- a/cmd/soroban-cli/src/commands/tx/sign.rs
+++ b/cmd/soroban-cli/src/commands/tx/sign.rs
@@ -22,9 +22,9 @@ pub enum Error {
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// XDR or file containing XDR to decode, or stdin if empty
+    /// Base-64 transaction envelope XDR, or file containing XDR to decode, or stdin if empty
     #[arg()]
-    pub input: Option<OsString>,
+    pub tx_xdr: Option<OsString>,
     #[command(flatten)]
     pub sign_with: sign_with::Args,
     #[command(flatten)]
@@ -36,7 +36,7 @@ pub struct Cmd {
 impl Cmd {
     #[allow(clippy::unused_async)]
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let tx_env = super::xdr::tx_envelope_from_input(&self.input)?;
+        let tx_env = super::xdr::tx_envelope_from_input(&self.tx_xdr)?;
         let tx_env_signed = self
             .sign_with
             .sign_tx_env(

--- a/cmd/soroban-cli/src/commands/tx/simulate.rs
+++ b/cmd/soroban-cli/src/commands/tx/simulate.rs
@@ -22,13 +22,13 @@ pub enum Error {
 }
 
 /// Command to simulate a transaction envelope via rpc
-/// e.g. `cat file.txt | soroban tx simulate`
+/// e.g. `stellar tx simulate file.txt` or `cat file.txt | stellar tx simulate`
 #[derive(Debug, clap::Parser, Clone, Default)]
 #[group(skip)]
 pub struct Cmd {
-    /// XDR or file containing XDR to decode, or stdin if empty
+    /// Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
     #[arg()]
-    pub input: Option<OsString>,
+    pub tx_xdr: Option<OsString>,
     #[clap(flatten)]
     pub config: config::Args,
 }
@@ -57,7 +57,7 @@ impl NetworkRunnable for Cmd {
         let config = config.unwrap_or(&self.config);
         let network = config.get_network()?;
         let client = network.rpc_client()?;
-        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.input)?)?;
+        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.tx_xdr)?)?;
         let tx = simulate_and_assemble_transaction(&client, &tx).await?;
         Ok(tx)
     }

--- a/cmd/soroban-cli/src/commands/tx/xdr.rs
+++ b/cmd/soroban-cli/src/commands/tx/xdr.rs
@@ -1,20 +1,17 @@
-use std::{
-    io::{stdin, Read},
-    path::PathBuf,
-};
-
 use crate::xdr::{
     Limits, Operation, ReadXdr, Transaction, TransactionEnvelope, TransactionV1Envelope,
 };
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::Cursor;
+use std::io::{stdin, Read};
+use std::path::Path;
+use stellar_xdr::curr::Limited;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("failed to decode XDR from base64")]
-    Base64Decode,
-    #[error("failed to decode XDR from file: {0}")]
-    FileDecode(PathBuf),
-    #[error("failed to decode XDR from stdin")]
-    StdinDecode,
+    #[error("failed to decode XDR: {0}")]
+    XDRDecode(#[from] stellar_xdr::curr::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("only transaction v1 is supported")]
@@ -23,16 +20,49 @@ pub enum Error {
     TooManyOperations,
 }
 
-pub fn tx_envelope_from_stdin() -> Result<TransactionEnvelope, Error> {
-    from_stdin()
+pub fn tx_envelope_from_input(input: &Option<OsString>) -> Result<TransactionEnvelope, Error> {
+    let read: &mut dyn Read = if let Some(input) = input {
+        let exist = Path::new(input).try_exists();
+        if let Ok(true) = exist {
+            &mut File::open(input)?
+        } else {
+            &mut Cursor::new(input.clone().into_encoded_bytes())
+        }
+    } else {
+        &mut stdin()
+    };
+
+    let mut lim = Limited::new(SkipWhitespace::new(read), Limits::none());
+    Ok(TransactionEnvelope::read_xdr_base64_to_end(&mut lim)?)
 }
-pub fn from_stdin<T: ReadXdr>() -> Result<T, Error> {
-    let mut buf = String::new();
-    let _ = stdin()
-        .read_to_string(&mut buf)
-        .map_err(|_| Error::StdinDecode)?;
-    T::from_xdr_base64(buf.trim(), Limits::none()).map_err(|_| Error::StdinDecode)
+
+// TODO: use SkipWhitespace from rs-stellar-xdr once it's updated to 23.0
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
 }
+
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+//
 
 pub fn unwrap_envelope_v1(tx_env: TransactionEnvelope) -> Result<Transaction, Error> {
     let TransactionEnvelope::Tx(TransactionV1Envelope { tx, .. }) = tx_env else {


### PR DESCRIPTION
### What

Makes `stellar tx` subcommands to accept stdin/string/file as an input

### Why

#1827 
#1822 

### Known limitations

* Only takes one string/file as an input
* Some copy-paste from `rs-stellar-xdr` that can be addressed later