### PR TITLE
Fix protocol features for testing

### DIFF
--- a/cmd/crates/soroban-test/Cargo.toml
+++ b/cmd/crates/soroban-test/Cargo.toml
@@ -50,5 +50,8 @@ tracing-subscriber = "0.3.18"
 httpmock = { workspace = true }
 
 [features]
+default = []
 it = []
 emulator-tests = ["stellar-ledger/emulator-tests"]
+version_lt_23 = []
+version_gte_23 = []

--- a/cmd/crates/soroban-test/build.rs
+++ b/cmd/crates/soroban-test/build.rs
@@ -1,5 +1,4 @@
 fn main() {
-    crate_git_revision::init();
     set_protocol_features();
 }
 


### PR DESCRIPTION
### What

Fixes protocol features for manual testing.
1. Adds features to `soroban-test` crate
2. Updates `build.rs` to only enable `version_lt_23` if `version_gte_23` is not enabled (previously if toml file's version set to 22 `version_lt_23` would always be enabled) 

### Why

Previously it was impossible to test p23 changes

### Known limitations

N/A
