### PR TITLE
Upgrade scc and sdd deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.9"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ff467073ddaff34c3a39e5b454f25dd982484a26fff50254ca793c56a1b714"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
 dependencies = [
  "sdd",
 ]
@@ -4012,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "2.1.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "sec1"


### PR DESCRIPTION
### What
Upgrade scc crate from 2.1.9 to 2.3.3 and sdd crate from 2.1.0 to 3.0.7.

### Why
scc 2.1.9 was yanked. According to the maintainer it is because of a use-after-free bug that existed in the lib.
- https://github.com/wvwwvwwv/scalable-concurrent-containers/issues/178