### PR TITLE
Make `keys generate` to no longer fund

### DIFF
--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -1,10 +1,10 @@
+use crate::util::{add_key, add_test_id, NoFund, SecretKind, DEFAULT_SEED_PHRASE};
 use assert_fs::TempDir;
 use predicates::prelude::predicate;
-use soroban_test::{AssertExt, TestEnv};
-use std::{fs, path::Path};
-use crate::util::{add_key, add_test_id, SecretKind, DEFAULT_SEED_PHRASE, NoFund};
 use soroban_cli::commands::network;
 use soroban_cli::config::network::passphrase::LOCAL as LOCAL_NETWORK_PASSPHRASE;
+use soroban_test::{AssertExt, TestEnv};
+use std::{fs, path::Path};
 
 fn ls(sandbox: &TestEnv) -> Vec<String> {
     sandbox

--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -2,8 +2,7 @@ use assert_fs::TempDir;
 use predicates::prelude::predicate;
 use soroban_test::{AssertExt, TestEnv};
 use std::{fs, path::Path};
-
-use crate::util::{add_key, add_test_id, SecretKind, DEFAULT_SEED_PHRASE};
+use crate::util::{add_key, add_test_id, SecretKind, DEFAULT_SEED_PHRASE, NoFund};
 use soroban_cli::commands::network;
 use soroban_cli::config::network::passphrase::LOCAL as LOCAL_NETWORK_PASSPHRASE;
 
@@ -197,7 +196,7 @@ fn generate_key() {
     sandbox
         .new_assert_cmd("keys")
         .arg("generate")
-        .arg("--no-fund")
+        .no_fund()
         .arg("--seed")
         .arg("0000000000000000")
         .arg("test_2")
@@ -407,7 +406,7 @@ fn cannot_create_contract_with_test_name() {
     sandbox
         .new_assert_cmd("keys")
         .arg("generate")
-        .arg("--no-fund")
+        .no_fund()
         .arg("d")
         .assert()
         .success();
@@ -436,7 +435,7 @@ fn cannot_create_key_with_alias() {
     sandbox
         .new_assert_cmd("keys")
         .arg("generate")
-        .arg("--no-fund")
+        .no_fund()
         .arg("t")
         .assert()
         .stderr(predicate::str::contains(

--- a/cmd/crates/soroban-test/tests/it/rpc_provider.rs
+++ b/cmd/crates/soroban-test/tests/it/rpc_provider.rs
@@ -7,6 +7,7 @@ use soroban_test::{TestEnv, LOCAL_NETWORK_PASSPHRASE};
 async fn test_use_rpc_provider_with_auth_header() {
     // mock out http request to rpc provider
     let server = MockServer::start();
+    #[cfg(feature = "version_lt_23")]
     let generate_account_mock = mock_generate_account(&server);
     let get_network_mock = mock_get_network(&server);
     let get_events_mock = mock_get_events(&server);
@@ -24,12 +25,14 @@ async fn test_use_rpc_provider_with_auth_header() {
         .success();
 
     // generate account is being called in `with_rpc_provider`
+    #[cfg(feature = "version_lt_23")]
     generate_account_mock.assert();
     // get_network and get_events are being called in the `stellar events` command
     get_network_mock.assert();
     get_events_mock.assert();
 }
 
+#[cfg(feature = "version_lt_23")]
 fn mock_generate_account(server: &MockServer) -> Mock {
     let cli_version = soroban_cli::commands::version::pkg();
     let agent = format!("soroban-cli/{cli_version}");

--- a/cmd/crates/soroban-test/tests/it/util.rs
+++ b/cmd/crates/soroban-test/tests/it/util.rs
@@ -4,6 +4,7 @@ use soroban_cli::{
 };
 use soroban_test::{TestEnv, Wasm, TEST_ACCOUNT};
 use std::path::Path;
+use assert_cmd::Command;
 
 pub const CUSTOM_TYPES: &Wasm = &Wasm::Custom("test-wasms", "test_custom_types");
 
@@ -60,3 +61,16 @@ pub async fn invoke_custom(
 pub const DEFAULT_CONTRACT_ID: &str = "CDR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OO5Z";
 #[allow(dead_code)]
 pub const LOCAL_NETWORK_PASSPHRASE: &str = "Local Sandbox Stellar Network ; September 2022";
+
+pub trait NoFund {
+    fn no_fund(&mut self) -> &mut Self;
+}
+
+impl NoFund for Command {
+    fn no_fund(&mut self) -> &mut Self {
+        #[cfg(feature = "version_lt_23")]
+        return self.arg("--no-fund");
+        #[cfg(not(feature = "version_lt_23"))]
+        return self;
+    }
+}

--- a/cmd/crates/soroban-test/tests/it/util.rs
+++ b/cmd/crates/soroban-test/tests/it/util.rs
@@ -1,10 +1,10 @@
+use assert_cmd::Command;
 use soroban_cli::{
     commands::contract,
     config::{locator::KeyType, secret::Secret},
 };
 use soroban_test::{TestEnv, Wasm, TEST_ACCOUNT};
 use std::path::Path;
-use assert_cmd::Command;
 
 pub const CUSTOM_TYPES: &Wasm = &Wasm::Custom("test-wasms", "test_custom_types");
 


### PR DESCRIPTION
### What

Previously, `--fund` flag was added, and funding by default gave a warning.
In this PR `-no-fund` flag was removed, and default behavior flipped to no longer fund 

### Why

Closing #1407

### Known limitations

Depends on #1888 
