### PR TITLE
Fix/refactor signing paths

### DIFF
--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -268,7 +268,12 @@ impl TestEnv {
                 global: false,
                 config_dir,
             },
-            hd_path: None,
+            sign_with: config::sign_with::Args {
+                sign_with_key: None, 
+                hd_path: None,
+                sign_with_lab: false,
+                sign_with_ledger: false
+            },
         }
     }
 

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -157,7 +157,7 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(Box::new(txn)));
         }
         let get_txn_resp = client
-            .send_transaction_polling(&self.config.sign_with_local_key(txn).await?)
+            .send_transaction_polling(&self.config.sign(txn).await?)
             .await?
             .try_into()?;
         if args.is_none_or(|a| !a.no_cache) {

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -290,7 +290,7 @@ impl NetworkRunnable for Cmd {
         }
 
         print.log_transaction(&txn, &network, true)?;
-        let signed_txn = &config.sign_with_local_key(*txn).await?;
+        let signed_txn = &config.sign(*txn).await?;
         print.globeln("Submitting deploy transaction…");
 
         let get_txn_resp = client

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -180,7 +180,7 @@ impl NetworkRunnable for Cmd {
             .transaction()
             .clone();
         let res = client
-            .send_transaction_polling(&config.sign_with_local_key(tx).await?)
+            .send_transaction_polling(&config.sign(tx).await?)
             .await?;
         if args.is_none_or(|a| !a.no_cache) {
             data::write(res.clone().try_into()?, &network.rpc_uri()?)?;

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -293,7 +293,7 @@ impl NetworkRunnable for Cmd {
             txn = Box::new(tx);
         }
         let res = client
-            .send_transaction_polling(&config.sign_with_local_key(*txn).await?)
+            .send_transaction_polling(&config.sign(*txn).await?)
             .await?;
         if !no_cache {
             data::write(res.clone().try_into()?, &network.rpc_uri()?)?;

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -173,7 +173,7 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(tx));
         }
         let res = client
-            .send_transaction_polling(&config.sign_with_local_key(*tx).await?)
+            .send_transaction_polling(&config.sign(*tx).await?)
             .await?;
         if args.is_none_or(|a| !a.no_cache) {
             data::write(res.clone().try_into()?, &network.rpc_uri()?)?;

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -200,7 +200,7 @@ impl NetworkRunnable for Cmd {
             return Ok(TxnResult::Txn(txn));
         }
 
-        let signed_txn = &self.config.sign_with_local_key(*txn).await?;
+        let signed_txn = &self.config.sign(*txn).await?;
 
         print.globeln("Submitting install transaction…");
         let txn_resp = client.send_transaction_polling(signed_txn).await?;

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -120,7 +120,7 @@ impl Args {
         &self,
         address: &UnresolvedMuxedAccount,
     ) -> Result<xdr::MuxedAccount, Error> {
-        Ok(address.resolve_muxed_account_sync(&self.config.locator, self.config.sign_with.hd_path)?)
+        Ok(address.resolve_muxed_account_sync(&self.config.locator, self.config.hd_path())?)
     }
 
     pub fn resolve_account_id(
@@ -128,7 +128,7 @@ impl Args {
         address: &UnresolvedMuxedAccount,
     ) -> Result<xdr::AccountId, Error> {
         Ok(address
-            .resolve_muxed_account_sync(&self.config.locator, self.config.sign_with.hd_path)?
+            .resolve_muxed_account_sync(&self.config.locator, self.config.hd_path())?
             .account_id())
     }
 
@@ -142,7 +142,7 @@ impl Args {
         if let Some(account) = op_source {
             source_account = Some(
                 account
-                    .resolve_muxed_account(&self.config.locator, self.config.sign_with.hd_path)
+                    .resolve_muxed_account(&self.config.locator, self.config.hd_path())
                     .await?,
             );
         }

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -120,7 +120,7 @@ impl Args {
         &self,
         address: &UnresolvedMuxedAccount,
     ) -> Result<xdr::MuxedAccount, Error> {
-        Ok(address.resolve_muxed_account_sync(&self.config.locator, self.config.hd_path)?)
+        Ok(address.resolve_muxed_account_sync(&self.config.locator, self.config.sign_with.hd_path)?)
     }
 
     pub fn resolve_account_id(
@@ -128,7 +128,7 @@ impl Args {
         address: &UnresolvedMuxedAccount,
     ) -> Result<xdr::AccountId, Error> {
         Ok(address
-            .resolve_muxed_account_sync(&self.config.locator, self.config.hd_path)?
+            .resolve_muxed_account_sync(&self.config.locator, self.config.sign_with.hd_path)?
             .account_id())
     }
 
@@ -142,7 +142,7 @@ impl Args {
         if let Some(account) = op_source {
             source_account = Some(
                 account
-                    .resolve_muxed_account(&self.config.locator, self.config.hd_path)
+                    .resolve_muxed_account(&self.config.locator, self.config.sign_with.hd_path)
                     .await?,
             );
         }

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -102,7 +102,7 @@ impl Args {
         }
 
         let txn_resp = client
-            .send_transaction_polling(&self.config.sign_with_local_key(tx).await?)
+            .send_transaction_polling(&self.config.sign(tx).await?)
             .await?;
 
         if !args.no_cache {

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -84,9 +84,7 @@ impl Args {
         Ok(key.key_pair(self.hd_path())?)
     }
 
-    // have this use sign_with ✅
-    // change the name of this
-    pub async fn sign_with_local_key(&self, tx: Transaction) -> Result<TransactionEnvelope, Error> {
+    pub async fn sign(&self, tx: Transaction) -> Result<TransactionEnvelope, Error> {
         let tx_env = TransactionEnvelope::Tx(TransactionV1Envelope {
             tx,
             signatures: VecM::default(),

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use crate::{
-    print::Print,
     signer,
     xdr::{self, SequenceNumber, Transaction, TransactionEnvelope, TransactionV1Envelope, VecM},
     Pwd,
@@ -90,12 +89,12 @@ impl Args {
             signatures: VecM::default(),
         });
         Ok(self.sign_with
-            .sign_tx_env(
+            .sign_tx_env_with_default_signer(
                 &tx_env,
                 &self.locator,
                 &self.network.get(&self.locator)?,
-                false
-                // global_args.quiet,
+                false,
+                self.source_account.clone()
             ).await?)
     }
 

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -61,10 +61,6 @@ pub struct Args {
     /// sign the final transaction. In that case, trying to sign with public key will fail.
     pub source_account: UnresolvedMuxedAccount,
 
-    // #[arg(long)]
-    // /// If using a seed phrase, which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-    // pub hd_path: Option<usize>,
-
     #[command(flatten)]
     pub locator: locator::Args,
 
@@ -77,20 +73,20 @@ impl Args {
     pub async fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
         Ok(self
             .source_account
-            .resolve_muxed_account(&self.locator, self.sign_with.hd_path)
+            .resolve_muxed_account(&self.locator, self.hd_path())
             .await?)
     }
 
     pub fn key_pair(&self) -> Result<ed25519_dalek::SigningKey, Error> {
         let key = &self.source_account.resolve_secret(&self.locator)?;
-        Ok(key.key_pair(self.sign_with.hd_path)?)
+        Ok(key.key_pair(self.hd_path())?)
     }
 
     // have this use sign_with
     // change the name of this
     pub async fn sign_with_local_key(&self, tx: Transaction) -> Result<TransactionEnvelope, Error> {
         let key = &self.source_account.resolve_secret(&self.locator)?;
-        let signer = key.signer(self.sign_with.hd_path, Print::new(false)).await?;
+        let signer = key.signer(self.hd_path(), Print::new(false)).await?;
         let network = &self.get_network()?;
 
         Ok(signer.sign_tx(tx, network).await?)
@@ -132,6 +128,10 @@ impl Args {
             .0
             + 1)
         .into())
+    }
+
+    pub fn hd_path(&self) -> Option<usize> {
+        self.sign_with.hd_path
     }
 }
 

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -220,6 +220,8 @@ pub enum SignerKind {
     SecureStore(SecureStoreEntry),
 }
 
+// Instead of using `sign_tx` and `sign_tx_env` directly, it is advised to instead use the sign_with module
+// which allows for signing with a local key, lab or a ledger device
 impl Signer {
     pub async fn sign_tx(
         &self,


### PR DESCRIPTION
### What

Closes https://github.com/stellar/stellar-cli/issues/2008

### Why
We previously had 2 paths to signing tx, one was used in the `tx sign` (sign_with), and the other path was used in the rest of the tx signing (using signer.sign directly). Making sure that all signing goes through one path seems less likely to introduce bugs when working on the signing flow. 

### Known limitations

N/A
