### PR TITLE
Update container log and stop command suggestions.

### DIFF
--- a/cmd/soroban-cli/src/commands/container/start.rs
+++ b/cmd/soroban-cli/src/commands/container/start.rs
@@ -215,12 +215,12 @@ impl Runner {
         let tail = format!("{container_name} {additional_flags}");
 
         self.print.searchln(format!(
-            "Watch logs with `stellar network container logs {}`",
+            "Watch logs with `stellar container logs {}`",
             tail.trim()
         ));
 
         self.print.infoln(format!(
-            "Stop the container with `stellar network container stop {}`",
+            "Stop the container with `stellar container stop {}`",
             tail.trim()
         ));
     }


### PR DESCRIPTION
### What
  Update container log and stop command suggestions.

  ### Why
  The suggested commands used outdated paths, referring to 'stellar network container' instead of 'stellar container'.

Close #2094