### PR TITLE
Set DOCKER_HOST to colima so that macos-13 emulator tests work

### DIFF
--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -41,6 +41,9 @@ jobs:
           brew install docker
           brew install colima
           colima start
+      - name: Set DOCKER_HOST to Colima socket
+        if: runner.os == 'macos'
+        run: echo "DOCKER_HOST=unix:///Users/runner/.colima/default/docker.sock" >> $GITHUB_ENV
       - name: install optional dependencies (Linux only)
         run: sudo apt update && sudo apt install -y libudev-dev libdbus-1-dev
         if: runner.os == 'Linux'


### PR DESCRIPTION
@Ifropc I think that this change should get the emulator tests running on macos-13. The last run took 32min, but i had noticed it being quicker in previous attempts, so it may need some fine tuning still. 

### What

Set the DOCKER_HOST to the colima host and pipe to github env

### Why

the emulator tests were failing on macos because we need to account for colima's socket being different than the default docker socket. and the test containers library (and it's dep bollard) were expecting the socket to be at the default docker host.

### Known limitations

the cargo deny failure should be fixed once `emulator-multiplatform` and this branch are updated with main.
