### PR TITLE
Update invoke example values for numeric and byte types

### DIFF
--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -1213,24 +1213,24 @@ impl Spec {
     #[must_use]
     pub fn example(&self, type_: &ScType) -> Option<String> {
         match type_ {
-            ScType::U64 => Some("42".to_string()),
-            ScType::I64 => Some("-42".to_string()),
-            ScType::U128 => Some("\"1000\"".to_string()),
-            ScType::I128 => Some("\"-100\"".to_string()),
+            ScType::U64 => Some("1".to_string()),
+            ScType::I64 => Some("1".to_string()),
+            ScType::U128 => Some("\"1\"".to_string()),
+            ScType::I128 => Some("\"1\"".to_string()),
             ScType::U32 => Some("1".to_string()),
-            ScType::I32 => Some("-1".to_string()),
+            ScType::I32 => Some("1".to_string()),
             ScType::Bool => Some("true".to_string()),
             ScType::Symbol => Some("\"hello\"".to_string()),
             ScType::Error => Some("Error".to_string()),
-            ScType::Bytes => Some("\"beefface123\"".to_string()),
+            ScType::Bytes => Some("\"0000000000000000\"".to_string()),
             ScType::Address => {
                 Some("\"GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4\"".to_string())
             }
             ScType::Void => Some("null".to_string()),
-            ScType::Timepoint => Some("1234".to_string()),
-            ScType::Duration => Some("9999".to_string()),
-            ScType::U256 => Some("\"2000\"".to_string()),
-            ScType::I256 => Some("\"-20000\"".to_string()),
+            ScType::Timepoint => Some("1743010492".to_string()),
+            ScType::Duration => Some("1".to_string()),
+            ScType::U256 => Some("\"1\"".to_string()),
+            ScType::I256 => Some("\"1\"".to_string()),
             ScType::String => Some("\"hello world\"".to_string()),
             ScType::Option(val) => {
                 let ScSpecTypeOption { value_type } = val.as_ref();
@@ -1275,13 +1275,7 @@ impl Spec {
             }
             ScType::BytesN(n) => {
                 let n = n.n as usize;
-                let res = if n % 2 == 0 {
-                    "ef".repeat(n)
-                } else {
-                    let mut s = "ef".repeat(n - 1);
-                    s.push('e');
-                    s
-                };
+                let res = "00".repeat(n);
                 Some(format!("\"{res}\""))
             }
             ScType::Udt(ScSpecTypeUdt { name }) => {

--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -1212,6 +1212,7 @@ fn arg_value_enum(enum_: &ScSpecUdtEnumV0) -> String {
 impl Spec {
     #[must_use]
     pub fn example(&self, type_: &ScType) -> Option<String> {
+        #[allow(clippy::match_same_arms)]
         match type_ {
             ScType::U64 => Some("1".to_string()),
             ScType::I64 => Some("1".to_string()),

--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -1225,7 +1225,7 @@ impl Spec {
             ScType::Error => Some("Error".to_string()),
             ScType::Bytes => Some("\"0000000000000000\"".to_string()),
             ScType::Address => {
-                Some("\"GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4\"".to_string())
+                Some("\"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\"".to_string())
             }
             ScType::Void => Some("null".to_string()),
             ScType::Timepoint => Some("1743010492".to_string()),

--- a/cmd/crates/soroban-test/tests/it/help.rs
+++ b/cmd/crates/soroban-test/tests/it/help.rs
@@ -53,7 +53,7 @@ async fn complex_enum_help() {
     assert!(output.contains(r#"{"Tuple":[{ "a": 1, "b": true, "c": "hello" }"#,));
     assert!(output.contains(r#"{"Enum":"First"|"Second"|"Third"}"#,));
     assert!(output.contains(
-        r#"{"Asset":["GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4", "-100"]}"#,
+        r#"{"Asset":["GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF", "1"]}"#,
     ));
     assert!(output.contains(r#""Void"'"#));
 }


### PR DESCRIPTION
### What
Update example values for numeric and byte types that are presented to users in docs about a contract on the invoke command. 

### Why
The examples provided were a mix of rather random values, such as 'beefface123' for bytes, and some integers were exampled as '42', others contained negative signs which looked a bit confusing when seeing a suggestion to use a negative value for values in a contract that should never be negative.

Also, the BytesN command outputted invalid examples whenever the N was not event.