### PR TITLE
Fix/cargo deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3117,9 +3117,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,9 +5335,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "2209a14885b74764cce87ffa777ffa1b8ce81a3f3166c6f886b83337fe7e077f"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
### What

- Update openssl to 0.10.72 per cargo deny advisories suggestion
- Update tokio to 1.42.1 per cargo deny advisories suggestion

### Why
- openssl upgrade to fix this error:
```
error[vulnerability]: Use-After-Free in `Md::fetch` and `Cipher::fetch`
    ┌─ /Users/ebethme/Desktop/projects/stellar/stellar-cli/Cargo.lock:281:1
    │
281 │ openssl 0.10.70 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2025-0022
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0022
    = When a `Some(...)` value was passed to the `properties` argument of either of these functions, a use-after-free would result.

      In practice this would nearly always result in OpenSSL treating the properties as an empty string (due to `CString::drop`'s behavior).

      The maintainers thank [quitbug](https://github.com/quitbug/) for reporting this vulnerability to us.
    = Announcement: https://github.com/sfackler/rust-openssl/pull/2390
    = Solution: Upgrade to >=0.10.72 (try `cargo update -p openssl`)
```
- tokio upgrade to fix this error:
```
    ┌─ /Users/ebethme/Desktop/projects/stellar/stellar-cli/Cargo.lock:470:1
    │
470 │ tokio 1.39.2 registry+https://github.com/rust-lang/crates.io-index
    │ ------------------------------------------------------------------ unsound advisory detected
    │
    = ID: RUSTSEC-2025-0023
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0023
    = The broadcast channel internally calls `clone` on the stored value when
      receiving it, and only requires `T:Send`. This means that using the broadcast
      channel with values that are `Send` but not `Sync` can trigger unsoundness if
      the `clone` implementation makes use of the value being `!Sync`.
```

### Known limitations

N/A