### PR TITLE
Change macos runner

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -34,7 +34,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin
-          - os: macos-14
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
         - os: ubuntu-jammy-16-cores-arm64
           target: aarch64-unknown-linux-gnu
-        - os: macos-latest
+        - os: macos-13
           target: x86_64-apple-darwin
         - os: macos-latest
           target: aarch64-apple-darwin
@@ -130,7 +130,7 @@ jobs:
         #  target: aarch64-unknown-linux-gnu
         #  cargo-hack-feature-options: --feature-powerset
         #  additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev
-        - os: macos-latest
+        - os: macos-13
           target: x86_64-apple-darwin
           cargo-hack-feature-options: --feature-powerset
         - os: macos-latest


### PR DESCRIPTION
### What

Downgrade macos runner to 13

### Why

This is the latest macos runner on Intel. We currently use ARM runner for our x86-64 builds and tests, but Intel runner should provide a native experience (i.e. we will catch if there's any potential x86-64 issue specifically on Macos, for external libraries/e2e integration, etc.) 

### Known limitations

Previously used runner is v14, but there shouldn't be any issues with downgrading
