### PR TITLE
Add network config settings command

### DIFF
--- a/cmd/soroban-cli/src/commands/network/config_settings.rs
+++ b/cmd/soroban-cli/src/commands/network/config_settings.rs
@@ -1,0 +1,86 @@
+use crate::commands::global;
+use crate::config::network;
+use crate::rpc::FullLedgerEntries;
+use crate::{config, print};
+use clap::command;
+use stellar_xdr::curr::{
+    ConfigSettingId, ConfigUpgradeSet, LedgerEntryData, LedgerKey, LedgerKeyConfigSetting,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]
+pub enum OutputFormat {
+    /// JSON result of the RPC request
+    #[default]
+    Json,
+    /// Formatted (multiline) JSON output of the RPC request
+    JsonFormatted,
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config: config::ArgsLocatorAndNetwork,
+    /// Format of the output
+    #[arg(long, default_value = "json")]
+    pub output: OutputFormat,
+}
+
+impl Cmd {
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = print::Print::new(global_args.quiet);
+        let result = self
+            .config
+            .get_network()?
+            .rpc_client()?
+            .get_full_ledger_entries(&self.config_settings_keys())
+            .await;
+
+        match result {
+            Ok(FullLedgerEntries { entries, .. }) => {
+                let entries = entries
+                    .into_iter()
+                    .filter_map(|e| match e.val {
+                        LedgerEntryData::ConfigSetting(setting) => Some(setting),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                let set = ConfigUpgradeSet {
+                    updated_entry: entries.try_into().unwrap(),
+                };
+                match self.output {
+                    OutputFormat::Json => println!("{}", serde_json::to_string(&set)?),
+                    OutputFormat::JsonFormatted => {
+                        println!("{}", serde_json::to_string_pretty(&set)?)
+                    }
+                }
+            }
+            Err(err) => {
+                print.errorln(format!("failed to fetch network config settings: {err}"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn config_settings_keys(&self) -> Vec<LedgerKey> {
+        ConfigSettingId::variants()
+            .into_iter()
+            .map(|id| {
+                LedgerKey::ConfigSetting(LedgerKeyConfigSetting {
+                    config_setting_id: id,
+                })
+            })
+            .collect()
+    }
+}

--- a/cmd/soroban-cli/src/commands/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/network/mod.rs
@@ -2,6 +2,7 @@ use super::{config::locator, global};
 use clap::Parser;
 
 pub mod add;
+pub mod config_settings;
 pub mod default;
 pub mod health;
 pub mod ls;
@@ -17,6 +18,9 @@ pub enum Cmd {
 
     /// List networks
     Ls(ls::Cmd),
+
+    /// Fetch the config settings for the network
+    ConfigSettings(config_settings::Cmd),
 
     /// ⚠️ Deprecated: use `stellar container start` instead
     ///
@@ -68,6 +72,10 @@ pub enum Error {
 
     #[error(transparent)]
     Ls(#[from] ls::Error),
+
+    #[error(transparent)]
+    ConfigSettings(#[from] config_settings::Error),
+
     #[error(transparent)]
     Health(#[from] health::Error),
 
@@ -91,6 +99,7 @@ impl Cmd {
             Cmd::Add(cmd) => cmd.run()?,
             Cmd::Rm(new) => new.run()?,
             Cmd::Ls(cmd) => cmd.run()?,
+            Cmd::ConfigSettings(cmd) => cmd.run(global_args).await?,
             #[cfg(feature = "version_lt_23")]
             Cmd::Container(cmd) => cmd.run(global_args).await?,
 


### PR DESCRIPTION
### What
  Add command to fetch network configuration settings in JSON format.

  ### Why
  A convenient way to retrieve the current network configuration for a network without needing to install, setup, and boot stellar-core.