### PR TITLE
Add env lookup by name

### DIFF
--- a/cmd/soroban-cli/src/commands/env/mod.rs
+++ b/cmd/soroban-cli/src/commands/env/mod.rs
@@ -7,6 +7,10 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {
+    /// Env variable name to get the value of.
+    #[arg()]
+    pub name: Option<String>,
+
     #[command(flatten)]
     pub config_locator: locator::Args,
 }
@@ -20,7 +24,7 @@ pub enum Error {
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = Print::new(global_args.quiet);
-        let mut lines: Vec<(String, String)> = Vec::new();
+        let mut lines: Vec<EnvVar> = Vec::new();
 
         if let Some(data) = get("STELLAR_NETWORK") {
             lines.push(data);
@@ -30,32 +34,56 @@ impl Cmd {
             lines.push(data);
         }
 
+        if let Some(name) = &self.name {
+            if let Some(entry) = lines.iter().find(|var| &var.key == name) {
+                println!("{}", entry.value);
+            }
+            Ok(())
+        }
+
         if lines.is_empty() {
             print.warnln("No defaults or environment variables set".to_string());
             return Ok(());
         }
 
-        let max_len = lines.iter().map(|l| l.0.len()).max().unwrap_or(0);
+        let max_len = lines.iter().map(|v| v.str().len()).max().unwrap_or(0);
 
         lines.sort();
 
-        for (value, source) in lines {
-            println!("{value:max_len$} # {source}");
+        for var in lines {
+            println!("{:max_len$} # {}", var.str(), var.source);
         }
 
         Ok(())
     }
 }
 
-fn get(env_var: &str) -> Option<(String, String)> {
-    // The _SOURCE env var is set from cmd/soroban-cli/src/cli.rs#set_env_value_from_config
-    let source = std::env::var(format!("{env_var}_SOURCE"))
-        .ok()
-        .unwrap_or("env".to_string());
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct EnvVar {
+    key: String,
+    value: String,
+    source: String,
+}
 
-    if let Ok(value) = std::env::var(env_var) {
-        return Some((format!("{env_var}={value}"), source));
+impl EnvVar {
+    fn get(key: &str) -> Option<Self> {
+        // The _SOURCE env var is set from cmd/soroban-cli/src/cli.rs#set_env_value_from_config
+        let source = std::env::var(format!("{key}_SOURCE"))
+            .ok()
+            .unwrap_or("env".to_string());
+
+        if let Ok(value) = std::env::var(key) {
+            return Some(EnvVar {
+                key: env_var.to_string(),
+                value,
+                source,
+            });
+        }
+
+        None
     }
 
-    None
+    fn str(&self) -> String {
+        format!("{}={}", self.key, self.value)
+    }
 }


### PR DESCRIPTION
### What
Add ability to lookup env config values by name with the `stellar env` command.

### Why
Allow scripts to parse specific environment variables programmatically, to retrieve them and display them places. Helpful for integrating the stellar-cli into things like a shell prompt, or use in scripting.

The format and behaviour of the command is modeled after the `go env` command that works identically.