### PR TITLE
bump cargo-deny-action to 2.0.7

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
     continue-on-error: ${{ matrix.check == 'advisories' }}
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@0484eedcba649433ebd03d9b7c9c002746bbc4b9
+    - uses: EmbarkStudios/cargo-deny-action@8d73959fce1cdc8989f23fdf03bec6ae6a6576ef
       with:
         command: check ${{ matrix.check }}
 


### PR DESCRIPTION
### What

bump cargo-deny-action to 2.0.7

### Why

Fixes the CI (see [slack discussion](https://stellarfoundation.slack.com/archives/C06KTGUULUF/p1741050856664549))

### Known limitations

N/A
