### PR TITLE
Upload cookbook docs to artifacts

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Compress
         run: |
-          tar czvf ${{ env.NAME }}.tar.gz cookbook
+          tar czvf ${{ env.NAME }}.tar.gz cookbook FULL_HELP_DOCS.md
 
       - name: Upload to Artifacts
         uses: ./.github/actions/artifact-upload

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -106,3 +106,24 @@ jobs:
         with:
           name: ${{ env.STELLAR_CLI_INSTALLER }}
           path: ${{ env.STELLAR_CLI_INSTALLER }}
+
+  cookbook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup vars
+        run: |
+          version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stellar-cli") | .version')"
+          echo "VERSION=${version}" >> $GITHUB_ENV
+          echo "NAME=stellar-cli-${version}-docs-cookbook" >> $GITHUB_ENV
+
+      - name: Compress
+        run: |
+          tar czvf ${{ env.NAME }}.tar.gz cookbook
+
+      - name: Upload to Artifacts
+        uses: ./.github/actions/artifact-upload
+        with:
+          name: ${{ env.NAME }}.tar.gz
+          path: ${{ env.NAME }}.tar.gz

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -116,14 +116,21 @@ jobs:
         run: |
           version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stellar-cli") | .version')"
           echo "VERSION=${version}" >> $GITHUB_ENV
-          echo "NAME=stellar-cli-${version}-docs-cookbook" >> $GITHUB_ENV
+          echo "COOKBOOK=stellar-cli-${version}-docs-cookbook.tar.gz" >> $GITHUB_ENV
+          echo "FULL_HELP_DOCS=stellar-cli-${version}-docs-user-manual.md" >> $GITHUB_ENV
 
       - name: Compress
         run: |
-          tar czvf ${{ env.NAME }}.tar.gz cookbook FULL_HELP_DOCS.md
+          tar czvf ${{ env.COOKBOOK }} cookbook
 
       - name: Upload to Artifacts
         uses: ./.github/actions/artifact-upload
         with:
-          name: ${{ env.NAME }}.tar.gz
-          path: ${{ env.NAME }}.tar.gz
+          name: ${{ env.COOKBOOK }}
+          path: ${{ env.COOKBOOK }}
+
+      - name: Upload to Artifacts
+        uses: ./.github/actions/artifact-upload
+        with:
+          name: ${{ env.FULL_HELP_DOCS }}
+          path: ${{ env.FULL_HELP_DOCS }}


### PR DESCRIPTION
### What

Uploads cookbook docs to artifacts

### Why

To decouple cookbook docs from our actual release and avoid potential breakage
docs PR: https://github.com/stellar/stellar-docs/pull/1439

### Known limitations

I manually uploaded artifact produced by the latest run to 22.6.0 release