### PR TITLE
Fix metadata entry not properly written

### DIFF
--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -4,7 +4,7 @@ use soroban_spec_tools::contract::Spec;
 use soroban_test::TestEnv;
 use std::env;
 use std::io::Cursor;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn build_all() {
@@ -113,12 +113,11 @@ fn build_default_members() {
 }
 
 #[test]
-#[ignore] // TODO: unignore -- reproduces unfixed bug https://github.com/stellar/stellar-cli/issues/1694
-fn build_with_metadata() {
+fn build_with_metadata_rewrite() {
     let sandbox = TestEnv::default();
+    let outdir = sandbox.dir().join("out");
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/contracts/add");
-    let outdir = sandbox.dir().join("out");
 
     sandbox
         .new_assert_cmd("contract")
@@ -142,13 +141,87 @@ fn build_with_metadata() {
         .assert()
         .success();
 
+    let entries = get_entries(&fixture_path, &outdir);
+    let expected_entries = vec![
+        ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: "Description".try_into().unwrap(),
+            val: "A test add contract".try_into().unwrap(),
+        }),
+        ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: "meta_replaced".try_into().unwrap(),
+            val: "some_new_meta".try_into().unwrap(),
+        }),
+    ];
+
+    assert_eq!(entries, expected_entries);
+}
+
+#[test]
+fn build_with_metadata_diff_dir() {
+    let sandbox = TestEnv::default();
+    let outdir1 = sandbox.dir().join("out-1");
+    let outdir2 = sandbox.dir().join("out-2");
+    let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_path = cargo_dir.join("tests/fixtures/workspace/contracts/add");
+
+    sandbox
+        .new_assert_cmd("contract")
+        .current_dir(&fixture_path)
+        .arg("build")
+        .arg("--meta")
+        .arg("contract meta=added on build")
+        .arg("--out-dir")
+        .arg(&outdir1)
+        .assert()
+        .success();
+
+    sandbox
+        .new_assert_cmd("contract")
+        .current_dir(&fixture_path)
+        .arg("build")
+        .arg("--meta")
+        .arg("meta_replaced=some_new_meta")
+        .arg("--out-dir")
+        .arg(&outdir2)
+        .assert()
+        .success();
+
+    let entries_dir1 = get_entries(&fixture_path, &outdir1);
+    let expected_entries_dir1 = vec![
+        ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: "Description".try_into().unwrap(),
+            val: "A test add contract".try_into().unwrap(),
+        }),
+        ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: "contract meta".try_into().unwrap(),
+            val: "added on build".try_into().unwrap(),
+        }),
+    ];
+
+    let entries_dir2 = get_entries(&fixture_path, &outdir2);
+    let expected_entries_dir2 = vec![
+        ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: "Description".try_into().unwrap(),
+            val: "A test add contract".try_into().unwrap(),
+        }),
+        ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: "meta_replaced".try_into().unwrap(),
+            val: "some_new_meta".try_into().unwrap(),
+        }),
+    ];
+
+    assert_eq!(entries_dir1, expected_entries_dir1);
+    assert_eq!(entries_dir2, expected_entries_dir2);
+}
+
+fn get_entries(fixture_path: &Path, outdir: &Path) -> Vec<ScMetaEntry> {
     // verify that the metadata added in the contract code via contractmetadata! macro is present
     // as well as the meta that is included on build
-    let wasm_path = fixture_path.join(&outdir).join("add.wasm");
+    let wasm_path = fixture_path.join(outdir).join("add.wasm");
     let wasm = std::fs::read(wasm_path).unwrap();
     let spec = Spec::new(&wasm).unwrap();
     let meta = spec.meta_base64.unwrap();
-    let entries = ScMetaEntry::read_xdr_base64_iter(&mut Limited::new(
+    ScMetaEntry::read_xdr_base64_iter(&mut Limited::new(
         Cursor::new(meta.as_bytes()),
         Limits::none(),
     ))
@@ -163,20 +236,7 @@ fn build_with_metadata() {
         _ => true,
     })
     .collect::<Result<Vec<_>, _>>()
-    .unwrap();
-
-    let expected_entries = vec![
-        ScMetaEntry::ScMetaV0(ScMetaV0 {
-            key: "Description".try_into().unwrap(),
-            val: "A test add contract".try_into().unwrap(),
-        }),
-        ScMetaEntry::ScMetaV0(ScMetaV0 {
-            key: "meta_replaced".try_into().unwrap(),
-            val: "some_new_meta".try_into().unwrap(),
-        }),
-    ];
-
-    assert_eq!(entries, expected_entries);
+    .unwrap()
 }
 
 fn add_path() -> String {

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -13,7 +13,6 @@ use std::{
 };
 use stellar_xdr::curr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
-use crate::commands::contract::build::Error::DeletingArtifact;
 use crate::{commands::global, print::Print};
 
 /// Build a contract from source
@@ -96,8 +95,6 @@ pub enum Error {
     AbsolutePath(io::Error),
     #[error("creating out directory: {0}")]
     CreatingOutDir(io::Error),
-    #[error("deleting existing artifact: {0}")]
-    DeletingArtifact(io::Error),
     #[error("copying wasm file: {0}")]
     CopyingWasmFile(io::Error),
     #[error("getting the current directory: {0}")]
@@ -169,36 +166,37 @@ impl Cmd {
                 cmd.env("CARGO_BUILD_RUSTFLAGS", rustflags);
             }
 
-            let mut cmd_str_parts = Vec::<String>::new();
-            cmd_str_parts.extend(cmd.get_envs().map(|(key, val)| {
-                format!(
-                    "{}={}",
-                    key.to_string_lossy(),
-                    shell_escape::escape(val.unwrap_or_default().to_string_lossy())
-                )
-            }));
-            cmd_str_parts.push("cargo".to_string());
-            cmd_str_parts.extend(
-                cmd.get_args()
-                    .map(OsStr::to_string_lossy)
-                    .map(Cow::into_owned),
-            );
-            let cmd_str = cmd_str_parts.join(" ");
+            let mut clean_cmd = Command::new("cargo");
+            clean_cmd.stdout(Stdio::piped());
+            clean_cmd.arg("clean");
+            clean_cmd.arg(format!(
+                "--manifest-path={}",
+                manifest_path.to_string_lossy()
+            ));
+
+            let cmd_str = Self::cmd_str(&cmd);
+            let clean_cmd_str = Self::cmd_str(&clean_cmd);
 
             if self.print_commands_only {
+                println!("{clean_cmd_str}");
                 println!("{cmd_str}");
             } else {
-                print.infoln(cmd_str);
-
                 let file = format!("{}.wasm", p.name.replace('-', "_"));
                 let target_file_path = Path::new(target_dir)
                     .join(WASM_TARGET)
                     .join(&self.profile)
                     .join(&file);
 
-                if target_file_path.is_file() {
-                    fs::remove_file(&target_file_path).map_err(DeletingArtifact)?;
+                // Need to clean first to remove existing WASM file.
+                // (That could potentially be modified in handle_contract_metadata_args)
+                print.infoln(clean_cmd_str);
+
+                let status = clean_cmd.status().map_err(Error::CargoCmd)?;
+                if !status.success() {
+                    return Err(Error::Exit(status));
                 }
+
+                print.infoln(cmd_str);
 
                 let status = cmd.status().map_err(Error::CargoCmd)?;
                 if !status.success() {
@@ -221,6 +219,24 @@ impl Cmd {
         }
 
         Ok(())
+    }
+
+    fn cmd_str(cmd: &Command) -> String {
+        let mut cmd_str_parts = Vec::<String>::new();
+        cmd_str_parts.extend(cmd.get_envs().map(|(key, val)| {
+            format!(
+                "{}={}",
+                key.to_string_lossy(),
+                shell_escape::escape(val.unwrap_or_default().to_string_lossy())
+            )
+        }));
+        cmd_str_parts.push("cargo".to_string());
+        cmd_str_parts.extend(
+            cmd.get_args()
+                .map(OsStr::to_string_lossy)
+                .map(Cow::into_owned),
+        );
+        cmd_str_parts.join(" ")
     }
 
     fn features(&self) -> Option<Vec<String>> {

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use stellar_xdr::curr::{Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
+use crate::commands::contract::build::Error::DeletingArtifact;
 use crate::{commands::global, print::Print};
 
 /// Build a contract from source
@@ -31,7 +32,7 @@ use crate::{commands::global, print::Print};
 pub struct Cmd {
     /// Path to Cargo.toml
     #[arg(long)]
-    pub manifest_path: Option<PathBuf>,
+    pub manifest_path: Option<std::path::PathBuf>,
     /// Package to build
     ///
     /// If omitted, all packages that build for crate-type cdylib are built.
@@ -61,14 +62,12 @@ pub struct Cmd {
     ///
     /// If ommitted, wasm files are written only to the cargo target directory.
     #[arg(long)]
-    pub out_dir: Option<PathBuf>,
+    pub out_dir: Option<std::path::PathBuf>,
     /// Print commands to build without executing them
     #[arg(long, conflicts_with = "out_dir", help_heading = "Other")]
     pub print_commands_only: bool,
     /// Add key-value to contract meta (adds the meta to the `contractmetav0` custom section)
-    #[arg(
-        long, num_args = 1, value_parser = parse_meta_arg, action = clap::ArgAction::Append, help_heading = "Metadata"
-    )]
+    #[arg(long, num_args=1, value_parser=parse_meta_arg, action=clap::ArgAction::Append, help_heading = "Metadata")]
     pub meta: Vec<(String, String)>,
 }
 
@@ -97,6 +96,8 @@ pub enum Error {
     AbsolutePath(io::Error),
     #[error("creating out directory: {0}")]
     CreatingOutDir(io::Error),
+    #[error("deleting existing artifact: {0}")]
+    DeletingArtifact(io::Error),
     #[error("copying wasm file: {0}")]
     CopyingWasmFile(io::Error),
     #[error("getting the current directory: {0}")]
@@ -109,8 +110,6 @@ pub enum Error {
     WritingWasmFile(io::Error),
     #[error("invalid meta entry: {0}")]
     MetaArg(String),
-    #[error("providing --out-dir is required when --meta is passed")]
-    OutDirRequired,
 }
 
 const WASM_TARGET: &str = "wasm32-unknown-unknown";
@@ -132,15 +131,6 @@ impl Cmd {
                     package: package.clone(),
                 });
             }
-        }
-
-        match &self.out_dir {
-            None => {
-                if !self.meta.is_empty() {
-                    return Err(Error::OutDirRequired);
-                }
-            }
-            Some(out_dir) => fs::create_dir_all(out_dir).map_err(Error::CreatingOutDir)?,
         }
 
         for p in packages {
@@ -206,6 +196,10 @@ impl Cmd {
                     .join(&self.profile)
                     .join(&file);
 
+                if target_file_path.is_file() {
+                    fs::remove_file(&target_file_path).map_err(DeletingArtifact)?;
+                }
+
                 let status = cmd.status().map_err(Error::CargoCmd)?;
                 if !status.success() {
                     return Err(Error::Exit(status));
@@ -214,6 +208,7 @@ impl Cmd {
                 let out_file_path = match &self.out_dir {
                     None => target_file_path,
                     Some(out_dir) => {
+                        fs::create_dir_all(out_dir).map_err(Error::CreatingOutDir)?;
                         let out_file_path = Path::new(out_dir).join(&file);
                         fs::copy(target_file_path, &out_file_path)
                             .map_err(Error::CopyingWasmFile)?;
@@ -262,17 +257,17 @@ impl Cmd {
             .packages
             .iter()
             .filter(|p|
-            // Filter by the package name if one is selected based on the above logic.
-            if let Some(name) = &name {
-                &p.name == name
-            } else {
-                // Otherwise filter crates that are default members of the
-                // workspace and that build to cdylib (wasm).
-                metadata.workspace_default_members.contains(&p.id)
-                    && p.targets
-                    .iter()
-                    .any(|t| t.crate_types.iter().any(|c| c == "cdylib"))
-            }
+                // Filter by the package name if one is selected based on the above logic.
+                if let Some(name) = &name {
+                    &p.name == name
+                } else {
+                    // Otherwise filter crates that are default members of the
+                    // workspace and that build to cdylib (wasm).
+                    metadata.workspace_default_members.contains(&p.id)
+                        && p.targets
+                            .iter()
+                            .any(|t| t.crate_types.iter().any(|c| c == "cdylib"))
+                }
             )
             .cloned()
             .collect();


### PR DESCRIPTION
### What

Fixes metadata not properly written. See previous discussion in #1694

Original implementation took artifact straight from the build directory, wrote metadata there, and then copied it to destination directory (if provided).
Naturally, if no code changes happens between rebuilds, cargo will simply do nothing, as the result WASM file is unchanged according to cargo. However, we already modified it in our code previously, and we write new metadata entries in that existing WASM file.
With this change we require output dir to be specified if we writing any meta (thus ensuring WASM is first copied and only then modified). Then, do the same steps as before.

### Why

#1694

### Known limitations

It's technically a breaking change to require output dir