### PR TITLE
Improve payment amount parameter description

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1874,7 +1874,7 @@ Sends an amount in a specific asset to a destination account
 * `--asset <ASSET>` — Asset to send, default native, e.i. XLM
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of the aforementioned asset to send. e.g. `10_000_000` (1 XLM)
+* `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = 10_000_000 stroops).
 
 
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1874,7 +1874,7 @@ Sends an amount in a specific asset to a destination account
 * `--asset <ASSET>` — Asset to send, default native, e.i. XLM
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = 10_000_000 stroops).
+* `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = 10_000_000 stroops)
 
 
 
@@ -2214,7 +2214,7 @@ Sends an amount in a specific asset to a destination account
 * `--asset <ASSET>` — Asset to send, default native, e.i. XLM
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of the aforementioned asset to send. e.g. `10_000_000` (1 XLM)
+* `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = 10_000_000 stroops)
 
 
 

--- a/cmd/soroban-cli/src/commands/tx/new/payment.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/payment.rs
@@ -19,7 +19,7 @@ pub struct Args {
     /// Asset to send, default native, e.i. XLM
     #[arg(long, default_value = "native")]
     pub asset: builder::Asset,
-    /// Amount of the aforementioned asset to send. e.g. `10_000_000` (1 XLM)
+    /// Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = 10_000_000 stroops).
     #[arg(long)]
     pub amount: builder::Amount,
 }


### PR DESCRIPTION
- Clarify that amount is specified in stroops
- Add explanation of stroop to asset conversion (1 stroop = 0.0000001 of asset)
- Update both source code comment and generated documentation
- Example: 1 XLM = 10_000_000 stroops

(https://github.com/stellar/stellar-cli/issues/1693)
