### PR TITLE
Fix how config dir is displayed for the deprecation message.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1336,11 +1336,11 @@ Fetch the network's config settings
 
   Possible values:
   - `xdr`:
-    XDR (ConfigUpgradeSet type)
+    XDR (`ConfigUpgradeSet` type)
   - `json`:
-    JSON, XDR-JSON of the ConfigUpgradeSet XDR type
+    JSON, XDR-JSON of the `ConfigUpgradeSet` XDR type
   - `json-formatted`:
-    JSON formatted, XDR-JSON of the ConfigUpgradeSet XDR type
+    JSON formatted, XDR-JSON of the `ConfigUpgradeSet` XDR type
 
 
 

--- a/cmd/soroban-cli/src/commands/contract/alias/ls.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/ls.rs
@@ -108,7 +108,7 @@ impl Cmd {
                 for entry in list {
                     #[cfg(feature = "version_gte_23")]
                     if !found && deprecation_mode {
-                        print_deprecation_warning();
+                        print_deprecation_warning(config_dir);
                     }
                     found = true;
                     println!("{}: {}", entry.alias, entry.contract);

--- a/cmd/soroban-cli/src/commands/network/settings.rs
+++ b/cmd/soroban-cli/src/commands/network/settings.rs
@@ -26,12 +26,12 @@ pub enum Error {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum, Default)]
 pub enum OutputFormat {
-    /// XDR (ConfigUpgradeSet type)
+    /// XDR (`ConfigUpgradeSet` type)
     Xdr,
-    /// JSON, XDR-JSON of the ConfigUpgradeSet XDR type
+    /// JSON, XDR-JSON of the `ConfigUpgradeSet` XDR type
     #[default]
     Json,
-    /// JSON formatted, XDR-JSON of the ConfigUpgradeSet XDR type
+    /// JSON formatted, XDR-JSON of the `ConfigUpgradeSet` XDR type
     JsonFormatted,
 }
 

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -3,7 +3,6 @@ use directories::UserDirs;
 use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use std::{
-    env::current_dir,
     ffi::OsStr,
     fmt::Display,
     fs::{self, create_dir_all, OpenOptions},
@@ -367,7 +366,7 @@ impl Args {
             Location::Local(config_dir) => {
                 let path = config_dir.join("contract-ids").join(&file_name);
                 if path.exists() {
-                    print_deprecation_warning();
+                    print_deprecation_warning(config_dir);
 
                     let content = fs::read_to_string(path)?;
                     let data: alias::Data = serde_json::from_str(&content).unwrap_or_default();
@@ -495,19 +494,11 @@ impl Args {
 }
 
 #[cfg(feature = "version_gte_23")]
-pub fn print_deprecation_warning() {
+pub fn print_deprecation_warning(dir: &Path) {
     let print = Print::new(false);
-    let pwd = current_dir().unwrap_or_else(|_| PathBuf::from("."));
-
-    let local_dir = if pwd.join(".stellar").exists() {
-        ".stellar"
-    } else {
-        ".soroban"
-    };
-
     let global_dir = global_config_path().expect("Couldn't retrieve global directory.");
 
-    print.warnln(format!("A local config was found at {local_dir:?}."));
+    print.warnln(format!("A local config was found at {dir:?}."));
     print.blankln(" Local config is deprecated and will be removed in the future.".to_string());
     print.blankln(format!(
         " Run `stellar config migrate` to move the local config into the global config ({global_dir:?})."
@@ -570,8 +561,8 @@ impl KeyType {
 
             if let Ok(t) = Self::read_from_path(&path) {
                 #[cfg(feature = "version_gte_23")]
-                if let Location::Local(_) = location {
-                    print_deprecation_warning();
+                if let Location::Local(config_dir) = location {
+                    print_deprecation_warning(&config_dir);
                 }
 
                 return Ok(t);
@@ -631,9 +622,9 @@ impl KeyType {
             files.sort();
 
             #[cfg(feature = "version_gte_23")]
-            if let Location::Local(_) = pwd {
+            if let Location::Local(config_dir) = pwd {
                 if files.len() > 1 && print_warning {
-                    print_deprecation_warning();
+                    print_deprecation_warning(config_dir);
                 }
             }
 


### PR DESCRIPTION
### What

```console
$ tree -a a
a
└── b
    ├── .stellar
    │   └── identity
    │       └── 19510.toml
    └── c

5 directories, 1 file

$ cd a/b/c

$ stellar keys address 19510
⚠️ A local config was found at "/Users/fnando/Projects/stellar/a/b/.stellar".
   Local config is deprecated and will be removed in the future.
   Run `stellar config migrate` to move the local config into the global config ("/Users/fnando/.config/stellar").
GBUX5OWVZN4OGIM72GQZ4OH7USWQMQNFWNX3HGB5QIFQBB433S23DWOA
```

### Why

Fix #2105 

### Known limitations

N/A
