### PR TITLE
Update error message on missing network

### DIFF
--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -26,7 +26,7 @@ pub enum Error {
         r#"Access to the network is required
 `--network` or `--rpc-url` and `--network-passphrase` are required if using the network.
 Network configuration can also be set using `network use` subcommand. For example, to use
-testnet simply type `stellar network use testnet`
+testnet, run `stellar network use testnet`.
 Alternatively you can use their corresponding environment variables:
 STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE"#
     )]

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -25,10 +25,10 @@ pub enum Error {
     #[error(
         r#"Access to the network is required
 `--network` or `--rpc-url` and `--network-passphrase` are required if using the network.
-Alternatively you can use their corresponding environment variables:
-STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE
 Network configuration can also be set using `network use` subcommand. For example, to use
-testnet simply type `stellar network use testnet`"#
+testnet simply type `stellar network use testnet`
+Alternatively you can use their corresponding environment variables:
+STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE"#
     )]
     Network,
     #[error(

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -26,7 +26,9 @@ pub enum Error {
         r#"Access to the network is required
 `--network` or `--rpc-url` and `--network-passphrase` are required if using the network.
 Alternatively you can use their corresponding environment variables:
-STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE"#
+STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE
+Network configuration can also be set using `network use` subcommand. For example, to use
+testnet simply type `stellar network use testnet`"#
     )]
     Network,
     #[error(


### PR DESCRIPTION
### What

We should encourage users using `network use` instead of env variables 

### Why

Improving error message and usability

### Known limitations

N/A