### PR TITLE
Fix address display.

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/fund.rs
+++ b/cmd/soroban-cli/src/commands/keys/fund.rs
@@ -1,6 +1,5 @@
-use clap::command;
-
 use crate::{commands::global, config::network, print::Print};
+use clap::command;
 
 use super::public_key;
 
@@ -27,10 +26,11 @@ impl Cmd {
         let print = Print::new(global_args.quiet);
         let addr = self.address.public_key().await?;
         let network = self.network.get(&self.address.locator)?;
+        let formatted_name = self.address.name.to_string();
         network.fund_address(&addr).await?;
         print.checkln(format!(
             "Account {} funded on {:?}",
-            self.address.name, network.network_passphrase
+            formatted_name, network.network_passphrase
         ));
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -110,6 +110,7 @@ impl Cmd {
     async fn fund(&self, secret: &Secret, print: &Print) -> Result<(), Error> {
         let addr = secret.public_key(self.hd_path)?;
         let network = self.network.get(&self.config_locator)?;
+        let formatted_name = self.name.to_string();
         network
             .fund_address(&addr)
             .await
@@ -119,7 +120,7 @@ impl Cmd {
             .unwrap_or_default();
         print.checkln(format!(
             "Account {} funded on {:?}",
-            self.name, network.network_passphrase
+            formatted_name, network.network_passphrase
         ));
         Ok(())
     }


### PR DESCRIPTION
### What

Fix address display. Even though we have the Display trait implemented, the enum debug string is being used. Using `to_string()` fixes it.

```
before
✅ Account AliasOrSecret("me") funded on "Test SDF Network ; September 2015"

after
✅ Account me funded on "Test SDF Network ; September 2015"
```

### Why

So it's better.

### Known limitations

N/A
