### PR TITLE
Update ring dependency (to fix cargo deny advisories)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,12 +758,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -3693,15 +3694,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2024-0388", # derivative is no longer maintained, but that has no known material impact on the this repo
+    "RUSTSEC-2024-0436", # paste is no longer maintained
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ yanked = "warn"
 ignore = [
     "RUSTSEC-2024-0388", # derivative is no longer maintained, but that has no known material impact on the this repo
     "RUSTSEC-2024-0436", # paste is no longer maintained
+    "RUSTSEC-2025-0014", # humantime may no longer be maintained
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
### What

Update ring dependency.

### Why

I was seeing a cargo deny error that `ring v0.17.8` has a security vulnerability:

```
error[vulnerability]: Some AES functions may panic when overflow checking is enabled.
    ┌─ /Users/ebethme/Desktop/projects/stellar/stellar-cli/Cargo.lock:334:1
    │
334 │ ring 0.17.8 registry+https://github.com/rust-lang/crates.io-index
    │ ----------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2025-0009
```

### Known limitations

There is also an error about `paste` no longer being maintained that I added to the ignore list - happy to rethink this!