### PR TITLE
nix: move `pkg-config` to `nativeBuildInputs`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,13 @@
         stellardev = {
           name = "stellar";
           src = ./.;
-          nativeBuildInputs = pkgs.lib.optionals (pkgs.stdenv.isDarwin) [
+          nativeBuildInputs = (pkgs.lib.optionals (pkgs.stdenv.isDarwin) [
             pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
+          ]) ++ (with pkgs; [
+            pkg-config
+          ]);
           buildInputs = with pkgs; [
             openssl
-            pkg-config
             jq
             dbus
             (rust-bin.stable.latest.default.override {


### PR DESCRIPTION
### What

In the `stellar-cli` derivation in the nix flake, `pkg-config` was moved from `buildInputs` to `nativeBuildInputs`.

### Why

Prior to this change, the `stellar-cli` derivation fails to build on NixOS systems as `pkg-config` fails to find openssl when building. `pkg-config` [provides a setup-hook](https://github.com/NixOS/nixpkgs/blob/0039426728da074af7bf4851886758f9f3ee98e7/pkgs/build-support/pkg-config-wrapper/setup-hook.sh) that requires `pkg-config` to be in `nativeBuildInputs`. This setup-hook will look for derivations in `buildInputs` with a `pkgconfig` derivation. With this change, the derivation builds as expected. This kind of issue was also discussed in this [forum thread](https://discourse.nixos.org/t/rust-openssl-woes/12340/5).

<details><summary>Build logs:</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/xkhl4ihbcywlabqh1qn2v6y474ank8x2-00wyibfb5lw8hflri4vjaqyvayvm7wyz-source
source root is 00wyibfb5lw8hflri4vjaqyvayvm7wyz-source
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Executing cargoSetupPostPatchHook
Validating consistency between /build/00wyibfb5lw8hflri4vjaqyvayvm7wyz-source/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing cargoBuildHook
cargoBuildHook flags: -j 12 --target x86_64-unknown-linux-gnu --offline --profile release
[1m[32m   Compiling[0m proc-macro2 v1.0.86
[1m[32m   Compiling[0m unicode-ident v1.0.12
[1m[32m   Compiling[0m cfg-if v1.0.0
[1m[32m   Compiling[0m libc v0.2.155
[1m[32m   Compiling[0m serde v1.0.217
[1m[32m   Compiling[0m autocfg v1.3.0
[1m[32m   Compiling[0m version_check v0.9.5
[1m[32m   Compiling[0m typenum v1.17.0
[1m[32m   Compiling[0m memchr v2.7.4
[1m[32m   Compiling[0m once_cell v1.19.0
[1m[32m   Compiling[0m subtle v2.6.1
[1m[32m   Compiling[0m serde_json v1.0.138
[1m[32m   Compiling[0m itoa v1.0.11
[1m[32m   Compiling[0m ryu v1.0.18
[1m[32m   Compiling[0m smallvec v1.13.2
[1m[32m   Compiling[0m thiserror v1.0.64
[1m[32m   Compiling[0m shlex v1.3.0
[1m[32m   Compiling[0m pin-project-lite v0.2.14
[1m[32m   Compiling[0m log v0.4.22
[1m[32m   Compiling[0m generic-array v0.14.7
[1m[32m   Compiling[0m bytes v1.7.1
[1m[32m   Compiling[0m const-oid v0.9.6
[1m[32m   Compiling[0m cc v1.2.16
[1m[32m   Compiling[0m lock_api v0.4.12
[1m[32m   Compiling[0m parking_lot_core v0.9.10
[1m[32m   Compiling[0m equivalent v1.0.1
[1m[32m   Compiling[0m hashbrown v0.14.5
[1m[32m   Compiling[0m scopeguard v1.2.0
[1m[32m   Compiling[0m futures-core v0.3.31
[1m[32m   Compiling[0m strsim v0.11.1
[1m[32m   Compiling[0m fnv v1.0.7
[1m[32m   Compiling[0m ident_case v1.0.1
[1m[32m   Compiling[0m slab v0.4.9
[1m[32m   Compiling[0m futures-sink v0.3.31
[1m[32m   Compiling[0m tracing-core v0.1.32
[1m[32m   Compiling[0m quote v1.0.37
[1m[32m   Compiling[0m getrandom v0.2.11
[1m[32m   Compiling[0m socket2 v0.5.7
[1m[32m   Compiling[0m mio v1.0.1
[1m[32m   Compiling[0m signal-hook-registry v1.4.2
[1m[32m   Compiling[0m rand_core v0.6.4
[1m[32m   Compiling[0m syn v2.0.87
[1m[32m   Compiling[0m parking_lot v0.12.3
[1m[32m   Compiling[0m futures-io v0.3.31
[1m[32m   Compiling[0m indexmap v2.3.0
[1m[32m   Compiling[0m byteorder v1.5.0
[1m[32m   Compiling[0m futures-channel v0.3.31
[1m[32m   Compiling[0m num-traits v0.2.17
[1m[32m   Compiling[0m futures-task v0.3.31
[1m[32m   Compiling[0m pin-utils v0.1.0
[1m[32m   Compiling[0m syn v1.0.109
[1m[32m   Compiling[0m semver v1.0.20
[1m[32m   Compiling[0m heck v0.5.0
[1m[32m   Compiling[0m stable_deref_trait v1.2.0
[1m[32m   Compiling[0m untrusted v0.9.0
[1m[32m   Compiling[0m anstyle v1.0.8
[1m[32m   Compiling[0m cpufeatures v0.2.12
[1m[32m   Compiling[0m data-encoding v2.6.0
[1m[32m   Compiling[0m httparse v1.9.4
[1m[32m   Compiling[0m utf8parse v0.2.2
[1m[32m   Compiling[0m anstyle-parse v0.2.5
[1m[32m   Compiling[0m try-lock v0.2.5
[1m[32m   Compiling[0m ring v0.17.13
[1m[32m   Compiling[0m pkg-config v0.3.30
[1m[32m   Compiling[0m colorchoice v1.0.2
[1m[32m   Compiling[0m is_terminal_polyfill v1.70.1
[1m[32m   Compiling[0m anstyle-query v1.1.1
[1m[32m   Compiling[0m writeable v0.5.5
[1m[32m   Compiling[0m litemap v0.7.4
[1m[32m   Compiling[0m anstream v0.6.15
[1m[32m   Compiling[0m rustc_version v0.4.1
[1m[32m   Compiling[0m want v0.3.1
[1m[32m   Compiling[0m tower-service v0.3.2
[1m[32m   Compiling[0m clap_lex v0.7.2
[1m[32m   Compiling[0m openssl-probe v0.1.5
[1m[32m   Compiling[0m rustls-pki-types v1.8.0
[1m[32m   Compiling[0m http v1.1.0
[1m[32m   Compiling[0m aho-corasick v1.1.3
[1m[32m   Compiling[0m clap_builder v4.5.14
[1m[32m   Compiling[0m num-bigint v0.4.4
[1m[32m   Compiling[0m regex-syntax v0.8.4
[1m[32m   Compiling[0m icu_locid_transform_data v1.5.0
[1m[32m   Compiling[0m schemars v0.8.21
[1m[32m   Compiling[0m icu_properties_data v1.5.0
[1m[32m   Compiling[0m either v1.13.0
[1m[32m   Compiling[0m dyn-clone v1.0.17
[1m[32m   Compiling[0m num-integer v0.1.45
[1m[32m   Compiling[0m vcpkg v0.2.15
[1m[32m   Compiling[0m paste v1.0.15
[1m[32m   Compiling[0m write16 v1.0.0
[1m[32m   Compiling[0m async-trait v0.1.76
[1m[32m   Compiling[0m icu_normalizer_data v1.5.0
[1m[32m   Compiling[0m base64 v0.13.1
[1m[32m   Compiling[0m bitflags v2.6.0
[1m[32m   Compiling[0m tower-layer v0.3.2
[1m[32m   Compiling[0m utf8_iter v1.0.4
[1m[32m   Compiling[0m utf16_iter v1.0.5
[1m[32m   Compiling[0m escape-bytes v0.1.1
[1m[32m   Compiling[0m openssl-sys v0.9.107
[1m[32m   Compiling[0m http-body v1.0.1
[1m[32m   Compiling[0m percent-encoding v2.3.1
[1m[32m   Compiling[0m atomic-waker v1.1.2
[1m[32m   Compiling[0m form_urlencoded v1.2.1
[1m[33mwarning[0m[1m:[0m openssl-sys@0.9.107: Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the compilation process. See stderr section below for further information.
[1m[31merror[0m[1m:[0m failed to run custom build command for `openssl-sys v0.9.107`

Caused by:
  process didn't exit successfully: `/build/00wyibfb5lw8hflri4vjaqyvayvm7wyz-source/target/release/build/openssl-sys-36876915a18f54cc/build-script-main` (exit status: 101)
  --- stdout
  cargo:rustc-check-cfg=cfg(osslconf, values("OPENSSL_NO_OCB", "OPENSSL_NO_SM4", "OPENSSL_NO_SEED", "OPENSSL_NO_CHACHA", "OPENSSL_NO_CAST", "OPENSSL_NO_IDEA", "OPENSSL_NO_CAMELLIA", "OPENSSL_NO_RC4", "OPENSSL_NO_BF", "OPENSSL_NO_PSK", "OPENSSL_NO_DEPRECATED_3_0", "OPENSSL_NO_SCRYPT", "OPENSSL_NO_SM3", "OPENSSL_NO_RMD160", "OPENSSL_NO_EC2M", "OPENSSL_NO_OCSP", "OPENSSL_NO_CMS", "OPENSSL_NO_COMP", "OPENSSL_NO_SOCK", "OPENSSL_NO_STDIO", "OPENSSL_NO_EC", "OPENSSL_NO_SSL3_METHOD", "OPENSSL_NO_KRB5", "OPENSSL_NO_TLSEXT", "OPENSSL_NO_SRP", "OPENSSL_NO_RFC3779", "OPENSSL_NO_SHA", "OPENSSL_NO_NEXTPROTONEG", "OPENSSL_NO_ENGINE", "OPENSSL_NO_BUF_FREELISTS", "OPENSSL_NO_RC2"))
  cargo:rustc-check-cfg=cfg(openssl)
  cargo:rustc-check-cfg=cfg(libressl)
  cargo:rustc-check-cfg=cfg(boringssl)
  cargo:rustc-check-cfg=cfg(awslc)
  cargo:rustc-check-cfg=cfg(libressl250)
  cargo:rustc-check-cfg=cfg(libressl251)
  cargo:rustc-check-cfg=cfg(libressl252)
  cargo:rustc-check-cfg=cfg(libressl261)
  cargo:rustc-check-cfg=cfg(libressl270)
  cargo:rustc-check-cfg=cfg(libressl271)
  cargo:rustc-check-cfg=cfg(libressl273)
  cargo:rustc-check-cfg=cfg(libressl280)
  cargo:rustc-check-cfg=cfg(libressl281)
  cargo:rustc-check-cfg=cfg(libressl291)
  cargo:rustc-check-cfg=cfg(libressl310)
  cargo:rustc-check-cfg=cfg(libressl321)
  cargo:rustc-check-cfg=cfg(libressl332)
  cargo:rustc-check-cfg=cfg(libressl340)
  cargo:rustc-check-cfg=cfg(libressl350)
  cargo:rustc-check-cfg=cfg(libressl360)
  cargo:rustc-check-cfg=cfg(libressl361)
  cargo:rustc-check-cfg=cfg(libressl370)
  cargo:rustc-check-cfg=cfg(libressl380)
  cargo:rustc-check-cfg=cfg(libressl381)
  cargo:rustc-check-cfg=cfg(libressl382)
  cargo:rustc-check-cfg=cfg(libressl390)
  cargo:rustc-check-cfg=cfg(libressl400)
  cargo:rustc-check-cfg=cfg(libressl410)
  cargo:rustc-check-cfg=cfg(ossl101)
  cargo:rustc-check-cfg=cfg(ossl102)
  cargo:rustc-check-cfg=cfg(ossl102f)
  cargo:rustc-check-cfg=cfg(ossl102h)
  cargo:rustc-check-cfg=cfg(ossl110)
  cargo:rustc-check-cfg=cfg(ossl110f)
  cargo:rustc-check-cfg=cfg(ossl110g)
  cargo:rustc-check-cfg=cfg(ossl110h)
  cargo:rustc-check-cfg=cfg(ossl111)
  cargo:rustc-check-cfg=cfg(ossl111b)
  cargo:rustc-check-cfg=cfg(ossl111c)
  cargo:rustc-check-cfg=cfg(ossl111d)
  cargo:rustc-check-cfg=cfg(ossl300)
  cargo:rustc-check-cfg=cfg(ossl310)
  cargo:rustc-check-cfg=cfg(ossl320)
  cargo:rustc-check-cfg=cfg(ossl330)
  cargo:rustc-check-cfg=cfg(ossl340)
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR


  Could not find openssl via pkg-config:
  Could not run `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags openssl`
  The pkg-config command could not be found.

  Most likely, you need to install a pkg-config package for your OS.
  Try `apt install pkg-config`, or `yum install pkg-config`,
  or `pkg install pkg-config`, or `apk add pkgconfig` depending on your distribution.

  If you've already installed it, ensure the pkg-config command is one of the
  directories in the PATH environment variable.

  If you did not expect this build to link to a pre-installed system library,
  then check documentation of the openssl-sys crate for an option to
  build the library from source, or disable features or dependencies
  that require pkg-config.

  cargo:warning=Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the compilation process. See stderr section below for further information.

  --- stderr


  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.107


  It looks like you're compiling on Linux and also targeting Linux. Currently this
  requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
  could not be found. If you have OpenSSL installed you can likely fix this by
  installing `pkg-config`.


[1m[33mwarning[0m[1m:[0m build failed, waiting for other jobs to finish...
```
</details> 

### Known limitations

N/A