### PR TITLE
Remove soroban bin target from stellar-cli crate

### DIFF
--- a/cmd/stellar-cli/Cargo.toml
+++ b/cmd/stellar-cli/Cargo.toml
@@ -16,10 +16,6 @@ default-run = "stellar"
 name = "stellar"
 path = "src/bin/stellar.rs"
 
-[[bin]]
-name = "soroban"
-path = "src/bin/soroban.rs"
-
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"


### PR DESCRIPTION
### What
Remove the soroban binary target from the stellar-cli crate.

### Why
This repo publishes two crates `soroban-cli` and `stellar-cli`, and both publish two binaries `soroban` and `stellar`. The reason for this was to ease folks transition to using a `stellar` binary instead of a `soroban` binary.

The publishing of two crates has been happening since May 2024, so it's been almost 1 year and that seems like a sufficient amount of time to transition.

Mostly we recommend folks install from binary sources like Homebrew and WinGet now, and at both of those locations you only get a `stellar` binary. Also, sometime ago we stopped publishing the soroban binary on the GitHub releases.

I think because of all of the above we can remove the `soroban` binary from the `stellar-cli` crate and doing so should have minimal impact.

A reason to do this is because the cargo-binstall install method, used by some folks in the Rust ecosystem, doesn't support additional binaries not being present in the compressed archive files. The impact this has is that installing the stellar-cli using cargo-binstall always rebuilds from source, even though a binary is available.

CLose #1678