### PR TITLE
Add default json structure when calling `stellar tx edit`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1550,7 +1550,15 @@ Sign, Simulate, and Send transactions
 
 ## `stellar tx edit`
 
-Edit a transaction envelope from stdin. This command respects the environment variables `STELLAR_EDITOR`, `EDITOR` and `VISUAL`, in that order
+Edit a transaction envelope from stdin. This command respects the environment variables `STELLAR_EDITOR`, `EDITOR` and `VISUAL`, in that order.
+
+Example: Start a new edit session
+
+$ stellar tx edit
+
+Example: Pipe an XDR transaction envelope
+
+$ stellar tx new manage-data --data-name hello --build-only | stellar tx edit
 
 **Usage:** `stellar tx edit`
 

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -17,6 +17,15 @@ pub use args::Args;
 pub enum Cmd {
     /// Edit a transaction envelope from stdin. This command respects the environment variables
     /// `STELLAR_EDITOR`, `EDITOR` and `VISUAL`, in that order.
+    ///
+    /// Example: Start a new edit session
+    ///
+    /// $ stellar tx edit
+    ///
+    /// Example: Pipe an XDR transaction envelope
+    ///
+    /// $ stellar tx new manage-data --data-name hello --build-only | stellar tx edit
+    ///
     Edit(edit::Cmd),
     /// Calculate the hash of a transaction envelope
     Hash(hash::Cmd),


### PR DESCRIPTION
### What

Add default json structure when calling `stellar tx edit` without piping. It also updates the help message with an example:

```
$ stellar tx edit --help
Edit a transaction envelope from stdin. This command respects the environment variables `STELLAR_EDITOR`, `EDITOR` and `VISUAL`, in that order.

Example: Start a new edit session

$ stellar tx edit

Example: Pipe an XDR transaction envelope

$ stellar tx new manage-data --data-name hello --build-only | stellar tx edit
```

### Why

It's a better ux overall. It gives users the ability to explore the transaction editing from zero.

### Known limitations

N/A
