### PR TITLE
Update cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2024-0388", # derivative is no longer maintained, but that has no known material impact on the this repo
+    "RUSTSEC-2025-0007", # ring is no longer maintained, however a lot of depepndencies depend on it. This should have no impact on this repo, as all of them have it as an optional dependency
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
### What

Update cargo deny to ignore https://rustsec.org/advisories/RUSTSEC-2025-0007

### Why

`ring` is no longer maintaned. We don't depend on it and it comes from downstream dependencies. From github search on the repos, is appears that the `ring` is an optional dependency in all of them

```
 > cargo tree -i ring  --format "{p} {f}"  
ring v0.17.8 alloc,default,dev_urandom_fallback
├── rustls v0.21.12 log,logging,tls12
│   ├── hyper-rustls v0.24.2 http1,log,logging,native-tokio,rustls-native-certs,tls12,tokio-runtime
│   │   └── jsonrpsee-http-client v0.20.3 __tls,default,hyper-rustls,native-tls
│   │       ├── soroban-cli v22.2.0 (/projects/stellar-cli/cmd/soroban-cli) default
│   │       │   └── soroban-test v22.2.0 (/projects/stellar-cli/cmd/crates/soroban-test) 
│   │       └── stellar-rpc-client v22.0.0 
│   │           ├── soroban-cli v22.2.0 (/projects/stellar-cli/cmd/soroban-cli) default (*)
│   │           └── soroban-test v22.2.0 (/projects/stellar-cli/cmd/crates/soroban-test) 
│   └── tokio-rustls v0.24.1 logging,tls12
│       └── hyper-rustls v0.24.2 http1,log,logging,native-tokio,rustls-native-certs,tls12,tokio-runtime (*)
├── rustls v0.22.4 default,log,logging,ring,tls12
│   ├── bollard v0.16.1 default,home,hyper-rustls,rustls,rustls-native-certs,rustls-pemfile,rustls-pki-types,ssl
│   │   ├── soroban-cli v22.2.0 (/projects/stellar-cli/cmd/soroban-cli) default (*)
│   │   ├── stellar-ledger v22.2.0 (/projects/stellar-cli/cmd/crates/stellar-ledger) default,http-transport
│   │   │   ├── soroban-cli v22.2.0 (/projects/stellar-cli/cmd/soroban-cli) default (*)
│   │   │   └── soroban-test v22.2.0 (/projects/stellar-cli/cmd/crates/soroban-test) 
│   │   └── testcontainers v0.20.1 default
│   │       └── soroban-test v22.2.0 (/projects/stellar-cli/cmd/crates/soroban-test) 
│   ├── hyper-rustls v0.26.0 default,http1,log,logging,native-tokio,ring,rustls-native-certs,tls12
│   │   └── bollard v0.16.1 default,home,hyper-rustls,rustls,rustls-native-certs,rustls-pemfile,rustls-pki-types,ssl (*)
│   └── tokio-rustls v0.25.0 logging,tls12
│       └── hyper-rustls v0.26.0 default,http1,log,logging,native-tokio,ring,rustls-native-certs,tls12 (*)
├── rustls v0.23.12 ring,std,tls12
│   ├── hyper-rustls v0.27.3 http1,http2,native-tokio,ring,rustls-native-certs,tls12,webpki-roots,webpki-tokio
│   │   └── reqwest v0.12.7 __rustls,__rustls-ring,__tls,blocking,charset,default,default-tls,h2,hickory-dns,http2,json,macos-system-configuration,rustls-tls,rustls-tls-native-roots,rustls-tls-webpki-roots,stream
│   │       ├── soroban-cli v22.2.0 (/projects/stellar-cli/cmd/soroban-cli) default (*)
│   │       ├── stellar-ledger v22.2.0 (/projects/stellar-cli/cmd/crates/stellar-ledger) default,http-transport (*)
│   │       └── testcontainers v0.20.1 default (*)
│   ├── reqwest v0.12.7 __rustls,__rustls-ring,__tls,blocking,charset,default,default-tls,h2,hickory-dns,http2,json,macos-system-configuration,rustls-tls,rustls-tls-native-roots,rustls-tls-webpki-roots,stream (*)
│   └── tokio-rustls v0.26.0 ring,tls12
│       ├── hyper-rustls v0.27.3 http1,http2,native-tokio,ring,rustls-native-certs,tls12,webpki-roots,webpki-tokio (*)
│       └── reqwest v0.12.7 __rustls,__rustls-ring,__tls,blocking,charset,default,default-tls,h2,hickory-dns,http2,json,macos-system-configuration,rustls-tls,rustls-tls-native-roots,rustls-tls-webpki-roots,stream (*)
├── rustls-webpki v0.101.7 alloc,default,std
│   └── rustls v0.21.12 log,logging,tls12 (*)
├── rustls-webpki v0.102.6 alloc,ring,std
│   ├── rustls v0.22.4 default,log,logging,ring,tls12 (*)
│   └── rustls v0.23.12 ring,std,tls12 (*)
└── sct v0.7.1 
    └── rustls v0.21.12 log,logging,tls12 (*)

```

### Known limitations

N/A