### PR TITLE
Remove package step from binary build workflow for releases

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -54,21 +54,9 @@ jobs:
         echo "VERSION=${version}" >> $GITHUB_ENV
         echo "NAME=${{ matrix.crate.name }}-${version}-${{ matrix.sys.target }}" >> $GITHUB_ENV
 
-    - name: Package (release only)
-      if: github.event_name == 'release'
-      run: cargo package --no-verify --package ${{ matrix.crate.name }}
-
-    - name: Package Extract (release only)
-      if: github.event_name == 'release'
-      run: |
-        cd target/package
-        tar xvfz ${{ matrix.crate.name }}-$VERSION.crate
-        echo "BUILD_WORKING_DIR=target/package/${{ matrix.crate.name }}-$VERSION" >> $GITHUB_ENV
-
     - name: Build
-      working-directory: ${{ env.BUILD_WORKING_DIR }}
       run: |
-        cargo build --target-dir="$GITHUB_WORKSPACE/target" --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
+        cargo build --package ${{ matrix.crate.name }} --features opt --release --target ${{ matrix.sys.target }}
 
     - name: Build provenance for attestation (release only)
       if: github.event_name == 'release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, cargo-deny, check-generated-full-help-docs, build-and-test, publish-dry-run]
+    needs: [fmt, cargo-deny, check-generated-full-help-docs, build-and-test, disallow-git-deps, publish-dry-run]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -97,6 +97,23 @@ jobs:
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         CARGO_BUILD_TARGET: ${{ matrix.sys.target }}
+
+  disallow-git-deps:
+    # This job fails if a release is being prepared and there are still crate
+    # dependencies in the Cargo.toml files that reference dependencies via git.
+    # Git dependencies should not be set when releasing because the binary
+    # builds that happen based on the local source, and the published crate,
+    # may not build to be the same. This is because when the crate is published
+    # the git dependencies are stripped out automatically, but when building
+    # locally they'd still be present. The presence of git dependencies at
+    # release time in any case is probably a bug.
+    if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check that Cargo.tomls do not contain git dependencies for release
+      run: |
+        ! git --no-pager grep 'git\s*=' -- Cargo.toml **/Cargo.toml
 
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')


### PR DESCRIPTION
### What
Remove packaging steps in the GitHub workflow for building binaries.

### Why
When I wrote the binary build workflow, my goal was to have it match installing from cargo install as closely as possible. For that goal I had the build occur using a locally built package, generated with `cargo package`. This worked fine when the stellar-cli was a single crate in this repo.

When we started adding additional crates to the repo this approach became flawed. The cargo package process doesn't have any workspace intelligence built in, so it needs any dependencies to have already been published to crates.io.

While flawed, the binary builds continued to work for a time because the cargo publish was always occurring before the binary build step because both occurred in the same workflow.

At some point I split the binary build and publish workflows up, because I wanted binary builds to occur on PRs too. At that point in time the binary builds started to fail during release with packaging failing because the dependencies aren't published to crates.io yet.

We don't have to package before hand, and packaging before hand is a bit odd here, because what's actually happening is we're packaging the `stellar-cli` crate locally, and during build building against the `soroban-cli` crate on crates.io. If we want to keep building against the released / packaged crate, we should build from one source, either the whole workspace locally, or the whole workspace from crates.io. If we want to keep packaging locally we'd need to do some cargo-fu like what happens in the publish-dry-run workflow to basically build our own registry locally, then build from there. Given the pain we've experienced maintaining the cargo-fu in the publish-dry-run workflow, I don't think this is the wisest option even if it would feel more perfect from an engineering perspective.

This change simply removes the packaging steps and builds locally. There's some risk here that things like git revs are in the toml file and that the binary builds with them instead of without them like how the crate when packaged would. I think this risk is the right tradeoff given the above thoughts. To remove the risk of building a release against git builds we can add an additional check to publish-dry-run to disallow releasing if there are any git refs in the toml file.