### PR TITLE
Add subcommand lookup for missing commands.

### DIFF
--- a/cmd/crates/soroban-test/tests/it/plugin.rs
+++ b/cmd/crates/soroban-test/tests/it/plugin.rs
@@ -64,7 +64,7 @@ fn has_no_path_failure() {
         .unwrap_or_else(|_| assert_cmd::Command::new("stellar"))
         .arg("hello")
         .assert()
-        .stderr(predicates::str::contains("error: no such command: `hello`"));
+        .stderr(predicates::str::contains("unrecognized subcommand 'hello'"));
 }
 
 fn target_bin() -> PathBuf {

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -83,13 +83,16 @@ impl Root {
         Self::try_parse().map_err(|e| {
             if std::env::args().any(|s| s == "--list") {
                 let plugins = plugin::list().unwrap_or_default();
+
                 if plugins.is_empty() {
-                    println!("No Plugins installed. E.g. soroban-hello");
+                    println!("No Plugins installed. E.g. stellar-hello");
                 } else {
                     println!("Installed Plugins:\n    {}", plugins.join("\n    "));
                 }
+
                 std::process::exit(0);
             }
+
             match e.kind() {
                 ErrorKind::InvalidSubcommand => match plugin::run() {
                     Ok(()) => Error::Clap(e),
@@ -107,6 +110,7 @@ impl Root {
     {
         Self::from_arg_matches_mut(&mut Self::command().get_matches_from(itr))
     }
+
     pub async fn run(&mut self) -> Result<(), Error> {
         match &mut self.cmd {
             Cmd::Completion(completion) => completion.run(),

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -61,19 +61,18 @@ pub fn list() -> Result<Vec<String>, Error> {
 
 fn find_plugin() -> Option<(PathBuf, Vec<String>)> {
     let args_vec: Vec<String> = std::env::args().skip(1).collect();
-    let chain: Vec<String> = args_vec
+    let mut chain: Vec<String> = args_vec
         .iter()
         .take_while(|arg| !arg.starts_with("--"))
         .map(ToString::to_string)
         .collect();
 
-    let mut index = chain.len() - 1;
-
-    while index > 0 {
-        let name = chain[..index].join("-");
+    while !chain.is_empty() {
+        let name = chain.join("-");
         let bin = find_bin(&name).ok();
 
         if let Some(bin) = &bin {
+            let index = chain.len();
             let args = args_vec[index..]
                 .iter()
                 .map(ToString::to_string)
@@ -82,7 +81,7 @@ fn find_plugin() -> Option<(PathBuf, Vec<String>)> {
             return Some((bin.into(), args));
         }
 
-        index -= 1;
+        chain.pop();
     }
 
     None

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -1,82 +1,33 @@
 use std::{path::PathBuf, process::Command};
-
-use clap::CommandFactory;
 use which::which;
 
-use crate::{utils, Root};
+use crate::utils;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Plugin not provided. Should be `stellar plugin` for a binary `stellar-plugin`")]
-    MissingSubcommand,
     #[error(transparent)]
     IO(#[from] std::io::Error),
-    #[error(
-        r"error: no such command: `{0}`
-        
-        {1}View all installed plugins with `stellar --list`"
-    )]
-    ExecutableNotFound(String, String),
+
     #[error(transparent)]
     Which(#[from] which::Error),
+
     #[error(transparent)]
     Regex(#[from] regex::Error),
 }
 
-const SUBCOMMAND_TOLERANCE: f64 = 0.75;
-const PLUGIN_TOLERANCE: f64 = 0.75;
-const MIN_LENGTH: usize = 4;
-
-/// Tries to run a plugin, if the plugin's name is similar enough to any of the current subcommands return Ok.
-/// Otherwise only errors can be returned because this process will exit with the plugin.
 pub fn run() -> Result<(), Error> {
-    let (name, args) = {
-        let mut args = std::env::args().skip(1);
-        let name = args.next().ok_or(Error::MissingSubcommand)?;
-        (name, args)
-    };
-
-    if Root::command().get_subcommands().any(|c| {
-        let sc_name = c.get_name();
-        sc_name.starts_with(&name)
-            || (name.len() >= MIN_LENGTH && strsim::jaro(sc_name, &name) >= SUBCOMMAND_TOLERANCE)
-    }) {
-        return Ok(());
+    if let Some((plugin_bin, args)) = find_plugin() {
+        std::process::exit(
+            Command::new(plugin_bin)
+                .args(args)
+                .spawn()?
+                .wait()?
+                .code()
+                .unwrap(),
+        );
     }
 
-    let bin = find_bin(&name).map_err(|_| {
-        let suggestion = if let Ok(bins) = list() {
-            let suggested_name = bins
-                .iter()
-                .map(|b| (b, strsim::jaro_winkler(&name, b)))
-                .filter(|(_, i)| *i > PLUGIN_TOLERANCE)
-                .min_by(|a, b| a.1.total_cmp(&b.1))
-                .map(|(a, _)| a.to_string())
-                .unwrap_or_default();
-
-            if suggested_name.is_empty() {
-                suggested_name
-            } else {
-                format!(
-                    r"Did you mean `{suggested_name}`?
-        "
-                )
-            }
-        } else {
-            String::new()
-        };
-
-        Error::ExecutableNotFound(name, suggestion)
-    })?;
-
-    std::process::exit(
-        Command::new(bin)
-            .args(args)
-            .spawn()?
-            .wait()?
-            .code()
-            .unwrap(),
-    );
+    Ok(())
 }
 
 const MAX_HEX_LENGTH: usize = 10;
@@ -106,4 +57,33 @@ pub fn list() -> Result<Vec<String>, Error> {
         .filter(|s| !(utils::is_hex_string(s) && s.len() > MAX_HEX_LENGTH))
         .map(|s| s.replace("soroban-", "").replace("stellar-", ""))
         .collect())
+}
+
+fn find_plugin() -> Option<(PathBuf, Vec<String>)> {
+    let args_vec: Vec<String> = std::env::args().skip(1).collect();
+    let chain: Vec<String> = args_vec
+        .iter()
+        .take_while(|arg| !arg.starts_with("--"))
+        .map(ToString::to_string)
+        .collect();
+
+    let mut index = chain.len() - 1;
+
+    while index > 0 {
+        let name = chain[..index].join("-");
+        let bin = find_bin(&name).ok();
+
+        if let Some(bin) = &bin {
+            let args = args_vec[index..]
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>();
+
+            return Some((bin.into(), args));
+        }
+
+        index -= 1;
+    }
+
+    None
 }


### PR DESCRIPTION
### What

Add support for subcommand plugins lookup. If you have a binary like `stellar-contract-bindings-typescript`, that means you can call it by using `stellar contract bindings typescript`.

```console
$ which stellar-hello
/Users/fnando/Projects/stellar/stellar-cli/target/debug/stellar-hello

$ stellar hello
running `stellar hello` with args:

$ stellar hello 1
running `stellar hello` with args: 1

$ which stellar-contract-hello
/Users/fnando/Projects/stellar/stellar-cli/target/debug/stellar-contract-hello

$ stellar contract hello
running `stellar contract hello` with args:

$ stellar contract hello foo bar --nice 1
running `stellar contract hello` with args: foo bar --nice 1

$ stellar env
STELLAR_ACCOUNT=me      # use
STELLAR_NETWORK=testnet # use
```

### Why

This allows publishers to extend the CLI by bringing their own subcommands.

### Known limitations

For now, we had to remove command suggestion, but clap already does command suggestion.

```console
$ stellar contrac
error: unrecognized subcommand 'contrac'

  tip: some similar subcommands exist: 'container', 'contract'

Usage: stellar [OPTIONS] <COMMAND>

For more information, try '--help'.
```
