### PR TITLE
Update ubuntu version.

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -28,7 +28,7 @@ jobs:
           - name: stellar-cli
             binary: stellar
         sys:
-          - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
+          - os: ubuntu-22.04 # Use 22 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04-arm # Use 22 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -103,7 +103,7 @@ jobs:
 
   json-schema:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - run: sudo apt-get update && sudo apt-get -y install libudev-dev libdbus-1-dev


### PR DESCRIPTION
The ubuntu-20.04 image is deprecated since Feb 1 and will be officially unsupported starting Apr 1.

### What

Update ubuntu to 22.04.

### Why

The ubuntu-20.04 image is deprecated since Feb 1 and will be officially unsupported starting Apr 1.

### Known limitations

N/A