### PR TITLE
Add build summary to output of build command

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -209,7 +209,7 @@ impl Cmd {
                     target_file_path
                 };
 
-                self.print_build_summary(&print, &final_path)?;
+                Self::print_build_summary(&print, &final_path)?;
             }
         }
 
@@ -311,7 +311,7 @@ impl Cmd {
         fs::write(target_file_path, wasm_bytes).map_err(Error::WritingWasmFile)
     }
 
-    fn print_build_summary(&self, print: &Print, target_file_path: &PathBuf) -> Result<(), Error> {
+    fn print_build_summary(print: &Print, target_file_path: &PathBuf) -> Result<(), Error> {
         print.infoln("Build Summary:");
         let rel_target_file_path = target_file_path
             .strip_prefix(env::current_dir().unwrap())

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -199,11 +199,16 @@ impl Cmd {
 
                 self.handle_contract_metadata_args(&target_file_path)?;
 
-                if let Some(out_dir) = &self.out_dir {
+                let final_path = if let Some(out_dir) = &self.out_dir {
                     fs::create_dir_all(out_dir).map_err(Error::CreatingOutDir)?;
                     let out_file_path = Path::new(out_dir).join(&file);
-                    fs::copy(target_file_path, out_file_path).map_err(Error::CopyingWasmFile)?;
-                }
+                    fs::copy(target_file_path, &out_file_path).map_err(Error::CopyingWasmFile)?;
+                    out_file_path
+                } else {
+                    target_file_path
+                };
+
+                self.print_build_summary(&print, &final_path)?;
             }
         }
 
@@ -303,6 +308,44 @@ impl Cmd {
         }
 
         fs::write(target_file_path, wasm_bytes).map_err(Error::WritingWasmFile)
+    }
+
+    fn print_build_summary(&self, print: &Print, target_file_path: &PathBuf) -> Result<(), Error> {
+        let rel_target_file_path = target_file_path
+            .strip_prefix(env::current_dir().unwrap())
+            .unwrap_or(target_file_path);
+        print.infoln(format!("Build Summary: {}", rel_target_file_path.display()));
+
+        let wasm_bytes = fs::read(target_file_path).map_err(Error::ReadingWasmFile)?;
+
+        let parser = wasmparser::Parser::new(0);
+        let export_names: Vec<&str> = parser
+            .parse_all(&wasm_bytes)
+            .filter_map(Result::ok)
+            .filter_map(|payload| {
+                if let wasmparser::Payload::ExportSection(exports) = payload {
+                    Some(exports)
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .filter_map(Result::ok)
+            .filter(|export| matches!(export.kind, wasmparser::ExternalKind::Func))
+            .map(|export| export.name)
+            .sorted()
+            .collect();
+        if export_names.is_empty() {
+            print.warnln("Function: None found");
+        } else {
+            print.infoln(format!("Functions: {} found", export_names.len()));
+            for name in export_names {
+                print.blankln(format!("  • {name}"));
+            }
+        }
+        print.checkln("Build Complete");
+
+        Ok(())
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -211,7 +211,7 @@ impl Cmd {
                     target_file_path
                 };
 
-                Self::print_build_summary(global_args.verbose, &print, &final_path)?;
+                Self::print_build_summary(&print, &final_path)?;
             }
         }
 
@@ -316,11 +316,7 @@ impl Cmd {
         fs::write(target_file_path, wasm_bytes).map_err(Error::WritingWasmFile)
     }
 
-    fn print_build_summary(
-        verbose: bool,
-        print: &Print,
-        target_file_path: &PathBuf,
-    ) -> Result<(), Error> {
+    fn print_build_summary(print: &Print, target_file_path: &PathBuf) -> Result<(), Error> {
         print.infoln("Build Summary:");
         let rel_target_file_path = target_file_path
             .strip_prefix(env::current_dir().unwrap())
@@ -334,34 +330,31 @@ impl Cmd {
             hex::encode(Sha256::digest(&wasm_bytes))
         ));
 
-        if verbose {
-            let parser = wasmparser::Parser::new(0);
-            let export_names: Vec<&str> = parser
-                .parse_all(&wasm_bytes)
-                .filter_map(Result::ok)
-                .filter_map(|payload| {
-                    if let wasmparser::Payload::ExportSection(exports) = payload {
-                        Some(exports)
-                    } else {
-                        None
-                    }
-                })
-                .flatten()
-                .filter_map(Result::ok)
-                .filter(|export| matches!(export.kind, wasmparser::ExternalKind::Func))
-                .map(|export| export.name)
-                .sorted()
-                .collect();
-            if export_names.is_empty() {
-                print.blankln("Exported Functions: None found");
-            } else {
-                print.blankln(format!("Exported Functions: {} found", export_names.len()));
-                for name in export_names {
-                    print.blankln(format!("  • {name}"));
+        let parser = wasmparser::Parser::new(0);
+        let export_names: Vec<&str> = parser
+            .parse_all(&wasm_bytes)
+            .filter_map(Result::ok)
+            .filter_map(|payload| {
+                if let wasmparser::Payload::ExportSection(exports) = payload {
+                    Some(exports)
+                } else {
+                    None
                 }
+            })
+            .flatten()
+            .filter_map(Result::ok)
+            .filter(|export| matches!(export.kind, wasmparser::ExternalKind::Func))
+            .map(|export| export.name)
+            .sorted()
+            .collect();
+        if export_names.is_empty() {
+            print.blankln("Exported Functions: None found");
+        } else {
+            print.blankln(format!("Exported Functions: {} found", export_names.len()));
+            for name in export_names {
+                print.blankln(format!("  • {name}"));
             }
         }
-
         print.checkln("Build Complete");
 
         Ok(())

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -109,3 +109,4 @@ create_print_functions!(exclaim, exclaimln, "❗️");
 create_print_functions!(arrow, arrowln, "➡️");
 create_print_functions!(log, logln, "📔");
 create_print_functions!(event, eventln, "📅");
+create_print_functions!(blank, blankln, " ");

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -43,7 +43,9 @@ impl Print {
     // we need an additional space.
     pub fn compute_emoji<T: Display + Sized>(&self, emoji: T) -> String {
         if let Ok(term_program) = env::var("TERM_PROGRAM") {
-            if TERMS.contains(&term_program.as_str()) && emoji.to_string().chars().count() == 2 {
+            if TERMS.contains(&term_program.as_str())
+                && (emoji.to_string().chars().count() == 2 || format!("{emoji}") == " ")
+            {
                 return format!("{emoji} ");
             }
         }


### PR DESCRIPTION
### What
Add build summary displaying file location, hash, and exported functions, to the `stellar contract build` command.

```
$ stellar contract build
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/leighmcculloch/.cargo/registry/src= cargo rustc --manifest-path=Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release
    Finished `release` profile [optimized] target(s) in 0.08s
ℹ️ Build Summary:
   Wasm File: target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
   Wasm Hash: 8153ca452b10ed4edaefeb5235145b9938786c8c6a626e060e3dce85752c0cc3
   Exported Functions: 2 found
     • _
     • increment
✅ Build Complete
```

### Why
I think it could be helpful to output the wasm hash in the logs of builds.

It also outputs the exported functions because I was recently thinking more about the following issue, and pondering ways we could make it more obvious to folks when a build contains unexpected functions. This doesn't adequately solve that problem though, I wouldn't consider it a solution for that problem, so we should hold it as a why very loosely.
- https://github.com/stellar/rs-soroban-sdk/issues/1439

@fnando This was something that was more me experimenting with. I think it looks good, but I am not attached to it and can close it if you don't.