### PR TITLE
Remove backticks from cookbook front matter

### DIFF
--- a/cookbook/tx-new.mdx
+++ b/cookbook/tx-new.mdx
@@ -1,5 +1,5 @@
 ---
-title: `tx` Commands
+title: tx Commands
 hide_table_of_contents: true
 description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-new.mdx

--- a/cookbook/tx-op-add.mdx
+++ b/cookbook/tx-op-add.mdx
@@ -1,5 +1,5 @@
 ---
-title: `tx op add`
+title: tx op add
 hide_table_of_contents: true
 description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-op-add.mdx

--- a/cookbook/tx-sign.mdx
+++ b/cookbook/tx-sign.mdx
@@ -1,5 +1,5 @@
 ---
-title: `tx sign` and `tx send`
+title: tx sign and tx send
 hide_table_of_contents: true
 description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-sign.mdx


### PR DESCRIPTION
### What

This PR removes the backticks in the cookbook front matter titles. 

### Why

We were seeing a failure in the dev docs build with the following error:
```
Error:  Error while parsing Markdown front matter.
...
[cause]: YAMLException: end of the stream or a document separator is expected at line 2, column 8:
        title: `tx` Commands

```

### Known limitations

[TODO or N/A]
