### PR TITLE
Add `network health` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4823,8 +4823,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-rpc-client"
-version = "22.0.0"
-source = "git+https://github.com/stellar/rs-stellar-rpc-client?branch=get-health#034a202d651e9e0eb93d752fe0793f999c841082"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ce469900dde4426b3456692fd2778ac9c50d55195aed93188f153358b71f63"
 dependencies = [
  "clap",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4824,8 +4824,7 @@ dependencies = [
 [[package]]
 name = "stellar-rpc-client"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4daeb7f113802cc4bcce8736be32bde243e8e2bf29dda76614b949ed445cf"
+source = "git+https://github.com/stellar/rs-stellar-rpc-client?branch=get-health#034a202d651e9e0eb93d752fe0793f999c841082"
 dependencies = [
  "clap",
  "hex",
@@ -4844,7 +4843,6 @@ dependencies = [
  "termcolor_output",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,7 @@ version = "=22.0.4"
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-#version = "=22.0.0"
-git = "https://github.com/stellar/rs-stellar-rpc-client"
-branch = "get-health"
+version = "=22.1.0"
 
 [workspace.dependencies.stellar-ledger]
 version = "=22.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,9 @@ version = "=22.0.4"
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-version = "=22.0.0"
+#version = "=22.0.0"
+git = "https://github.com/stellar/rs-stellar-rpc-client"
+branch = "get-health"
 
 [workspace.dependencies.stellar-ledger]
 version = "=22.6.0"

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1194,6 +1194,7 @@ Configure connection to networks
 * `stop` — ⚠️ Deprecated: use `stellar container stop` instead
 * `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
 * `container` — ⚠️ Deprecated: use `stellar container` instead
+* `health` — Gets network health
 
 
 
@@ -1402,6 +1403,35 @@ Stop a network container started with `stellar container start`
 ###### **Options:**
 
 * `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
+
+
+
+## `stellar network health`
+
+Gets network health
+
+**Usage:** `stellar network health [OPTIONS]`
+
+###### **Options:**
+
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>` — Location of config directory, default is "."
+* `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`:
+    Text output of network health status
+  - `json`:
+    JSON result of the RPC request
+  - `json-formatted`:
+    Formatted (multiline) JSON output of the RPC request
+
 
 
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1194,7 +1194,7 @@ Configure connection to networks
 * `stop` — ⚠️ Deprecated: use `stellar container stop` instead
 * `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
 * `container` — ⚠️ Deprecated: use `stellar container` instead
-* `health` — Gets network health
+* `health` — Checks the health of the configured RPC
 
 
 
@@ -1408,7 +1408,7 @@ Stop a network container started with `stellar container start`
 
 ## `stellar network health`
 
-Gets network health
+Checks the health of the configured RPC
 
 **Usage:** `stellar network health [OPTIONS]`
 

--- a/cmd/soroban-cli/src/commands/network/health.rs
+++ b/cmd/soroban-cli/src/commands/network/health.rs
@@ -47,7 +47,7 @@ impl Cmd {
                     } else {
                         print.warnln(format!("Status: {}", resp.status));
                     }
-                    println!("Latest ledger: {}", resp.latest_ledger);
+                    print.infoln(format!("Latest ledger: {}", resp.latest_ledger));
                 }
                 OutputFormat::Json => println!("{}", serde_json::to_string(&resp)?),
                 OutputFormat::JsonFormatted => println!("{}", serde_json::to_string_pretty(&resp)?),

--- a/cmd/soroban-cli/src/commands/network/health.rs
+++ b/cmd/soroban-cli/src/commands/network/health.rs
@@ -42,15 +42,19 @@ impl Cmd {
         match result {
             Ok(resp) => match self.output {
                 OutputFormat::Text => {
-                    print.emoji_println('🟢', "Healthy");
+                    if resp.status.to_ascii_lowercase() == "healthy" {
+                        print.checkln("Healthy");
+                    } else {
+                        print.warnln(format!("Status: {}", resp.status));
+                    }
                     println!("Latest ledger: {}", resp.latest_ledger);
                 }
                 OutputFormat::Json => println!("{}", serde_json::to_string(&resp)?),
                 OutputFormat::JsonFormatted => println!("{}", serde_json::to_string_pretty(&resp)?),
             },
             Err(err) => {
+                print.errorln("Unhealthy");
                 print.errorln(format!("failed to fetch network health: {err}"));
-                print.emoji_println('🔴', "Unhealthy");
             }
         }
 

--- a/cmd/soroban-cli/src/commands/network/health.rs
+++ b/cmd/soroban-cli/src/commands/network/health.rs
@@ -1,0 +1,59 @@
+use crate::commands::global;
+use crate::config::network;
+use crate::{config, print};
+use clap::command;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]
+pub enum OutputFormat {
+    /// Text output of network health status
+    #[default]
+    Text,
+    /// JSON result of the RPC request
+    Json,
+    /// Formatted (multiline) JSON output of the RPC request
+    JsonFormatted,
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config: config::ArgsLocatorAndNetwork,
+    /// Format of the output
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+}
+
+impl Cmd {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = print::Print::new(global_args.quiet);
+        let result = self.config.get_network()?.rpc_client()?.get_health().await;
+
+        match result {
+            Ok(resp) => match self.output {
+                OutputFormat::Text => {
+                    print.emoji_println('🟢', "Healthy");
+                    println!("Latest ledger: {}", resp.latest_ledger);
+                }
+                OutputFormat::Json => println!("{}", serde_json::to_string(&resp)?),
+                OutputFormat::JsonFormatted => println!("{}", serde_json::to_string_pretty(&resp)?),
+            },
+            Err(err) => {
+                print.errorln(format!("failed to fetch network health: {err}"));
+                print.emoji_println('🔴', "Unhealthy");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -51,7 +51,7 @@ pub enum Cmd {
     #[command(subcommand)]
     Container(crate::commands::container::Cmd),
 
-    /// Gets network health
+    /// Checks the health of the configured RPC
     Health(health::Cmd),
 }
 

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 pub mod add;
 pub mod default;
-mod health;
+pub mod health;
 pub mod ls;
 pub mod rm;
 

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -30,6 +30,12 @@ impl Print {
         }
     }
 
+    pub fn emoji_println<T: Display + Sized, R: Display + Sized>(&self, icon: R, message: T) {
+        if !self.quiet {
+            eprintln!("{} {}", self.compute_emoji(icon), message);
+        }
+    }
+
     pub fn clear_line(&self) {
         if cfg!(windows) {
             eprint!("\r");

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -30,12 +30,6 @@ impl Print {
         }
     }
 
-    pub fn emoji_println<T: Display + Sized, R: Display + Sized>(&self, icon: R, message: T) {
-        if !self.quiet {
-            eprintln!("{} {}", self.compute_emoji(icon), message);
-        }
-    }
-
     pub fn clear_line(&self) {
         if cfg!(windows) {
             eprint!("\r");


### PR DESCRIPTION
### What

Adds `network health` command

```
> cargo run network health --network=local
❌ Unhealthy
❌ failed to fetch network health: Networking or low-level protocol error: HTTP error: error trying to connect: tcp connect error: Connection refused (os error 111)
> cargo run network health              
✅ Healthy
ℹ️ Latest ledger: 104038
> cargo run network health --output json-formatted
{
  "status": "healthy",
  "latestLedger": 104044,
  "oldestLedger": 256,
  "ledgerRetentionWindow": 120960
}
```


### Why

Closing #1913

### Known limitations

Depends on https://github.com/stellar/rs-stellar-rpc-client/pull/24
