### PR TITLE
Fix cargo-hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,7 +153,7 @@ jobs:
           target: x86_64-pc-windows-msvc
           cargo-hack-feature-options: --features opt --ignore-unknown-features
 
-    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@72eef253eda395a9787c91981b281db4ca988691
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
     with:
       runs-on: ${{ matrix.os }}
       target: ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,26 +116,25 @@ jobs:
         ! git --no-pager grep 'git\s*=' -- Cargo.toml **/Cargo.toml
 
   publish-dry-run:
-    if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
+   ## if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest-16-cores
           target: x86_64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
           additional-deb-packages: libudev-dev libdbus-1-dev
-        # TODO: add back ARM support
-        #- os: ubuntu-latest-16-cores
-        #  target: aarch64-unknown-linux-gnu
-        #  cargo-hack-feature-options: --feature-powerset
-        #  additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev
+        - os: ubuntu-latest-16-cores
+          target: aarch64-unknown-linux-gnu
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
+          additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev
         - os: macos-13
           target: x86_64-apple-darwin
-          cargo-hack-feature-options: --feature-powerset
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
         - os: macos-latest
           target: aarch64-apple-darwin
-          cargo-hack-feature-options: --feature-powerset
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
         # Windows builds notes:
         #
         # The different features that need testing are split over unique

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
           additional-deb-packages: libudev-dev libdbus-1-dev
-        - os: ubuntu-latest-16-cores
+        - os: ubuntu-jammy-16-cores-arm64
           target: aarch64-unknown-linux-gnu
           cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
           additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,7 +153,7 @@ jobs:
           target: x86_64-pc-windows-msvc
           cargo-hack-feature-options: --features opt --ignore-unknown-features
 
-    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@72eef253eda395a9787c91981b281db4ca988691
     with:
       runs-on: ${{ matrix.os }}
       target: ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,7 +116,7 @@ jobs:
         ! git --no-pager grep 'git\s*=' -- Cargo.toml **/Cargo.toml
 
   publish-dry-run:
-   ## if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
+    if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,18 +123,18 @@ jobs:
         include:
         - os: ubuntu-latest-16-cores
           target: x86_64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
           additional-deb-packages: libudev-dev libdbus-1-dev
         - os: ubuntu-jammy-16-cores-arm64
           target: aarch64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
           additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev
         - os: macos-13
           target: x86_64-apple-darwin
-          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
         - os: macos-latest
           target: aarch64-apple-darwin
-          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features
+          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
         # Windows builds notes:
         #
         # The different features that need testing are split over unique

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,10 +125,10 @@ jobs:
           target: x86_64-unknown-linux-gnu
           cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
           additional-deb-packages: libudev-dev libdbus-1-dev
-        - os: ubuntu-jammy-16-cores-arm64
-          target: aarch64-unknown-linux-gnu
-          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
-          additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev
+#        - os: ubuntu-jammy-16-cores-arm64
+#          target: aarch64-unknown-linux-gnu
+#          cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features
+#          additional-deb-packages: libudev-dev libssl-dev libdbus-1-dev
         - os: macos-13
           target: x86_64-apple-darwin
           cargo-hack-feature-options: --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-unknown-features

--- a/cmd/stellar-cli/Cargo.toml
+++ b/cmd/stellar-cli/Cargo.toml
@@ -26,6 +26,8 @@ bin-dir = "{ bin }{ binary-ext }"
 
 [features]
 default = []
+version_lt_23 = []
+version_gte_23 = []
 opt = ["soroban-cli/opt"]
 emulator-tests = ["soroban-cli/emulator-tests"]
 

--- a/cmd/stellar-cli/Cargo.toml
+++ b/cmd/stellar-cli/Cargo.toml
@@ -26,8 +26,6 @@ bin-dir = "{ bin }{ binary-ext }"
 
 [features]
 default = []
-version_lt_23 = []
-version_gte_23 = []
 opt = ["soroban-cli/opt"]
 emulator-tests = ["soroban-cli/emulator-tests"]
 


### PR DESCRIPTION
### What

Fixes publish-dry-run with reducing number of permutations down to 11
```
 > cargo-hack hack --feature-powerset --skip version_gte_23,emulator-tests --group-features default,version_lt_23 --ignore-private --ignore-unknown-features --print-command-list package        
cargo package --manifest-path cmd/stellar-cli/Cargo.toml --no-default-features
cargo package --manifest-path cmd/stellar-cli/Cargo.toml --no-default-features --features opt
cargo package --manifest-path cmd/soroban-cli/Cargo.toml --no-default-features
cargo package --manifest-path cmd/soroban-cli/Cargo.toml --no-default-features --features opt,default,version_lt_23
cargo package --manifest-path cmd/soroban-cli/Cargo.toml --no-default-features --features opt
cargo package --manifest-path cmd/soroban-cli/Cargo.toml --no-default-features --features default,version_lt_23
cargo package --manifest-path cmd/crates/soroban-spec-json/Cargo.toml
cargo package --manifest-path cmd/crates/soroban-spec-tools/Cargo.toml
cargo package --manifest-path cmd/crates/soroban-spec-typescript/Cargo.toml
cargo package --manifest-path cmd/crates/stellar-ledger/Cargo.toml --no-default-features
cargo package --manifest-path cmd/crates/stellar-ledger/Cargo.toml --no-default-features --features http-transport
```

### Why

Fixes #1949

### Known limitations

Depends on https://github.com/stellar/actions/pull/89