### PR TITLE
Fix `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ runs:
     id: version
     shell: bash
     run: |
+      echo "${{ inputs.version }}"
+      echo "${{ inputs.version == '' }}"
+      echo "${{ inputs.version != '' && inputs.version || github.action_ref}}"
+      echo "${{ inputs.version || 'test'}}"
       echo "version=${{ inputs.version || github.action_ref }}" >> "$GITHUB_OUTPUT"
   - name: Copy binary to install location
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,10 @@ runs:
     id: version
     shell: bash
     run: |
-      echo "${{ inputs.version }}"
-      echo "${{ inputs.version == '' }}"
-      echo "${{ inputs.version != '' && inputs.version || github.action_ref}}"
-      echo "${{ inputs.version || 'test'}}"
-      echo "version=${{ inputs.version || github.action_ref }}" >> "$GITHUB_OUTPUT"
+      echo "using version: $VERSION"
+      echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+    env:
+      VERSION: ${{ inputs.version || github.action_ref }}
   - name: Copy binary to install location
     shell: bash
     run: |


### PR DESCRIPTION
### What

Fix `action.yml`

Example [run after fix](https://github.com/stellar/soroban-examples/actions/runs/13820848385/job/38665604577?pr=368)
```
 using version: a06ff9fd2bcd9e45a86ec3518b1a83bde898b32a
Run version="a06ff9fd2bcd9e45a86ec3518b1a83bde898b32a"
https://github.com/stellar/stellar-cli/releases/download/va06ff9fd2bcd9e45a86ec3518b1a83bde898b32a/stellar-cli-a06ff9fd2bcd9e45a86ec3518b1a83bde898b32a-x86_64-unknown-linux-gnu.tar.gz
```

Example [run before fix
](https://github.com/stellar/soroban-examples/actions/runs/13820464519/job/38664345285)
```
Run version=""
https://github.com/stellar/stellar-cli/releases/download/v/stellar-cli--x86_64-unknown-linux-gnu.tar.gz

```

### Why

We got github action'd

https://github.com/orgs/community/discussions/49245

TLDR: `version=${{ inputs.version || github.action_ref }}` only works if it's in env, and won't work if it's in `run`
See [doc](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)

### Known limitations

[TODO or N/A]
