### PR TITLE
Feat/expose build_custom_cmd

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
+++ b/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
@@ -174,7 +174,7 @@ pub fn build_host_function_parameters(
     Ok((function.clone(), spec, invoke_args, signers))
 }
 
-fn build_custom_cmd(name: &str, spec: &Spec) -> Result<clap::Command, Error> {
+pub fn build_custom_cmd(name: &str, spec: &Spec) -> Result<clap::Command, Error> {
     let func = spec
         .find_function(name)
         .map_err(|_| Error::FunctionNotFoundInContractSpec(name.to_string()))?;


### PR DESCRIPTION
### What

Exposing the `build_custom_cmd` function in `arg_parsing` 

### Why

In `stellar scaffold` we are creating an `upgrade` command that allows you to upgrade your workspace to a scaffold project. We'd like to read the wasm specs and prompt the user for their default constructor args for their contracts if needed. 

### Known limitations

N/A
