### PR TITLE
fix incompatible frontmatter in tx cookbock files

### DIFF
--- a/cookbook/tx-new.mdx
+++ b/cookbook/tx-new.mdx
@@ -1,5 +1,5 @@
 ---
-title: `tx` Commands
+title: Create new Stellar transactions
 hide_table_of_contents: true
 description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-new.mdx

--- a/cookbook/tx-op-add.mdx
+++ b/cookbook/tx-op-add.mdx
@@ -1,5 +1,5 @@
 ---
-title: `tx op add`
+title: Add an operation to a Stellar transaction
 hide_table_of_contents: true
 description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-op-add.mdx
@@ -15,7 +15,7 @@ Let's consider a more complicated example. Consider issuing an asset, here `USDC
 ```sh
 
 stellar keys generate --fund issuer
-stellar keys generate --fund distributor 
+stellar keys generate --fund distributor
 
 ISSUER_PK=$(stellar keys address issuer)
 
@@ -39,7 +39,7 @@ stellar tx new set-options --fee 1000 --source issuer --set-clawback-enabled --s
 | stellar tx sign --sign-with-key distributor \
 | stellar tx send
 
-# Next is an example of sandwiching an operation. That is giving permission in one operation, preforming the operation, and then removing the permission in a third operation. 
+# Next is an example of sandwiching an operation. That is giving permission in one operation, preforming the operation, and then removing the permission in a third operation.
 # Here is an example of minting new assets to the distributor with a sandwich transaction
 # First authorize the distributor to receive the asset
 stellar tx new set-trustline-flags --fee 1000 --build-only --source issuer --asset $ASSET --trustor $distributor_PK --set-authorize \

--- a/cookbook/tx-sign.mdx
+++ b/cookbook/tx-sign.mdx
@@ -1,18 +1,18 @@
 ---
-title: `tx sign` and `tx send`
+title: Sign and send Stellar transactions
 hide_table_of_contents: true
 description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-sign.mdx
 ---
 
-The previous examples of using `tx new` showed how to create transactions. However, these transactions were immediately ready to be signed and submitted to the network. 
+The previous examples of using `tx new` showed how to create transactions. However, these transactions were immediately ready to be signed and submitted to the network.
 
 To avoid this each of the subcommands has the `--build-only` argument, which as the name suggests only builds the transaction and prints the transaction envelope.
 
 ## `tx sign`
 
 Let's return to the first example of creating `bob`s account:
-  
+
   ```sh
 stellar tx new create-account \
     --source alice \
@@ -21,7 +21,7 @@ stellar tx new create-account \
     --build-only
   ```
   would output something like:
-  
+
 ```sh
 AAAAAgAAAADwSUp9CwmVlPN40mKX1I1j39y6DmYc36QS1aK2x6eYVQAAAGQAEcMsAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAACTMkzn1TwPo8SIhnKvnyuv9K2/aWjpX9NTYfyiA7vXaAAAAAAX14QAAAAAAAAAAAA==
 ```


### PR DESCRIPTION
### What

remove the backticks from frontmatter titles in some cookbook files

### Why

docs builds are breaking

### Known limitations

the pre-push git hook is giving me some kind of error that i don't really understand
