### PR TITLE
Disable publishing soroban-test crate

### DIFF
--- a/cmd/crates/soroban-test/Cargo.toml
+++ b/cmd/crates/soroban-test/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 autobins = false
+publish = false
 
 
 [lib]


### PR DESCRIPTION
### What
Prevent the soroban-test crate from being published to crates.io by setting publish=false in Cargo.toml.

### Why
The soroban-test crate is intended for internal use only and should not be available on crates.io. While we can publish it, it introduces a lot of builds into the publish-dry-run workflow. It's unclear why it's being published, so unpublishing it for the time being seems okay. If someone brings it to our attention that publishing had some value, we can return to doing so as needed.

Close https://github.com/stellar/stellar-cli/issues/1969