### PR TITLE
Remove contract alias length limit

### DIFF
--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/src/lib.rs
@@ -118,7 +118,7 @@ impl CustomAccountInterface for Contract {
                 Context::CreateContractWithCtorHostFn(_) | Context::CreateContractHostFn(_) => {
                     return Err(Error::InvalidContext)
                 }
-            };
+            }
         }
 
         // Dummy public key verification check

--- a/cmd/soroban-cli/src/commands/contract/deploy/utils.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/utils.rs
@@ -2,14 +2,12 @@ use regex::Regex;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error(
-        "alias must be 1-30 chars long, and have only letters, numbers, underscores and dashes"
-    )]
+    #[error("alias must have only letters, numbers, underscores and dashes")]
     InvalidAliasFormat { alias: String },
 }
 
 pub fn alias_validator(alias: &str) -> Result<String, Error> {
-    let regex = Regex::new(r"^[a-zA-Z0-9_-]{1,30}$").unwrap();
+    let regex = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
 
     if regex.is_match(alias) {
         Ok(alias.into())
@@ -46,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_alias_validator_with_invalid_inputs() {
-        let invalid_inputs = ["", "invalid!", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"];
+        let invalid_inputs = ["", "invalid!", "oh no"];
 
         for input in invalid_inputs {
             let result = alias_validator(input);

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -112,10 +112,6 @@ pub enum Error {
     Network(#[from] network::Error),
     #[error(transparent)]
     Wasm(#[from] wasm::Error),
-    #[error(
-        "alias must be 1-30 chars long, and have only letters, numbers, underscores and dashes"
-    )]
-    InvalidAliasFormat { alias: String },
     #[error(transparent)]
     Locator(#[from] locator::Error),
     #[error(transparent)]


### PR DESCRIPTION
### What

Remove 30-char length limit on aliases.

### Why

Does this serve a purpose? Will there be actual problems caused by people (or tooling) creating humongously long aliases?

I ran into this limit while incorporating [OpenZeppelin's `fungible-token-interface-example`](https://github.com/OpenZeppelin/stellar-contracts/blob/main/examples/fungible-token-interface/Cargo.toml) into https://github.com/AhaLabs/scaffold-stellar-frontend. The alias is not for human use; it's for tooling. It is generated automatically.

But even if people want to create ridiculously long aliases, why should the CLI limit them?

### Known limitations

None???
