### PR TITLE
Remove default seed option from generate command

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1093,7 +1093,6 @@ Generate a new identity using a 24-word seed phrase The seed phrase can be store
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
 * `--hd-path <HD_PATH>` — When generating a secret key, which `hd_path` should be used from the original `seed_phrase`
-* `-d`, `--default-seed` — Generate the default seed phrase. Useful for testing. Equivalent to --seed 0000000000000000
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server

--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -40,7 +40,7 @@ pub struct Cmd {
 
     /// Optional seed to use when generating seed phrase.
     /// Random otherwise.
-    #[arg(long, conflicts_with = "default_seed")]
+    #[arg(long)]
     pub seed: Option<String>,
 
     /// Output the generated identity as a secret key
@@ -57,11 +57,6 @@ pub struct Cmd {
     /// When generating a secret key, which `hd_path` should be used from the original `seed_phrase`.
     #[arg(long)]
     pub hd_path: Option<usize>,
-
-    /// Generate the default seed phrase. Useful for testing.
-    /// Equivalent to --seed 0000000000000000
-    #[arg(long, short = 'd', conflicts_with = "seed")]
-    pub default_seed: bool,
 
     #[command(flatten)]
     pub network: network::Args,
@@ -142,11 +137,7 @@ impl Cmd {
     }
 
     fn seed_phrase(&self) -> Result<SeedPhrase, Error> {
-        Ok(if self.default_seed {
-            secret::test_seed_phrase()
-        } else {
-            secret::seed_phrase_from_seed(self.seed.as_deref())
-        }?)
+        Ok(secret::seed_phrase_from_seed(self.seed.as_deref())?)
     }
 }
 
@@ -171,7 +162,6 @@ mod tests {
             secure_store: false,
             config_locator: locator.clone(),
             hd_path: None,
-            default_seed: false,
             network: super::network::Args::default(),
             fund: false,
             overwrite: false,

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -161,10 +161,6 @@ impl Secret {
     pub fn from_seed(seed: Option<&str>) -> Result<Self, Error> {
         Ok(seed_phrase_from_seed(seed)?.into())
     }
-
-    pub fn test_seed_phrase() -> Result<Self, Error> {
-        Self::from_seed(Some("0000000000000000"))
-    }
 }
 
 pub fn seed_phrase_from_seed(seed: Option<&str>) -> Result<SeedPhrase, Error> {
@@ -173,10 +169,6 @@ pub fn seed_phrase_from_seed(seed: Option<&str>) -> Result<SeedPhrase, Error> {
     } else {
         sep5::SeedPhrase::random(sep5::MnemonicType::Words24)?
     })
-}
-
-pub fn test_seed_phrase() -> Result<SeedPhrase, Error> {
-    Ok("0000000000000000".parse()?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What
Remove default seed option from generate command.

### Why
It appears to be broken:

```
$ stellar keys generate --default-seed issuer
⚠️ Behavior of `generate` will change in the future, and it will no longer fund by default. If you want to fund please provide `--fund` flag. If you don't need to fund your keys in the future, ignore this warning. It can be suppressed with -q flag.
❌ error: invalid word in phrase
```

We could fix it, but if it's broken and no one has noticed it suggests it isn't being used anywhere. I believe it was added for testing at some point, but it also scares me a bit that there's an option on the key generation command that results in a fixed test key getting used. There's no case where that should be used in the production release.