### PR TITLE
Make envelope the default fetch when no subcommand is given

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -2391,7 +2391,7 @@ Fetch a transaction from the network by hash If no subcommand is passed in, the 
 
 ###### **Options:**
 
-* `--hash <HASH>`
+* `--hash <HASH>` — Hash of transaction to fetch
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1584,7 +1584,7 @@ Sign, Simulate, and Send transactions
 * `send` — Send a transaction envelope to the network
 * `sign` — Sign a transaction envelope appending the signature to the envelope
 * `simulate` — Simulate a transaction envelope from stdin
-* `fetch` — Fetch a transaction from the network by hash
+* `fetch` — Fetch a transaction from the network by hash If no subcommand is passed in, the transaction envelope will be returned
 
 
 
@@ -2379,15 +2379,35 @@ Simulate a transaction envelope from stdin
 
 ## `stellar tx fetch`
 
-Fetch a transaction from the network by hash
+Fetch a transaction from the network by hash If no subcommand is passed in, the transaction envelope will be returned
 
-**Usage:** `stellar tx fetch <COMMAND>`
+**Usage:** `stellar tx fetch [OPTIONS]
+       fetch <COMMAND>`
 
 ###### **Subcommands:**
 
 * `result` — Fetch the transaction result
 * `meta` — Fetch the transaction meta
-* `envelope` — Fetch the transaction envelope
+
+###### **Options:**
+
+* `--hash <HASH>`
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `--output <OUTPUT>` — Format of the output
+
+  Default value: `json`
+
+  Possible values:
+  - `json`:
+    JSON output of the ledger entry with parsed XDRs (one line, not formatted)
+  - `json-formatted`:
+    Formatted (multiline) JSON output of the ledger entry with parsed XDRs
+  - `xdr`:
+    Original RPC output (containing XDRs)
+
 
 
 
@@ -2395,14 +2415,11 @@ Fetch a transaction from the network by hash
 
 Fetch the transaction result
 
-**Usage:** `stellar tx fetch result [OPTIONS] <HASH>`
-
-###### **Arguments:**
-
-* `<HASH>` — Transaction hash to fetch
+**Usage:** `stellar tx fetch result [OPTIONS] --hash <HASH>`
 
 ###### **Options:**
 
+* `--hash <HASH>` — Transaction hash to fetch
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
@@ -2426,45 +2443,11 @@ Fetch the transaction result
 
 Fetch the transaction meta
 
-**Usage:** `stellar tx fetch meta [OPTIONS] <HASH>`
-
-###### **Arguments:**
-
-* `<HASH>` — Transaction hash to fetch
+**Usage:** `stellar tx fetch meta [OPTIONS] --hash <HASH>`
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
-
-  Default value: `json`
-
-  Possible values:
-  - `json`:
-    JSON output of the ledger entry with parsed XDRs (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the ledger entry with parsed XDRs
-  - `xdr`:
-    Original RPC output (containing XDRs)
-
-
-
-
-## `stellar tx fetch envelope`
-
-Fetch the transaction envelope
-
-**Usage:** `stellar tx fetch envelope [OPTIONS] <HASH>`
-
-###### **Arguments:**
-
-* `<HASH>` — Transaction hash to fetch
-
-###### **Options:**
-
+* `--hash <HASH>` — Transaction hash to fetch
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server

--- a/cmd/crates/soroban-test/tests/it/integration/tx/fetch.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/fetch.rs
@@ -22,6 +22,7 @@ async fn tx_fetch() {
         .new_assert_cmd("tx")
         .arg("fetch")
         .arg("result")
+        .arg("--hash")
         .arg(&tx_hash)
         .arg("--network")
         .arg("testnet")
@@ -42,6 +43,7 @@ async fn tx_fetch() {
         .new_assert_cmd("tx")
         .arg("fetch")
         .arg("meta")
+        .arg("--hash")
         .arg(&tx_hash)
         .arg("--network")
         .arg("testnet")
@@ -57,6 +59,35 @@ async fn tx_fetch() {
         .new_assert_cmd("tx")
         .arg("fetch")
         .arg("envelope")
+        .arg("--hash")
+        .arg(&tx_hash)
+        .arg("--network")
+        .arg("testnet")
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    let parsed: TransactionEnvelope = serde_json::from_str(&output).unwrap();
+    assert!(matches!(
+        parsed,
+        TransactionEnvelope::Tx(TransactionV1Envelope { .. })
+    ));
+}
+
+#[tokio::test]
+async fn tx_fetch_default_to_envelope() {
+    let sandbox = &TestEnv::new();
+    let test_account_alias = "test";
+    // create a tx
+    let data_name = "test_data_key";
+    let data_value = "abcdef";
+    let tx_hash = add_account_data(sandbox, test_account_alias, data_name, data_value).await;
+
+    // fetch the tx envelope when no subcommand is given
+    let output = sandbox
+        .new_assert_cmd("tx")
+        .arg("fetch")
+        .arg("--hash")
         .arg(&tx_hash)
         .arg("--network")
         .arg("testnet")
@@ -85,6 +116,7 @@ async fn tx_fetch_xdr_output() {
         .new_assert_cmd("tx")
         .arg("fetch")
         .arg("result")
+        .arg("--hash")
         .arg(&tx_hash)
         .arg("--network")
         .arg("testnet")
@@ -107,6 +139,7 @@ async fn tx_fetch_xdr_output() {
         .new_assert_cmd("tx")
         .arg("fetch")
         .arg("meta")
+        .arg("--hash")
         .arg(&tx_hash)
         .arg("--network")
         .arg("testnet")
@@ -124,6 +157,7 @@ async fn tx_fetch_xdr_output() {
         .new_assert_cmd("tx")
         .arg("fetch")
         .arg("envelope")
+        .arg("--hash")
         .arg(&tx_hash)
         .arg("--network")
         .arg("testnet")

--- a/cmd/soroban-cli/src/commands/tx/fetch/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/args.rs
@@ -1,0 +1,72 @@
+use crate::{
+    config::{
+        locator,
+        network::{self, Network},
+    },
+    rpc,
+    xdr::{self, Hash},
+};
+
+#[derive(Debug, Clone, clap::Parser)]
+// #[group(skip)]
+pub struct Args {
+    #[arg(long)]
+    pub hash: Hash,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    /// Format of the output
+    #[arg(long, default_value = "json")]
+    pub output: OutputFormat,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Rpc(#[from] rpc::Error),
+    #[error(transparent)]
+    Xdr(#[from] xdr::Error),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]
+pub enum OutputFormat {
+    /// JSON output of the ledger entry with parsed XDRs (one line, not formatted)
+    #[default]
+    Json,
+    /// Formatted (multiline) JSON output of the ledger entry with parsed XDRs
+    JsonFormatted,
+    /// Original RPC output (containing XDRs)
+    Xdr,
+}
+
+impl Args {
+    // pub async fn run(&self) -> Result<(), Error> {
+    //         let network = self.network.get(&self.locator)?;
+    //         let client = network.rpc_client()?;
+    //         let tx_hash = self.hash.clone();
+    //         match self.output {
+    //             OutputFormat::Json => {
+    //                 let resp = client.get_transaction(&tx_hash).await?;
+    //                 let envelope = resp.envelope.unwrap();
+    //                 println!("{}", serde_json::to_string(&envelope)?);
+    //             }
+    //             OutputFormat::Xdr => {
+    //                 let resp = client.get_transaction(&tx_hash).await?;
+    //                 let resp_as_xdr: GetTransactionResponseRaw = resp.clone().try_into()?;
+    //                 let envelope = resp_as_xdr.envelope_xdr;
+    //                 println!("{}", serde_json::to_string(&envelope)?);
+    //             }
+    //             OutputFormat::JsonFormatted => {
+    //                 let resp = client.get_transaction(&tx_hash).await?;
+    //                 let envelope = resp.envelope.unwrap();
+    //                 println!("{}", serde_json::to_string_pretty(&envelope)?);
+    //             }
+    //         }
+    //         Ok(())
+    //     }
+}

--- a/cmd/soroban-cli/src/commands/tx/fetch/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/args.rs
@@ -1,15 +1,13 @@
+use soroban_rpc::GetTransactionResponse;
+
 use crate::{
-    config::{
-        locator,
-        network::{self, Network},
-    },
-    rpc,
-    xdr::{self, Hash},
+    commands::global, config::network, rpc, xdr::{self, Hash}
 };
 
 #[derive(Debug, Clone, clap::Parser)]
 // #[group(skip)]
 pub struct Args {
+    /// Transaction hash to fetch
     #[arg(long)]
     pub hash: Hash,
 
@@ -45,28 +43,10 @@ pub enum OutputFormat {
 }
 
 impl Args {
-    // pub async fn run(&self) -> Result<(), Error> {
-    //         let network = self.network.get(&self.locator)?;
-    //         let client = network.rpc_client()?;
-    //         let tx_hash = self.hash.clone();
-    //         match self.output {
-    //             OutputFormat::Json => {
-    //                 let resp = client.get_transaction(&tx_hash).await?;
-    //                 let envelope = resp.envelope.unwrap();
-    //                 println!("{}", serde_json::to_string(&envelope)?);
-    //             }
-    //             OutputFormat::Xdr => {
-    //                 let resp = client.get_transaction(&tx_hash).await?;
-    //                 let resp_as_xdr: GetTransactionResponseRaw = resp.clone().try_into()?;
-    //                 let envelope = resp_as_xdr.envelope_xdr;
-    //                 println!("{}", serde_json::to_string(&envelope)?);
-    //             }
-    //             OutputFormat::JsonFormatted => {
-    //                 let resp = client.get_transaction(&tx_hash).await?;
-    //                 let envelope = resp.envelope.unwrap();
-    //                 println!("{}", serde_json::to_string_pretty(&envelope)?);
-    //             }
-    //         }
-    //         Ok(())
-    //     }
+    pub async fn fetch_transaction(&self, global_args: &global::Args) -> Result<GetTransactionResponse, Error> {
+        let network = self.network.get(&global_args.locator)?;
+        let client = network.rpc_client()?;
+        let tx_hash = self.hash.clone();
+        Ok(client.get_transaction(&tx_hash).await?)
+    }
 }

--- a/cmd/soroban-cli/src/commands/tx/fetch/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/args.rs
@@ -1,7 +1,10 @@
 use soroban_rpc::GetTransactionResponse;
 
 use crate::{
-    commands::global, config::network, rpc, xdr::{self, Hash}
+    commands::global,
+    config::network,
+    rpc,
+    xdr::{self, Hash},
 };
 
 #[derive(Debug, Clone, clap::Parser)]
@@ -43,7 +46,10 @@ pub enum OutputFormat {
 }
 
 impl Args {
-    pub async fn fetch_transaction(&self, global_args: &global::Args) -> Result<GetTransactionResponse, Error> {
+    pub async fn fetch_transaction(
+        &self,
+        global_args: &global::Args,
+    ) -> Result<GetTransactionResponse, Error> {
         let network = self.network.get(&global_args.locator)?;
         let client = network.rpc_client()?;
         let tx_hash = self.hash.clone();

--- a/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
@@ -11,55 +11,37 @@ use super::args;
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// Transaction hash to fetch
-    #[arg(long)]
-    pub hash: Hash,
-
     #[command(flatten)]
-    pub network: network::Args,
-
-    /// Format of the output
-    #[arg(long, default_value = "json")]
-    pub output: args::OutputFormat,
+    pub(crate) args: args::Args
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    Network(#[from] network::Error),
-    #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error(transparent)]
-    Rpc(#[from] rpc::Error),
-    #[error(transparent)]
     Xdr(#[from] xdr::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error)
 }
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let network = self.network.get(&global_args.locator)?;
-        let client = network.rpc_client()?;
-        let tx_hash = self.hash.clone();
-        match self.output {
-            args::OutputFormat::Json => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(envelope) = resp.envelope {
+        let resp = self.args.fetch_transaction(global_args).await?;
+        if let Some(envelope) = resp.envelope {
+            match self.args.output {
+                args::OutputFormat::Json => {
                     println!("{}", serde_json::to_string(&envelope)?);
                 }
-            }
-            args::OutputFormat::Xdr => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(envelope) = resp.envelope {
+                args::OutputFormat::Xdr => {
                     let envelope_xdr = envelope.to_xdr_base64(Limits::none()).unwrap();
                     println!("{envelope_xdr}");
                 }
-            }
-            args::OutputFormat::JsonFormatted => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(envelope) = resp.envelope {
+                args::OutputFormat::JsonFormatted => {
                     println!("{}", serde_json::to_string_pretty(&envelope)?);
                 }
             }
+
         }
 
         Ok(())

--- a/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
@@ -23,7 +23,6 @@ pub struct Cmd {
     pub output: args::OutputFormat,
 }
 
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]

--- a/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
@@ -1,8 +1,6 @@
 use crate::{
     commands::global,
-    config::network,
-    rpc,
-    xdr::{self, Hash, Limits, WriteXdr},
+    xdr::{self, Limits, WriteXdr},
 };
 use clap::{command, Parser};
 
@@ -12,7 +10,7 @@ use super::args;
 #[group(skip)]
 pub struct Cmd {
     #[command(flatten)]
-    pub(crate) args: args::Args
+    pub(crate) args: args::Args,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -22,7 +20,7 @@ pub enum Error {
     #[error(transparent)]
     Xdr(#[from] xdr::Error),
     #[error(transparent)]
-    Args(#[from] args::Error)
+    Args(#[from] args::Error),
 }
 
 impl Cmd {
@@ -41,7 +39,6 @@ impl Cmd {
                     println!("{}", serde_json::to_string_pretty(&envelope)?);
                 }
             }
-
         }
 
         Ok(())

--- a/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
@@ -6,31 +6,23 @@ use crate::{
 };
 use clap::{command, Parser};
 
+use super::args;
+
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// Transaction hash to fetch
-    #[arg(long)]
-    pub hash: Hash,
-
     #[command(flatten)]
-    pub network: network::Args,
-
-    /// Format of the output
-    #[arg(long, default_value = "json")]
-    pub output: OutputFormat,
+    args: args::Args
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    Network(#[from] network::Error),
-    #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error(transparent)]
-    Rpc(#[from] rpc::Error),
-    #[error(transparent)]
     Xdr(#[from] xdr::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error)
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]
@@ -46,31 +38,21 @@ pub enum OutputFormat {
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let network = self.network.get(&global_args.locator)?;
-        let client = network.rpc_client()?;
-        let tx_hash = self.hash.clone();
-        match self.output {
-            OutputFormat::Json => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(meta) = resp.result_meta {
+        let resp = self.args.fetch_transaction(global_args).await?;
+        if let Some(meta) = resp.result_meta {
+            match self.args.output {
+                args::OutputFormat::Json => {
                     println!("{}", serde_json::to_string(&meta)?);
                 }
-            }
-            OutputFormat::Xdr => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(meta) = resp.result_meta {
+                args::OutputFormat::Xdr => {
                     let meta_xdr = meta.to_xdr_base64(Limits::none()).unwrap();
                     println!("{meta_xdr}");
                 }
-            }
-            OutputFormat::JsonFormatted => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(meta) = resp.result_meta {
+                args::OutputFormat::JsonFormatted => {
                     println!("{}", serde_json::to_string_pretty(&meta)?);
                 }
             }
         }
-
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
@@ -1,8 +1,6 @@
 use crate::{
     commands::global,
-    config::network,
-    rpc,
-    xdr::{self, Hash, Limits, WriteXdr},
+    xdr::{self, Limits, WriteXdr},
 };
 use clap::{command, Parser};
 
@@ -12,7 +10,7 @@ use super::args;
 #[group(skip)]
 pub struct Cmd {
     #[command(flatten)]
-    args: args::Args
+    args: args::Args,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -22,7 +20,7 @@ pub enum Error {
     #[error(transparent)]
     Xdr(#[from] xdr::Error),
     #[error(transparent)]
-    Args(#[from] args::Error)
+    Args(#[from] args::Error),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]

--- a/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
@@ -10,6 +10,7 @@ use clap::{command, Parser};
 #[group(skip)]
 pub struct Cmd {
     /// Transaction hash to fetch
+    #[arg(long)]
     pub hash: Hash,
 
     #[command(flatten)]

--- a/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
@@ -1,19 +1,12 @@
 use clap::{command, Parser, Subcommand};
 use std::fmt::Debug;
 
-use crate::{
-    commands::global,
-    config::network,
-    rpc,
-    xdr::{self, Hash, Limits, WriteXdr},
-};
+use crate::{commands::global, config::network, xdr::Hash};
 
+mod args;
 mod envelope;
 mod meta;
 mod result;
-mod args;
-
-
 
 #[derive(Debug, clap::Args)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -32,6 +25,7 @@ pub enum FetchCommands {
     /// Fetch the transaction meta
     Meta(meta::Cmd),
     /// Fetch the transaction envelope
+    #[command(hide = true)]
     Envelope(envelope::Cmd),
 }
 
@@ -65,13 +59,14 @@ impl Cmd {
             Some(FetchCommands::Meta(cmd)) => cmd.run(global_args).await?,
             Some(FetchCommands::Envelope(cmd)) => cmd.run(global_args).await?,
             None => {
-                envelope::Cmd{ 
-                    hash: self.default.hash.clone().unwrap(), 
+                envelope::Cmd {
+                    hash: self.default.hash.clone().unwrap(),
                     network: self.default.network.clone().unwrap(),
-                    output: self.default.output.clone().unwrap()
-                }.run(global_args).await?
-                
-            },
+                    output: self.default.output.clone().unwrap(),
+                }
+                .run(global_args)
+                .await?
+            }
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
@@ -1,20 +1,51 @@
-use clap::Parser;
+use clap::{command, Parser, Subcommand};
 use std::fmt::Debug;
 
-use crate::commands::global;
+use crate::{
+    commands::global,
+    config::network,
+    rpc,
+    xdr::{self, Hash, Limits, WriteXdr},
+};
 
 mod envelope;
 mod meta;
 mod result;
+mod args;
 
-#[derive(Debug, Parser)]
-pub enum Cmd {
+
+
+#[derive(Debug, clap::Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Cmd {
+    #[command(subcommand)]
+    subcommand: Option<FetchCommands>,
+
+    #[command(flatten)]
+    default: DefaultArgs,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum FetchCommands {
     /// Fetch the transaction result
     Result(result::Cmd),
     /// Fetch the transaction meta
     Meta(meta::Cmd),
     /// Fetch the transaction envelope
     Envelope(envelope::Cmd),
+}
+
+#[derive(Debug, clap::Args)]
+struct DefaultArgs {
+    #[arg(long)]
+    pub hash: Option<Hash>,
+
+    #[command(flatten)]
+    pub network: Option<network::Args>,
+
+    /// Format of the output
+    #[arg(long, default_value = "json")]
+    pub output: Option<args::OutputFormat>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -29,10 +60,18 @@ pub enum Error {
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        match self {
-            Cmd::Result(cmd) => cmd.run(global_args).await?,
-            Cmd::Meta(cmd) => cmd.run(global_args).await?,
-            Cmd::Envelope(cmd) => cmd.run(global_args).await?,
+        match &self.subcommand {
+            Some(FetchCommands::Result(cmd)) => cmd.run(global_args).await?,
+            Some(FetchCommands::Meta(cmd)) => cmd.run(global_args).await?,
+            Some(FetchCommands::Envelope(cmd)) => cmd.run(global_args).await?,
+            None => {
+                envelope::Cmd{ 
+                    hash: self.default.hash.clone().unwrap(), 
+                    network: self.default.network.clone().unwrap(),
+                    output: self.default.output.clone().unwrap()
+                }.run(global_args).await?
+                
+            },
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
@@ -61,11 +61,11 @@ impl Cmd {
             Some(FetchCommands::Envelope(cmd)) => cmd.run(global_args).await?,
             None => {
                 envelope::Cmd {
-                    args: args::Args{
+                    args: args::Args {
                         hash: self.default.hash.clone().unwrap(),
                         network: self.default.network.clone().unwrap(),
                         output: self.default.output.clone().unwrap(),
-                    }
+                    },
                 }
                 .run(global_args)
                 .await?

--- a/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
@@ -1,4 +1,4 @@
-use clap::{command, Parser, Subcommand};
+use clap::{command, Subcommand};
 use std::fmt::Debug;
 
 use crate::{commands::global, config::network, xdr::Hash};
@@ -31,6 +31,7 @@ pub enum FetchCommands {
 
 #[derive(Debug, clap::Args)]
 struct DefaultArgs {
+    /// Hash of transaction to fetch
     #[arg(long)]
     pub hash: Option<Hash>,
 
@@ -60,9 +61,11 @@ impl Cmd {
             Some(FetchCommands::Envelope(cmd)) => cmd.run(global_args).await?,
             None => {
                 envelope::Cmd {
-                    hash: self.default.hash.clone().unwrap(),
-                    network: self.default.network.clone().unwrap(),
-                    output: self.default.output.clone().unwrap(),
+                    args: args::Args{
+                        hash: self.default.hash.clone().unwrap(),
+                        network: self.default.network.clone().unwrap(),
+                        output: self.default.output.clone().unwrap(),
+                    }
                 }
                 .run(global_args)
                 .await?

--- a/cmd/soroban-cli/src/commands/tx/fetch/result.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/result.rs
@@ -5,32 +5,23 @@ use crate::{
     xdr::{self, Hash, Limits, WriteXdr},
 };
 use clap::{command, Parser};
+use super::args;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// Transaction hash to fetch
-    #[arg(long)]
-    pub hash: Hash,
-
     #[command(flatten)]
-    pub network: network::Args,
-
-    /// Format of the output
-    #[arg(long, default_value = "json")]
-    pub output: OutputFormat,
+    args: args::Args
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    Network(#[from] network::Error),
-    #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error(transparent)]
-    Rpc(#[from] rpc::Error),
-    #[error(transparent)]
     Xdr(#[from] xdr::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error)
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]
@@ -46,26 +37,17 @@ pub enum OutputFormat {
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
-        let network = self.network.get(&global_args.locator)?;
-        let client = network.rpc_client()?;
-        let tx_hash = self.hash.clone();
-        match self.output {
-            OutputFormat::Json => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(result) = resp.result {
+        let resp = self.args.fetch_transaction(global_args).await?;
+        if let Some(result) = resp.result {
+            match self.args.output {
+                args::OutputFormat::Json => {
                     println!("{}", serde_json::to_string(&result)?);
                 }
-            }
-            OutputFormat::Xdr => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(result) = resp.result {
+                args::OutputFormat::Xdr => {
                     let result_xdr = result.to_xdr_base64(Limits::none()).unwrap();
                     println!("{}", &result_xdr);
                 }
-            }
-            OutputFormat::JsonFormatted => {
-                let resp = client.get_transaction(&tx_hash).await?;
-                if let Some(result) = resp.result {
+                args::OutputFormat::JsonFormatted => {
                     println!("{}", serde_json::to_string_pretty(&result)?);
                 }
             }

--- a/cmd/soroban-cli/src/commands/tx/fetch/result.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/result.rs
@@ -1,17 +1,15 @@
+use super::args;
 use crate::{
     commands::global,
-    config::network,
-    rpc,
-    xdr::{self, Hash, Limits, WriteXdr},
+    xdr::{self, Limits, WriteXdr},
 };
 use clap::{command, Parser};
-use super::args;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
     #[command(flatten)]
-    args: args::Args
+    args: args::Args,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -21,7 +19,7 @@ pub enum Error {
     #[error(transparent)]
     Xdr(#[from] xdr::Error),
     #[error(transparent)]
-    Args(#[from] args::Error)
+    Args(#[from] args::Error),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]

--- a/cmd/soroban-cli/src/commands/tx/fetch/result.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/result.rs
@@ -10,6 +10,7 @@ use clap::{command, Parser};
 #[group(skip)]
 pub struct Cmd {
     /// Transaction hash to fetch
+    #[arg(long)]
     pub hash: Hash,
 
     #[command(flatten)]

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -47,6 +47,7 @@ pub enum Cmd {
     /// Simulate a transaction envelope from stdin
     Simulate(simulate::Cmd),
     /// Fetch a transaction from the network by hash
+    /// If no subcommand is passed in, the transaction envelope will be returned
     Fetch(fetch::Cmd),
 }
 

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -47,7 +47,6 @@ pub enum Cmd {
     /// Simulate a transaction envelope from stdin
     Simulate(simulate::Cmd),
     /// Fetch a transaction from the network by hash
-    #[command(subcommand)]
     Fetch(fetch::Cmd),
 }
 

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -60,7 +60,7 @@ STELLAR_NETWORK, STELLAR_RPC_URL and STELLAR_NETWORK_PASSPHRASE"#
 }
 
 #[derive(Debug, clap::Args, Clone, Default)]
-#[group(skip)]
+#[group(id = "network-args")]
 pub struct Args {
     /// RPC server endpoint
     #[arg(


### PR DESCRIPTION
In order to flatten an optional field, I needed to remove the group(skip) on network::Args. But this lead to a conflict because there are multiple groups with an implicit name of 'Args' that were all trying to be flattened. The solution to this was add a specific group id to network::Args.

