### PR TITLE
Optimize several wasm files at once.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -848,11 +848,11 @@ stellar contract invoke ... -- --help
 
 Optimize a WASM file
 
-**Usage:** `stellar contract optimize [OPTIONS] --wasm <WASM>`
+**Usage:** `stellar contract optimize [OPTIONS] --wasm <WASM>...`
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Path to wasm binary
+* `--wasm <WASM>` — Path to one or more wasm binaries
 * `--wasm-out <WASM_OUT>` — Path to write the optimized WASM file to (defaults to same location as --wasm with .optimized.wasm suffix)
 
 

--- a/cmd/soroban-cli/src/commands/contract/optimize.rs
+++ b/cmd/soroban-cli/src/commands/contract/optimize.rs
@@ -1,5 +1,5 @@
-use clap::{arg, command, Parser};
-use std::fmt::Debug;
+use clap::{arg, Parser};
+use std::{fmt::Debug, path::PathBuf};
 #[cfg(feature = "additional-libs")]
 use wasm_opt::{Feature, OptimizationError, OptimizationOptions};
 
@@ -8,8 +8,10 @@ use crate::wasm;
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    #[command(flatten)]
-    wasm: wasm::Args,
+    /// Path to one or more wasm binaries
+    #[arg(long, num_args = 1.., required = true)]
+    wasm: Vec<PathBuf>,
+
     /// Path to write the optimized WASM file to (defaults to same location as --wasm with .optimized.wasm suffix)
     #[arg(long)]
     wasm_out: Option<std::path::PathBuf>,
@@ -19,12 +21,17 @@ pub struct Cmd {
 pub enum Error {
     #[error(transparent)]
     Wasm(#[from] wasm::Error),
+
     #[cfg(feature = "additional-libs")]
     #[error("optimization error: {0}")]
     OptimizationError(OptimizationError),
+
     #[cfg(not(feature = "additional-libs"))]
     #[error("must install with \"additional-libs\" feature.")]
     Install,
+
+    #[error("--wasm-out cannot be used with --wasm option when passing multiple files")]
+    MultipleFilesOutput,
 }
 
 impl Cmd {
@@ -35,44 +42,53 @@ impl Cmd {
 
     #[cfg(feature = "additional-libs")]
     pub fn run(&self) -> Result<(), Error> {
-        let wasm_size = self.wasm.len()?;
+        if self.wasm.len() > 1 && self.wasm_out.is_some() {
+            return Err(Error::MultipleFilesOutput);
+        }
 
-        println!(
-            "Reading: {} ({} bytes)",
-            self.wasm.wasm.to_string_lossy(),
-            wasm_size
-        );
+        for wasm_path in &self.wasm {
+            let wasm_arg = wasm::Args {
+                wasm: wasm_path.into(),
+            };
+            let wasm_size = wasm_arg.len()?;
 
-        let wasm_out = self.wasm_out.clone().unwrap_or_else(|| {
-            let mut wasm_out = self.wasm.wasm.clone();
-            wasm_out.set_extension("optimized.wasm");
-            wasm_out
-        });
+            println!(
+                "Reading: {} ({} bytes)",
+                wasm_arg.wasm.to_string_lossy(),
+                wasm_size
+            );
 
-        let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
-        options.converge = true;
+            let wasm_out = self.wasm_out.clone().unwrap_or_else(|| {
+                let mut wasm_out = wasm_arg.wasm.clone();
+                wasm_out.set_extension("optimized.wasm");
+                wasm_out
+            });
 
-        // Explicitly set to MVP + sign-ext + mutable-globals, which happens to
-        // also be the default featureset, but just to be extra clear we set it
-        // explicitly.
-        //
-        // Formerly Soroban supported only the MVP feature set, but Rust 1.70 as
-        // well as Clang generate code with sign-ext + mutable-globals enabled,
-        // so Soroban has taken a change to support them also.
-        options.mvp_features_only();
-        options.enable_feature(Feature::MutableGlobals);
-        options.enable_feature(Feature::SignExt);
+            let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
+            options.converge = true;
 
-        options
-            .run(&self.wasm.wasm, &wasm_out)
-            .map_err(Error::OptimizationError)?;
+            // Explicitly set to MVP + sign-ext + mutable-globals, which happens to
+            // also be the default featureset, but just to be extra clear we set it
+            // explicitly.
+            //
+            // Formerly Soroban supported only the MVP feature set, but Rust 1.70 as
+            // well as Clang generate code with sign-ext + mutable-globals enabled,
+            // so Soroban has taken a change to support them also.
+            options.mvp_features_only();
+            options.enable_feature(Feature::MutableGlobals);
+            options.enable_feature(Feature::SignExt);
 
-        let wasm_out_size = wasm::len(&wasm_out)?;
-        println!(
-            "Optimized: {} ({} bytes)",
-            wasm_out.to_string_lossy(),
-            wasm_out_size
-        );
+            options
+                .run(&wasm_arg.wasm, &wasm_out)
+                .map_err(Error::OptimizationError)?;
+
+            let wasm_out_size = wasm::len(&wasm_out)?;
+            println!(
+                "Optimized: {} ({} bytes)",
+                wasm_out.to_string_lossy(),
+                wasm_out_size
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
### What

Make `stellar contract optimize` accept one or more files.

```console
$ stellar contract optimize --wasm target/wasm32v1-none/release/hello_world.wasm target/wasm32v1-none/release/bye.wasm
Reading: target/wasm32v1-none/release/hello_world.wasm (574 bytes)
Optimized: target/wasm32v1-none/release/hello_world.optimized.wasm (537 bytes)
Reading: target/wasm32v1-none/release/bye.wasm (565 bytes)
Optimized: target/wasm32v1-none/release/bye.optimized.wasm (528 bytes)

$ stellar contract optimize
error: the following required arguments were not provided:
  --wasm <WASM>...

Usage: stellar contract optimize --wasm <WASM>...

For more information, try '--help'.

$ stellar contract optimize --wasm target/wasm32v1-none/release/hello_world.wasm target/wasm32v1-none/release/bye.wasm --wasm-out tmp/foo.wasm
❌ error: --wasm-out cannot be used with --wasm option when passing multiple files
```

### Why

Close #717.

### Known limitations

- Cannot specify `--wasm-out` when passing more than 1 file via `--wasm`.
