### PR TITLE
Adapt to wasm32v1-none target.

### DIFF
--- a/.github/workflows/bindings-ts.yml
+++ b/.github/workflows/bindings-ts.yml
@@ -37,7 +37,7 @@ jobs:
         run: sudo apt update && sudo apt install -y libdbus-1-dev libudev-dev
         if: runner.os == 'Linux'
       - run: cargo build
-      - run: rustup target add wasm32-unknown-unknown
+      - run: rustup target add wasm32v1-none
       - run: make build-test-wasms
       - run: npm ci && npm run test
         working-directory: cmd/crates/soroban-spec-typescript/ts-tests

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -46,6 +46,6 @@ jobs:
         run: |
           gnome-keyring-daemon
       - run: cargo build --features additional-libs
-      - run: rustup target add wasm32-unknown-unknown
+      - run: rustup target add wasm32v1-none
       - run: make build-test-wasms
       - run: SOROBAN_PORT=8000 cargo test --features it --package soroban-test --test it -- integration --test-threads=1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,7 @@ jobs:
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32-unknown-unknown
+    - run: rustup target add wasm32v1-none
     - if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libudev-dev libdbus-1-dev
     - run: cargo clippy --all-targets --target ${{ matrix.sys.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,6 +4426,7 @@ dependencies = [
  "reqwest",
  "rpassword",
  "rust-embed",
+ "rustc_version",
  "semver",
  "sep5",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build:
 	cargo build
 
 build-test-wasms:
-	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown
+	cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
 
 build-test: build-test-wasms install
 
@@ -72,11 +72,11 @@ publish:
 
 typescript-bindings-fixtures: build-test-wasms
 	cargo run -- contract bindings typescript \
-					--wasm ./target/wasm32-unknown-unknown/test-wasms/test_custom_types.wasm \
+					--wasm ./target/wasm32v1-none/test-wasms/test_custom_types.wasm \
 					--output-dir ./cmd/crates/soroban-spec-typescript/fixtures/test_custom_types \
 					--overwrite && \
 	cargo run -- contract bindings typescript \
-					--wasm ./target/wasm32-unknown-unknown/test-wasms/test_constructor.wasm \
+					--wasm ./target/wasm32v1-none/test-wasms/test_constructor.wasm \
 					--output-dir ./cmd/crates/soroban-spec-typescript/fixtures/test_constructor \
 					--overwrite
 

--- a/cmd/crates/soroban-spec-json/src/lib.rs
+++ b/cmd/crates/soroban-spec-json/src/lib.rs
@@ -72,7 +72,7 @@ mod test {
     use super::generate;
 
     const EXAMPLE_WASM: &[u8] =
-        include_bytes!("../../../../target/wasm32-unknown-unknown/test-wasms/test_udt.wasm");
+        include_bytes!("../../../../target/wasm32v1-none/test-wasms/test_udt.wasm");
 
     #[test]
     fn example() {

--- a/cmd/crates/soroban-spec-tools/src/contract.rs
+++ b/cmd/crates/soroban-spec-tools/src/contract.rs
@@ -59,7 +59,7 @@ impl Spec {
                 } else {
                     *out = Some(section.data().to_vec());
                 }
-            };
+            }
         }
 
         let mut env_meta_base64 = None;
@@ -179,7 +179,7 @@ impl Display for Spec {
 
 fn write_func(f: &mut std::fmt::Formatter<'_>, func: &ScSpecFunctionV0) -> std::fmt::Result {
     writeln!(f, " • Function: {}", func.name.to_utf8_string_lossy())?;
-    if func.doc.len() > 0 {
+    if !func.doc.is_empty() {
         writeln!(
             f,
             "     Docs: {}",
@@ -202,7 +202,7 @@ fn write_func(f: &mut std::fmt::Formatter<'_>, func: &ScSpecFunctionV0) -> std::
 
 fn write_union(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtUnionV0) -> std::fmt::Result {
     writeln!(f, " • Union: {}", format_name(&udt.lib, &udt.name))?;
-    if udt.doc.len() > 0 {
+    if !udt.doc.is_empty() {
         writeln!(
             f,
             "     Docs: {}",
@@ -219,7 +219,7 @@ fn write_union(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtUnionV0) -> std::
 
 fn write_struct(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtStructV0) -> std::fmt::Result {
     writeln!(f, " • Struct: {}", format_name(&udt.lib, &udt.name))?;
-    if udt.doc.len() > 0 {
+    if !udt.doc.is_empty() {
         writeln!(
             f,
             "     Docs: {}",
@@ -234,7 +234,7 @@ fn write_struct(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtStructV0) -> std
             field.name.to_utf8_string_lossy(),
             indent(&format!("{:#?}", field.type_), 8).trim()
         )?;
-        if field.doc.len() > 0 {
+        if !field.doc.is_empty() {
             writeln!(f, "{}", indent(&format!("{:#?}", field.doc), 8))?;
         }
     }
@@ -244,7 +244,7 @@ fn write_struct(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtStructV0) -> std
 
 fn write_enum(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtEnumV0) -> std::fmt::Result {
     writeln!(f, " • Enum: {}", format_name(&udt.lib, &udt.name))?;
-    if udt.doc.len() > 0 {
+    if !udt.doc.is_empty() {
         writeln!(
             f,
             "     Docs: {}",
@@ -261,7 +261,7 @@ fn write_enum(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtEnumV0) -> std::fm
 
 fn write_error(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtErrorEnumV0) -> std::fmt::Result {
     writeln!(f, " • Error: {}", format_name(&udt.lib, &udt.name))?;
-    if udt.doc.len() > 0 {
+    if !udt.doc.is_empty() {
         writeln!(
             f,
             "     Docs: {}",
@@ -285,13 +285,13 @@ fn indent(s: &str, n: usize) -> String {
 }
 
 fn format_name(lib: &StringM<80>, name: &StringM<60>) -> String {
-    if lib.len() > 0 {
+    if lib.is_empty() {
+        name.to_utf8_string_lossy()
+    } else {
         format!(
             "{}::{}",
             lib.to_utf8_string_lossy(),
             name.to_utf8_string_lossy()
         )
-    } else {
-        name.to_utf8_string_lossy()
     }
 }

--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
+use std::fmt::Write;
 use std::str::FromStr;
 
 use itertools::Itertools;
@@ -452,7 +453,7 @@ impl Spec {
                 );
             }
             (ScSpecUdtUnionCaseV0::TupleV0(ScSpecUdtUnionCaseTupleV0 { .. }), Some(_)) => {}
-        };
+        }
         Ok(ScVal::Vec(Some(res.try_into().map_err(Error::Xdr)?)))
     }
 
@@ -465,7 +466,7 @@ impl Spec {
         let ScSpecTypeTuple { value_types } = tuple;
         if items.len() != value_types.len() {
             return Err(Error::InvalidValue(Some(t.clone())));
-        };
+        }
         let parsed: Result<Vec<ScVal>, Error> = items
             .iter()
             .zip(value_types.iter())
@@ -1062,7 +1063,7 @@ fn sc_address_from_json(s: &str) -> Result<ScVal, Error> {
 fn to_lower_hex(bytes: &[u8]) -> String {
     let mut res = String::with_capacity(bytes.len());
     for b in bytes {
-        res.push_str(&format!("{b:02x}"));
+        let _ = write!(res, "{b:02x}");
     }
     res
 }

--- a/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
+++ b/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
@@ -146,9 +146,8 @@ mod test {
 
     use super::*;
 
-    const EXAMPLE_WASM: &[u8] = include_bytes!(
-        "../../../../target/wasm32-unknown-unknown/test-wasms/test_custom_types.wasm"
-    );
+    const EXAMPLE_WASM: &[u8] =
+        include_bytes!("../../../../target/wasm32v1-none/test-wasms/test_custom_types.wasm");
 
     fn init(root: impl AsRef<Path>) -> std::io::Result<Project> {
         let spec = soroban_spec::read::from_wasm(EXAMPLE_WASM).unwrap();

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -281,9 +281,11 @@ pub fn entry_to_method_type(entry: &Entry) -> String {
         Entry::Enum { doc, name, cases } => {
             let doc = doc_to_ts_doc(doc, None, 0);
             let cases = cases.iter().map(enum_case_to_ts).join("\n  ");
-            let name = (name == "Error")
-                .then(|| format!("{name}s"))
-                .unwrap_or(name.to_string());
+            let name = if name == "Error" {
+                format!("{name}s")
+            } else {
+                name.to_string()
+            };
             format!(
                 r"{doc}export enum {name} {{
   {cases}

--- a/cmd/crates/soroban-spec-typescript/ts-tests/initialize.sh
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/initialize.sh
@@ -32,8 +32,8 @@ function upload() {
   exe eval "(./stellar contract $1 --quiet --source root --wasm $2 --ignore-checks) > $3"
 }
 function deploy_all() {
-  upload deploy ../../../../target/wasm32-unknown-unknown/test-wasms/test_custom_types.wasm contract-id-custom-types.txt
-  upload install ../../../../target/wasm32-unknown-unknown/test-wasms/test_constructor.wasm contract-wasm-hash-constructor.txt
+  upload deploy ../../../../target/wasm32v1-none/test-wasms/test_custom_types.wasm contract-id-custom-types.txt
+  upload install ../../../../target/wasm32v1-none/test-wasms/test_constructor.wasm contract-wasm-hash-constructor.txt
   exe eval "./stellar contract asset deploy --asset native --source root"
 }
 function bind() {

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -9,13 +9,13 @@
 //! - `TestEnv` is a test environment for running tests isolated from each other.
 //! - `TestEnv::with_default` invokes a closure, which is passed a reference to a random `TestEnv`.
 //! - `TestEnv::new_assert_cmd` creates an `assert_cmd::Command` for a given subcommand and sets the current
-//!    directory to be the same as `TestEnv`.
+//!   directory to be the same as `TestEnv`.
 //! - `TestEnv::cmd` is a generic function which parses a command from a string.
-//!    Note, however, that it uses `shlex` to tokenize the string. This can cause issues
-//!    for commands which contain strings with `"`s. For example, `{"hello": "world"}` becomes
-//!    `{hello:world}`. For that reason it's recommended to use `TestEnv::cmd_arr` instead.
+//!   Note, however, that it uses `shlex` to tokenize the string. This can cause issues
+//!   for commands which contain strings with `"`s. For example, `{"hello": "world"}` becomes
+//!   `{hello:world}`. For that reason it's recommended to use `TestEnv::cmd_arr` instead.
 //! - `TestEnv::cmd_arr` is a generic function which takes an array of `&str` which is passed directly to clap.
-//!    This is the preferred way since it ensures no string parsing footguns.
+//!   This is the preferred way since it ensures no string parsing footguns.
 //! - `TestEnv::invoke` a convenience function for using the invoke command.
 //!
 #![allow(
@@ -109,7 +109,7 @@ impl TestEnv {
         env.network.rpc_url = rpc_url.to_string();
         if let Ok(network_passphrase) = std::env::var("STELLAR_NETWORK_PASSPHRASE") {
             env.network.network_passphrase = network_passphrase;
-        };
+        }
         env.generate_account("test", None).assert().success();
         env
     }
@@ -120,7 +120,7 @@ impl TestEnv {
         env.network.rpc_headers = rpc_headers;
         if let Ok(network_passphrase) = std::env::var("STELLAR_NETWORK_PASSPHRASE") {
             env.network.network_passphrase = network_passphrase;
-        };
+        }
         env.generate_account("test", None).assert().success();
         env
     }

--- a/cmd/crates/soroban-test/src/wasm.rs
+++ b/cmd/crates/soroban-test/src/wasm.rs
@@ -30,7 +30,7 @@ impl Wasm<'_> {
     ///
     /// # if not found
     pub fn path(&self) -> PathBuf {
-        let path = find_target_dir().unwrap().join("wasm32-unknown-unknown");
+        let path = find_target_dir().unwrap().join("wasm32v1-none");
         let mut path = match self {
             Wasm::Release(name) => path.join("release").join(name),
             Wasm::Custom(profile, name) => path.join(profile).join(name),

--- a/cmd/crates/soroban-test/tests/fixtures/eth_abi/Makefile
+++ b/cmd/crates/soroban-test/tests/fixtures/eth_abi/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -13,9 +13,14 @@ fn build_all() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
+    let expected = format!(
+        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
 cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
-cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", add_path(), call_path(), add2_path());
+cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
+        add_path(),
+        call_path(),
+        add2_path()
+    );
     sandbox
         .new_assert_cmd("contract")
         .current_dir(fixture_path)
@@ -31,7 +36,10 @@ fn build_package_by_name() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", add_path());
+    let expected = format!(
+        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
+        add_path()
+    );
     sandbox
         .new_assert_cmd("contract")
         .current_dir(fixture_path)
@@ -85,7 +93,10 @@ fn build_all_when_in_non_package_directory() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/contracts/add/src/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", parent_path());
+    let expected = format!(
+        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
+        parent_path()
+    );
 
     sandbox
         .new_assert_cmd("contract")
@@ -102,7 +113,10 @@ fn build_default_members() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace-with-default-members/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", add_path());
+    let expected = format!(
+        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
+        add_path()
+    );
 
     sandbox
         .new_assert_cmd("contract")

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -13,9 +13,9 @@ fn build_all() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32-unknown-unknown --release
-cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32-unknown-unknown --release
-cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32-unknown-unknown --release", add_path(), call_path(), add2_path());
+    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
+cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
+cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", add_path(), call_path(), add2_path());
     sandbox
         .new_assert_cmd("contract")
         .current_dir(fixture_path)
@@ -31,7 +31,7 @@ fn build_package_by_name() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32-unknown-unknown --release", add_path());
+    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", add_path());
     sandbox
         .new_assert_cmd("contract")
         .current_dir(fixture_path)
@@ -56,7 +56,7 @@ fn build_package_by_current_dir() {
         .assert()
         .success()
         .stdout(predicate::eq(
-            with_flags("cargo rustc --manifest-path=Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release"),
+            with_flags("cargo rustc --manifest-path=Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release"),
         ));
 }
 
@@ -85,7 +85,7 @@ fn build_all_when_in_non_package_directory() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/contracts/add/src/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32-unknown-unknown --release", parent_path());
+    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", parent_path());
 
     sandbox
         .new_assert_cmd("contract")
@@ -102,7 +102,7 @@ fn build_default_members() {
     let sandbox = TestEnv::default();
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace-with-default-members/");
-    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32-unknown-unknown --release", add_path());
+    let expected = format!("cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release", add_path());
 
     sandbox
         .new_assert_cmd("contract")
@@ -336,7 +336,7 @@ fn remap_absolute_paths() {
             .success();
 
         let wasm_path = manifest_path
-            .join("target/wasm32-unknown-unknown/release")
+            .join("target/wasm32v1-none/release")
             .join(format!("{contract_name}.wasm"));
 
         let cargo_home = home::cargo_home().unwrap();

--- a/cmd/crates/soroban-test/tests/it/integration/init.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/init.rs
@@ -30,7 +30,7 @@ fn init_and_deploy() {
 
     let target_dir = sandbox
         .dir()
-        .join("project/target/wasm32-unknown-unknown/release");
+        .join("project/target/wasm32v1-none/release");
     assert!(target_dir.exists());
 
     let assert = sandbox

--- a/cmd/crates/soroban-test/tests/it/integration/init.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/init.rs
@@ -28,9 +28,7 @@ fn init_and_deploy() {
         .assert()
         .success();
 
-    let target_dir = sandbox
-        .dir()
-        .join("project/target/wasm32v1-none/release");
+    let target_dir = sandbox.dir().join("project/target/wasm32v1-none/release");
     assert!(target_dir.exists());
 
     let assert = sandbox

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -135,6 +135,7 @@ zeroize = "1.8.1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"], optional = true }
 whoami = "1.5.2"
 serde_with = "3.11.0"
+rustc_version = "0.4.1"
 
 
 [build-dependencies]

--- a/cmd/soroban-cli/src/assembled.rs
+++ b/cmd/soroban-cli/src/assembled.rs
@@ -137,7 +137,7 @@ impl Assembled {
             }
             if let Some(log) = log_events {
                 log(footprint, &[self.auth_entries()], &self.sim_res.events()?);
-            };
+            }
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/cache/actionlog/mod.rs
+++ b/cmd/soroban-cli/src/commands/cache/actionlog/mod.rs
@@ -24,7 +24,7 @@ impl Cmd {
         match self {
             Cmd::Ls(cmd) => cmd.run()?,
             Cmd::Read(cmd) => cmd.run()?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/cache/mod.rs
+++ b/cmd/soroban-cli/src/commands/cache/mod.rs
@@ -32,7 +32,7 @@ impl Cmd {
             Cmd::Clean(cmd) => cmd.run()?,
             Cmd::Path(cmd) => cmd.run()?,
             Cmd::Actionlog(cmd) => cmd.run()?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/alias/add.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/add.rs
@@ -64,7 +64,7 @@ impl Cmd {
                     contract,
                 });
             }
-        };
+        }
 
         print.infoln(format!(
             "Contract alias '{alias}' will reference {contract} on network '{network_passphrase}'",

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -112,7 +112,7 @@ pub enum Error {
     WritingWasmFile(io::Error),
     #[error("invalid meta entry: {0}")]
     MetaArg(String),
-    #[error("rust version {0} cannot be used to build contracts")]
+    #[error("use rust 1.81 or 1.84+ to build contracts (got {0})")]
     RustVersion(String),
 }
 

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -114,8 +114,6 @@ pub enum Error {
     MetaArg(String),
     #[error("rust version {0} cannot be used to build contracts")]
     RustVersion(String),
-    #[error("unable to retrieve the rust version")]
-    UnknownRustVersion,
 }
 
 const WASM_TARGET: &str = "wasm32v1-none";
@@ -470,7 +468,7 @@ fn get_rustflags() -> Option<Vec<String>> {
 
 fn get_wasm_target() -> Result<String, Error> {
     let Ok(current_version) = version() else {
-        return Err(Error::UnknownRustVersion);
+        return Ok(WASM_TARGET.into());
     };
 
     let v184 = Version::parse("1.84.0").unwrap();

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -1,6 +1,8 @@
 use cargo_metadata::{Metadata, MetadataCommand, Package};
 use clap::Parser;
 use itertools::Itertools;
+use rustc_version::version;
+use semver::Version;
 use sha2::{Digest, Sha256};
 use std::{
     borrow::Cow,
@@ -110,17 +112,20 @@ pub enum Error {
     WritingWasmFile(io::Error),
     #[error("invalid meta entry: {0}")]
     MetaArg(String),
+    #[error("rust version {0} cannot be used to build contracts")]
+    RustVersion(String),
+    #[error("unable to retrieve the rust version")]
+    UnknownRustVersion,
 }
 
 const WASM_TARGET: &str = "wasm32v1-none";
+const WASM_TARGET_OLD: &str = "wasm32-unknown-unknown";
 const META_CUSTOM_SECTION_NAME: &str = "contractmetav0";
 
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = Print::new(global_args.quiet);
-
         let working_dir = env::current_dir().map_err(Error::GettingCurrentDir)?;
-
         let metadata = self.metadata()?;
         let packages = self.packages(&metadata)?;
         let target_dir = &metadata.target_directory;
@@ -133,6 +138,8 @@ impl Cmd {
             }
         }
 
+        let wasm_target = get_wasm_target()?;
+
         for p in packages {
             let mut cmd = Command::new("cargo");
             cmd.stdout(Stdio::piped());
@@ -144,7 +151,7 @@ impl Cmd {
                 manifest_path.to_string_lossy()
             ));
             cmd.arg("--crate-type=cdylib");
-            cmd.arg(format!("--target={WASM_TARGET}"));
+            cmd.arg(format!("--target={wasm_target}"));
             if self.profile == "release" {
                 cmd.arg("--release");
             } else {
@@ -196,7 +203,7 @@ impl Cmd {
 
                 let file = format!("{}.wasm", p.name.replace('-', "_"));
                 let target_file_path = Path::new(target_dir)
-                    .join(WASM_TARGET)
+                    .join(&wasm_target)
                     .join(&self.profile)
                     .join(&file);
 
@@ -459,4 +466,23 @@ fn get_rustflags() -> Option<Vec<String>> {
     }
 
     None
+}
+
+fn get_wasm_target() -> Result<String, Error> {
+    let Ok(current_version) = version() else {
+        return Err(Error::UnknownRustVersion);
+    };
+
+    let v184 = Version::parse("1.84.0").unwrap();
+    let v182 = Version::parse("1.82.0").unwrap();
+
+    if current_version >= v182 && current_version < v184 {
+        return Err(Error::RustVersion(current_version.to_string()));
+    }
+
+    if current_version < v184 {
+        Ok(WASM_TARGET_OLD.into())
+    } else {
+        Ok(WASM_TARGET.into())
+    }
 }

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -112,7 +112,7 @@ pub enum Error {
     MetaArg(String),
 }
 
-const WASM_TARGET: &str = "wasm32-unknown-unknown";
+const WASM_TARGET: &str = "wasm32v1-none";
 const META_CUSTOM_SECTION_NAME: &str = "contractmetav0";
 
 impl Cmd {

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -93,7 +93,7 @@ impl Cmd {
                         print.warnln(format!(
                             "Overwriting existing contract id: {existing_contract}"
                         ));
-                    };
+                    }
 
                     self.config.locator.save_contract_id(
                         &network.network_passphrase,

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -147,7 +147,7 @@ impl Cmd {
                         print.warnln(format!(
                             "Overwriting existing contract id: {existing_contract}"
                         ));
-                    };
+                    }
 
                     self.config.locator.save_contract_id(
                         &network.network_passphrase,
@@ -246,7 +246,7 @@ impl NetworkRunnable for Cmd {
         let entries = soroban_spec_tools::contract::Spec::new(&raw_wasm)?.spec;
         let res = soroban_spec_tools::Spec::new(entries.clone());
         let constructor_params = if let Ok(func) = res.find_function(CONSTRUCTOR_FUNCTION_NAME) {
-            if func.inputs.len() == 0 {
+            if func.inputs.is_empty() {
                 None
             } else {
                 let mut slop = vec![OsString::from(CONSTRUCTOR_FUNCTION_NAME)];

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -201,7 +201,7 @@ impl NetworkRunnable for Cmd {
 
         // Simply check if there is exactly one entry here. We only support extending a single
         // entry via this command (which we should fix separately, but).
-        if operations.len() == 0 {
+        if operations.is_empty() {
             return Err(Error::LedgerEntryNotFound);
         }
 

--- a/cmd/soroban-cli/src/commands/contract/info.rs
+++ b/cmd/soroban-cli/src/commands/contract/info.rs
@@ -80,7 +80,7 @@ impl Cmd {
             Cmd::Meta(meta) => meta.run(global_args).await?,
             Cmd::EnvMeta(env_meta) => env_meta.run(global_args).await?,
             Cmd::Build(build) => build.run(global_args).await?,
-        };
+        }
 
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/info/env_meta.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/env_meta.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::fmt::Write;
 
 use clap::{command, Parser};
 
@@ -68,9 +69,9 @@ impl Cmd {
                                 pre_release,
                             },
                         ) => {
-                            meta_str.push_str(&format!(" • Protocol: v{protocol}\n"));
+                            let _ = writeln!(meta_str, " • Protocol: v{protocol}");
                             if pre_release != &0 {
-                                meta_str.push_str(&format!(" • Pre-release: v{pre_release}\n"));
+                                let _ = writeln!(meta_str, " • Pre-release: v{pre_release}");
                             }
                         }
                     }

--- a/cmd/soroban-cli/src/commands/contract/info/meta.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/meta.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::fmt::Write;
 
 use crate::commands::contract::info::meta::Error::{NoMetaPresent, NoSACMeta};
 use crate::commands::contract::info::shared::{self, fetch, Fetched, MetasInfoOutput};
@@ -64,7 +65,7 @@ impl Cmd {
                                 }
                                 _ => val.to_string(),
                             };
-                            meta_str.push_str(&format!(" • {key}: {val}\n"));
+                            let _ = writeln!(meta_str, " • {key}: {val}");
                         }
                     }
                 }

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -198,7 +198,7 @@ impl NetworkRunnable for Cmd {
 
         // Simply check if there is exactly one entry here. We only support extending a single
         // entry via this command (which we should fix separately, but).
-        if operations.len() == 0 {
+        if operations.is_empty() {
             return Err(Error::LedgerEntryNotFound);
         }
 

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -89,7 +89,7 @@ impl Cmd {
         match res {
             TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
             TxnEnvelopeResult::Res(hash) => println!("{}", hex::encode(hash)),
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/keys/mod.rs
+++ b/cmd/soroban-cli/src/commands/keys/mod.rs
@@ -80,7 +80,7 @@ impl Cmd {
             Cmd::Rm(cmd) => cmd.run(global_args)?,
             Cmd::Secret(cmd) => cmd.run()?,
             Cmd::Default(cmd) => cmd.run(global_args)?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -119,7 +119,7 @@ impl Root {
             Cmd::Tx(tx) => tx.run(&self.global_args).await?,
             Cmd::Cache(cache) => cache.run()?,
             Cmd::Env(env) => env.run(&self.global_args)?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -107,7 +107,7 @@ impl Cmd {
                 cmd.run(global_args).await?;
             }
             Cmd::Health(cmd) => cmd.run(global_args).await?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/plugin/mod.rs
+++ b/cmd/soroban-cli/src/commands/plugin/mod.rs
@@ -28,7 +28,7 @@ impl Cmd {
         match self {
             Cmd::Search(cmd) => cmd.run(global_args).await?,
             Cmd::Ls(cmd) => cmd.run()?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/snapshot/mod.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/mod.rs
@@ -20,7 +20,7 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
             Cmd::Create(cmd) => cmd.run(global_args).await?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -86,7 +86,7 @@ impl Args {
         let res = self.handle(op, global_args).await?;
         if let TxnEnvelopeResult::TxnEnvelope(tx) = res {
             println!("{}", tx.to_xdr_base64(Limits::none())?);
-        };
+        }
         Ok(())
     }
 

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -80,7 +80,7 @@ impl Cmd {
             Cmd::Sign(cmd) => cmd.run(global_args).await?,
             Cmd::Simulate(cmd) => cmd.run(global_args).await?,
             Cmd::Update(cmd) => cmd.run(global_args).await?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/new/set_options.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/set_options.rs
@@ -79,16 +79,16 @@ impl TryFrom<&Cmd> for xdr::OperationBody {
 
         if cmd.set_required {
             set_flag(xdr::AccountFlags::RequiredFlag);
-        };
+        }
         if cmd.set_revocable {
             set_flag(xdr::AccountFlags::RevocableFlag);
-        };
+        }
         if cmd.set_immutable {
             set_flag(xdr::AccountFlags::ImmutableFlag);
-        };
+        }
         if cmd.set_clawback_enabled {
             set_flag(xdr::AccountFlags::ClawbackEnabledFlag);
-        };
+        }
 
         let mut clear_flags = None;
         let mut clear_flag = |flag: xdr::AccountFlags| {
@@ -96,16 +96,16 @@ impl TryFrom<&Cmd> for xdr::OperationBody {
         };
         if cmd.clear_required {
             clear_flag(xdr::AccountFlags::RequiredFlag);
-        };
+        }
         if cmd.clear_revocable {
             clear_flag(xdr::AccountFlags::RevocableFlag);
-        };
+        }
         if cmd.clear_immutable {
             clear_flag(xdr::AccountFlags::ImmutableFlag);
-        };
+        }
         if cmd.clear_clawback_enabled {
             clear_flag(xdr::AccountFlags::ClawbackEnabledFlag);
-        };
+        }
 
         let signer = if let (Some(key), Some(signer_weight)) =
             (cmd.signer.clone(), cmd.signer_weight.as_ref())

--- a/cmd/soroban-cli/src/commands/tx/new/set_trustline_flags.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/set_trustline_flags.rs
@@ -46,25 +46,25 @@ impl TryFrom<&Cmd> for xdr::OperationBody {
 
         if cmd.op.set_authorize {
             set_flag(xdr::TrustLineFlags::AuthorizedFlag);
-        };
+        }
         if cmd.op.set_authorize_to_maintain_liabilities {
             set_flag(xdr::TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag);
-        };
+        }
         if cmd.op.set_trustline_clawback_enabled {
             set_flag(xdr::TrustLineFlags::TrustlineClawbackEnabledFlag);
-        };
+        }
 
         let mut clear_flags = 0;
         let mut clear_flag = |flag: xdr::TrustLineFlags| clear_flags |= flag as u32;
         if cmd.op.clear_authorize {
             clear_flag(xdr::TrustLineFlags::AuthorizedFlag);
-        };
+        }
         if cmd.op.clear_authorize_to_maintain_liabilities {
             clear_flag(xdr::TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag);
-        };
+        }
         if cmd.op.clear_trustline_clawback_enabled {
             clear_flag(xdr::TrustLineFlags::TrustlineClawbackEnabledFlag);
-        };
+        }
 
         Ok(xdr::OperationBody::SetTrustLineFlags(
             xdr::SetTrustLineFlagsOp {

--- a/cmd/soroban-cli/src/commands/tx/op/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/mod.rs
@@ -19,7 +19,7 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
             Cmd::Add(cmd) => cmd.run(global_args).await?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/update/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/update/mod.rs
@@ -19,7 +19,7 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
             Cmd::SequenceNumber(cmd) => cmd.run(global_args).await?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/update/sequence_number/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/update/sequence_number/mod.rs
@@ -19,7 +19,7 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
             Cmd::Next(cmd) => cmd.run(global_args).await?,
-        };
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
+++ b/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
@@ -56,7 +56,7 @@ impl Cmd {
             TransactionEnvelope::TxV0(_) | TransactionEnvelope::TxFeeBump(_) => {
                 return Err(Error::Unsupported);
             }
-        };
+        }
         Ok(())
     }
 

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -482,9 +482,8 @@ impl KeyType {
 
     pub fn read_with_global<T: DeserializeOwned>(&self, key: &str, pwd: &Path) -> Result<T, Error> {
         for path in [pwd, global_config_path()?.as_path()] {
-            match self.read(key, path) {
-                Ok(t) => return Ok(t),
-                _ => continue,
+            if let Ok(t) = self.read(key, path) {
+                return Ok(t);
             }
         }
         Err(Error::ConfigMissing(self.to_string(), key.to_string()))

--- a/cmd/soroban-cli/src/utils/contract-template/Makefile
+++ b/cmd/soroban-cli/src/utils/contract-template/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
             dbus
             (rust-bin.stable.latest.default.override {
               extensions = [ "rust-src" ];
-              targets = [ "wasm32-unknown-unknown" ];
+              targets = [ "wasm32v1-none" ];
             })
           ] ++ lib.optionals (stdenv.isLinux) [libudev-zero];
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What

Continuing https://github.com/stellar/stellar-cli/pull/1988.

This pull requests selects the proper target based on your running rust version.

```console
$ rustup override set 1.82.0
info: override toolchain for '/Users/fnando/Projects/stellar/hello' set to '1.82.0-aarch64-apple-darwin'

$ stellar contract build
❌ error: rust version 1.82.0 cannot be used to build contracts

$ rustup override set 1.83.0
info: override toolchain for '/Users/fnando/Projects/stellar/hello' set to '1.83.0-aarch64-apple-darwin'

$ stellar contract build
❌ error: rust version 1.83.0 cannot be used to build contracts

$ rustup override set 1.81.0
info: override toolchain for '/Users/fnando/Projects/stellar/hello' set to '1.81.0-aarch64-apple-darwin'

$ stellar contract build
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/foo/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release
    Finished `release` profile [optimized] target(s) in 0.04s
ℹ️ Build Summary:
  Wasm File: target/wasm32-unknown-unknown/release/foo.wasm
  Wasm Hash: 89123eaa2902ec32e26db0141e2d0247e5e00846489f4d8b17d597a85466e863
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/hello_world/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release
    Finished `release` profile [optimized] target(s) in 0.04s
ℹ️ Build Summary:
  Wasm File: target/wasm32-unknown-unknown/release/hello_world.wasm
  Wasm Hash: 89123eaa2902ec32e26db0141e2d0247e5e00846489f4d8b17d597a85466e863
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/test/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release
    Finished `release` profile [optimized] target(s) in 0.04s
ℹ️ Build Summary:
  Wasm File: target/wasm32-unknown-unknown/release/test.wasm
  Wasm Hash: 89123eaa2902ec32e26db0141e2d0247e5e00846489f4d8b17d597a85466e863
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete

$ rustup override set 1.86.0
info: override toolchain for '/Users/fnando/Projects/stellar/hello' set to '1.86.0-aarch64-apple-darwin'

$ stellar contract build
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/foo/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.11s
ℹ️ Build Summary:
  Wasm File: target/wasm32v1-none/release/foo.wasm
  Wasm Hash: c358c50c6b37d298a28552ff8a901d73b4eb92647938f0635918c1bef3bf2ff8
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/hello_world/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.04s
ℹ️ Build Summary:
  Wasm File: target/wasm32v1-none/release/hello_world.wasm
  Wasm Hash: c358c50c6b37d298a28552ff8a901d73b4eb92647938f0635918c1bef3bf2ff8
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/test/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.04s
ℹ️ Build Summary:
  Wasm File: target/wasm32v1-none/release/test.wasm
  Wasm Hash: c358c50c6b37d298a28552ff8a901d73b4eb92647938f0635918c1bef3bf2ff8
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete

$ rustup override set 1.84.0
info: override toolchain for '/Users/fnando/Projects/stellar/hello' set to '1.84.0-aarch64-apple-darwin'

$ stellar contract build
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/foo/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
   Compiling proc-macro2 v1.0.86
   Compiling unicode-ident v1.0.13
   Compiling serde v1.0.210
   Compiling serde_json v1.0.128
   Compiling itoa v1.0.11
   Compiling ryu v1.0.18
   Compiling memchr v2.7.4
   Compiling strsim v0.11.1
   Compiling ident_case v1.0.1
   Compiling autocfg v1.3.0
   Compiling fnv v1.0.7
   Compiling thiserror v1.0.63
   Compiling typenum v1.17.0
   Compiling base32 v0.4.0
   Compiling version_check v0.9.5
   Compiling semver v1.0.23
   Compiling escape-bytes v0.1.1
   Compiling libc v0.2.158
   Compiling either v1.13.0
   Compiling hashbrown v0.14.5
   Compiling num-traits v0.2.19
   Compiling equivalent v1.0.1
   Compiling generic-array v0.14.7
   Compiling prettyplease v0.2.22
   Compiling cfg-if v1.0.0
   Compiling base64 v0.13.1
   Compiling itertools v0.11.0
   Compiling static_assertions v1.1.0
   Compiling rustc_version v0.4.1
   Compiling ethnum v1.5.0
   Compiling quote v1.0.37
   Compiling indexmap v2.5.0
   Compiling syn v2.0.77
   Compiling cpufeatures v0.2.14
   Compiling num-integer v0.1.46
   Compiling wasmparser v0.116.1
   Compiling num-bigint v0.4.6
   Compiling crypto-common v0.1.6
   Compiling block-buffer v0.10.4
   Compiling digest v0.10.7
   Compiling sha2 v0.10.8
   Compiling darling_core v0.20.10
   Compiling serde_derive v1.0.210
   Compiling thiserror-impl v1.0.63
   Compiling num-derive v0.4.2
   Compiling bytes-lit v0.0.5
   Compiling darling_macro v0.20.10
   Compiling darling v0.20.10
   Compiling serde_with_macros v3.9.0
   Compiling serde_with v3.9.0
   Compiling hex v0.4.3
   Compiling crate-git-revision v0.0.6
   Compiling stellar-strkey v0.0.8
   Compiling stellar-xdr v21.2.0
   Compiling soroban-env-common v21.2.1
   Compiling soroban-sdk-macros v21.7.0
   Compiling soroban-spec v21.7.0
   Compiling soroban-spec-rust v21.7.0
   Compiling soroban-env-macros v21.2.1
   Compiling soroban-env-guest v21.2.1
   Compiling soroban-sdk v21.7.0
   Compiling foo v0.0.0 (/Users/fnando/Projects/stellar/hello/contracts/foo)
    Finished `release` profile [optimized] target(s) in 15.23s
ℹ️ Build Summary:
  Wasm File: target/wasm32v1-none/release/foo.wasm
  Wasm Hash: 760dae254be0d102b10cbe4b2ff38b08b83bd8765c5f8cdc2fedde3d2debbac6
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/hello_world/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
   Compiling hello-world v0.0.0 (/Users/fnando/Projects/stellar/hello/contracts/hello_world)
    Finished `release` profile [optimized] target(s) in 0.16s
ℹ️ Build Summary:
  Wasm File: target/wasm32v1-none/release/hello_world.wasm
  Wasm Hash: 760dae254be0d102b10cbe4b2ff38b08b83bd8765c5f8cdc2fedde3d2debbac6
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/test/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
   Compiling test v0.0.0 (/Users/fnando/Projects/stellar/hello/contracts/test)
    Finished `release` profile [optimized] target(s) in 0.16s
ℹ️ Build Summary:
  Wasm File: target/wasm32v1-none/release/test.wasm
  Wasm Hash: 760dae254be0d102b10cbe4b2ff38b08b83bd8765c5f8cdc2fedde3d2debbac6
  Exported Functions: 2 found
    • _
    • hello
✅ Build Complete
```

### Why

So users can build smart contracts independently of the rust version they're using.

### Known limitations

N/A
