### PR TITLE
Bump Soroban SDK repo dependencies to rc.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,22 +50,22 @@ version = "23.0.0-rc.2"
 
 # Dependencies from the rs-soroban-sdk repo:
 [workspace.dependencies.soroban-spec]
-version = "23.0.0-rc.2"
+version = "23.0.0-rc.2.2"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "23.0.0-rc.2"
+version = "23.0.0-rc.2.2"
 
 [workspace.dependencies.soroban-sdk]
-version = "23.0.0-rc.2.1"
+version = "23.0.0-rc.2.2"
 
 [workspace.dependencies.soroban-env-host]
 version = "23.0.0-rc.2"
 
 [workspace.dependencies.soroban-token-sdk]
-version = "23.0.0-rc.2"
+version = "23.0.0-rc.2.2"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "23.0.0-rc.2"
+version = "23.0.0-rc.2.2"
 
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]


### PR DESCRIPTION
### What
  Update Soroban SDK repo dependencies from rc.2/rc.2.1 to rc.2.2.

  ### Why
  There were changes added to the newer SDK release to support binding generation of events, but those changes were missed being included in the last cli release.