### PR TITLE
fix(ts-bindings): valid TS when >1 contracterror

### DIFF
--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use sha2::{Digest, Sha256};
 use stellar_xdr::curr::{Limits, ScSpecEntry, WriteXdr};
 
-use types::Entry;
+use types::{Entry, ErrorEnumCase};
 
 use soroban_spec::read::{from_wasm, FromWasmError};
 
@@ -121,14 +121,7 @@ export class Client extends ContractClient {{
 }
 
 pub fn generate(spec: &[ScSpecEntry]) -> String {
-    let mut collected: Vec<_> = spec.iter().map(Entry::from).collect();
-    if !spec.iter().any(is_error_enum) {
-        collected.push(Entry::ErrorEnum {
-            doc: String::new(),
-            name: "Error".to_string(),
-            cases: vec![],
-        });
-    }
+    let collected: Vec<_> = spec.iter().map(Entry::from).collect();
     let mut constructor_args: Option<Vec<types::FunctionInput>> = None;
     // Filter out function entries with names that start with "__" and partition the results
     collected.iter().for_each(|entry| match entry {
@@ -143,7 +136,7 @@ pub fn generate(spec: &[ScSpecEntry]) -> String {
         .partition(|entry| matches!(entry, Entry::Function { .. }));
     let top = other.iter().map(entry_to_method_type).join("\n");
     let bottom = generate_class(&fns, constructor_args, spec);
-    format!("{top}\n\n{bottom}")
+    format!("{top}\n{bottom}")
 }
 
 fn doc_to_ts_doc(doc: &str, method: Option<&str>, indent_level: usize) -> String {
@@ -176,10 +169,6 @@ fn doc_to_ts_doc(doc: &str, method: Option<&str>, indent_level: usize) -> String
 {indent} */
 "
     )
-}
-
-fn is_error_enum(entry: &ScSpecEntry) -> bool {
-    matches!(entry, ScSpecEntry::UdtErrorEnumV0(_))
 }
 
 const METHOD_OPTIONS: &str = r"{
@@ -266,7 +255,7 @@ pub fn entry_to_method_type(entry: &Entry) -> String {
         Entry::TupleStruct { doc, name, fields } => {
             let docs = doc_to_ts_doc(doc, None, 0);
             let fields = fields.iter().map(type_to_ts).join(",  ");
-            format!("{docs}export type {name} = readonly [{fields}];")
+            format!("{docs}export type {name} = readonly [{fields}];\n")
         }
 
         Entry::Union { name, doc, cases } => {
@@ -293,33 +282,27 @@ pub fn entry_to_method_type(entry: &Entry) -> String {
 ",
             )
         }
-        Entry::ErrorEnum { doc, cases, .. } => {
+        Entry::ErrorEnum { doc, cases, name } => {
             let doc = doc_to_ts_doc(doc, None, 0);
-            let cases = cases
-                .iter()
-                .enumerate()
-                .map(|(i, c)| {
-                    if c.doc.is_empty() {
-                        format!(
-                            "{}  {}: {{message:\"{}\"}}",
-                            if i == 0 { "" } else { "\n" },
-                            c.value,
-                            c.name
-                        )
-                    } else {
-                        format!(
-                            "{}{}  {}: {{message:\"{}\"}}",
-                            if i == 0 { "" } else { "\n" },
-                            doc_to_ts_doc(&c.doc, None, 1),
-                            c.value,
-                            c.name
-                        )
-                    }
-                })
-                .join(",\n");
-            format!("{doc}export const Errors = {{\n{cases}\n}}")
+            let cases = cases.iter().map(error_case_to_ts).join(",\n");
+            let name = if name == "Error" {
+                format!("{name}s")
+            } else {
+                name.to_string()
+            };
+            format!(
+                r"{doc}export const {name} = {{
+  {cases}
+}}
+",
+            )
         }
     }
+}
+
+fn error_case_to_ts(ErrorEnumCase { doc, value, name }: &types::ErrorEnumCase) -> String {
+    let doc = doc_to_ts_doc(doc, None, 1);
+    format!("{doc}  {value}: {{message:\"{name}\"}}")
 }
 
 fn enum_case_to_ts(case: &types::EnumCase) -> String {

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/src/lib.rs
@@ -52,6 +52,16 @@ pub enum Error {
     /// Please provide an odd number
     NumberMustBeOdd = 1,
 }
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Erroneous {
+    /// Some contract libraries contain extra #[contracterror] definitions that end up compiled
+    /// into the main contract types. We need to make sure tooling deals with this properly.
+    HowCouldYou = 100,
+}
+
 #[contractimpl]
 impl Contract {
     pub fn hello(_env: Env, hello: Symbol) -> Symbol {


### PR DESCRIPTION
We were generating a separate `const Errors` definition for every `#[contracterror]` in the original contract source. For example, with the new `custom_type` source code, the generated TS would be:

```ts
export const Errors = {
  /**
   * Please provide an odd number
   */
  1: {message:"NumberMustBeOdd"}
}
export const Errors = {
  /**
   * Some contract libraries contain extra #[contracterror] definitions that end up compiled
   * into the main contract types. We need to make sure tooling deals with this properly.
   */
  100: {message:"HowCouldYou"}
}
```

This now names the `const` after the name of the error enum in the original file, following the logic of other enum types. It will also rename `Error` to `Errors`, to avoid conflicts with JS `Error` type. So the updated `custom_type` source code now generates:

```ts
export const Errors = {
  /**
   * Please provide an odd number
   */
  1: {message:"NumberMustBeOdd"}
}
export const Erroneous = {
  /**
   * Some contract libraries contain extra #[contracterror] definitions that end up compiled
   * into the main contract types. We need to make sure tooling deals with this properly.
   */
  100: {message:"HowCouldYou"}
}
```

These constants are NOT ACTUALLY USED by the TS, but are continuing to be exported to avoid considering this a breaking change to the library generation logic.

This is needed in order to generate TS bindings for [OpenZeppelin's Fungible Token][1]. The contract itself defines [`contracterror` number 1][2], the `pausable` libraries defines [100-series `contracterror`s][3], and the `fungible` library creates [200-series `contracterror`s][4].

  [1]: https://github.com/OpenZeppelin/stellar-contracts/blob/main/examples/fungible-token-interface/src/contract.rs
  [2]: https://github.com/OpenZeppelin/stellar-contracts/blob/54eec16f8f8d8373936147464d6eb81eff3c58c2/examples/fungible-token-interface/src/contract.rs#L29C1-L34C2
  [3]: https://github.com/OpenZeppelin/stellar-contracts/blob/54eec16f8f8d8373936147464d6eb81eff3c58c2/packages/contract-utils/pausable/src/pausable.rs#L74-L82
  [4]: https://github.com/OpenZeppelin/stellar-contracts/blob/54eec16f8f8d8373936147464d6eb81eff3c58c2/packages/tokens/fungible/src/fungible.rs#L156-L182
