### PR TITLE
[ci] Integration tests: support for Linux/Mac

### DIFF
--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -41,6 +41,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup update
       - run: sudo apt update && sudo apt install -y libudev-dev libdbus-1-dev
+        if: runner.os == 'Linux'
       - run: cargo build
       - run: rustup target add wasm32-unknown-unknown
       - run: make build-test-wasms

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -37,4 +37,4 @@ jobs:
       - run: cargo build
       - run: rustup target add wasm32-unknown-unknown
       - run: make build-test-wasms
-      - run: SOROBAN_PORT=8000 cargo test --features it --package soroban-test --test it -- integration
+      - run: SOROBAN_PORT=8000 cargo test --features it --package soroban-test --test it -- integration --test-threads=1

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -10,24 +10,25 @@ concurrency:
 
 jobs:
   test:
-    name: test RPC
-    runs-on: ubuntu-22.04
-    services:
-      rpc:
-        image: stellar/quickstart:testing
-        ports:
-          - 8000:8000
-        env:
-          ENABLE_LOGS: true
-          ENABLE_SOROBAN_DIAGNOSTIC_EVENTS: true
-          NETWORK: local
-          PROTOCOL_VERSION: 22
-        options: >-
-          --health-cmd "curl --no-progress-meter --fail-with-body -X POST \"http://localhost:8000/soroban/rpc\" -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":8675309,\"method\":\"getNetwork\"}' && curl --no-progress-meter \"http://localhost:8000/friendbot\" | grep '\"invalid_field\": \"addr\"'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 50
+    strategy:
+      fail-fast: false
+      matrix:
+        sys:
+            # x64
+          - ubuntu-latest-16-cores
+            # ARM
+          - ubuntu-jammy-16-cores-arm64
+            # Intel
+          - macos-13
+#        exclude:
+#          # Only run Linux x64 tests on pull request to save some time
+#          - sys: ${{ github.event_name != 'push' && 'ubuntu-jammy-16-cores-arm64' }}
+#          - sys: ${{ github.event_name != 'push' && 'macos-13' }}
+    runs-on: ${{ matrix.sys }}
     steps:
+      - uses: stellar/quickstart@main
+        with:
+          tag: testing
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -30,15 +30,7 @@ jobs:
         with:
           tag: testing
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: stellar/actions/rust-cache@main
       - run: rustup update
       - run: sudo apt update && sudo apt install -y libudev-dev libdbus-1-dev
         if: runner.os == 'Linux'

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -20,10 +20,10 @@ jobs:
           - ubuntu-jammy-16-cores-arm64
             # Intel
           - macos-13
-#        exclude:
-#          # Only run Linux x64 tests on pull request to save some time
-#          - sys: ${{ github.event_name != 'push' && 'ubuntu-jammy-16-cores-arm64' }}
-#          - sys: ${{ github.event_name != 'push' && 'macos-13' }}
+        exclude:
+          # Only run Linux x64 tests on pull request to save some time
+          - sys: ${{ github.event_name != 'push' && 'ubuntu-jammy-16-cores-arm64' }}
+          - sys: ${{ github.event_name != 'push' && 'macos-13' }}
     runs-on: ${{ matrix.sys }}
     steps:
       - uses: stellar/quickstart@main


### PR DESCRIPTION
### What

And ARM Linux and Mac support for integration tests

### Why

#1941 

### Known limitations

Set threads to 1, this doesn't slow build too much.
Current main:[ ~10 minutes](https://github.com/stellar/stellar-cli/actions/runs/14133879663/job/39600795975)
Multiplatform multithread (using `ubuntu-latest-16-cores`): [~7 minutes](https://github.com/stellar/stellar-cli/actions/runs/14120868525/job/39560755321) -> making a lot of requests in multithreaded environment messes up the fees and leads to failures. This doesn't happen with smaller instance because it doesn't send as much requests (however, it still leads to [flaky tests](https://github.com/stellar/stellar-cli/issues/1954) for the same reason -- fees)
Multiplatform singlethread: [~11 minutes](https://github.com/stellar/stellar-cli/actions/runs/14131787359/job/39616081641?pr=1989)