### PR TITLE
Avoid detecting contracts as read-only when build-only flag is set.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -247,7 +247,12 @@ impl NetworkRunnable for Cmd {
         let assembled = self
             .simulate(&host_function_params, &default_account_entry(), &client)
             .await?;
-        let should_send = self.should_send_tx(&assembled.sim_res)?;
+
+        let should_send = if self.fee.build_only {
+            ShouldSend::Yes
+        } else {
+            self.should_send_tx(&assembled.sim_res)?
+        };
 
         let account_details = if should_send == ShouldSend::Yes {
             client


### PR DESCRIPTION
When build_only is specified, skip the should_send_tx check that could prevent transaction assembly and building.

### What

Close #2109.

```console
# before
$ stellar contract invoke --id hello --build-only -- hello --to 'fnando'
ℹ️ Simulation identified as read-only. Send by rerunning with `--send=yes`.
["Hello","fnando"]

# after
$ stellar contract invoke --id hello --build-only -- hello --to 'fnando'
AAAAAgAAAADYcrin+iEjGmimHUdHO1ayN/n4bkbl6AqSvsit9+nL8QAAAGQAC0v9AAAACAAAAAAAAAAAAAAAAQAAAAAAAAAYAAAAAAAAAAE6MO1DdzCGq9XRsczB3lcR8GiBJQcHysbuKULvAtrpAAAAAAVoZWxsbwAAAAAAAAEAAAAOAAAABmZuYW5kbwAAAAAAAAAAAAAAAAAA

$ pbpaste | stellar xdr decode --type TransactionEnvelope
{"tx":{"tx":{"source_account":"GDMHFOFH7IQSGGTIUYOUORZ3K2ZDP6PYNZDOL2AKSK7MRLPX5HF7DEA4","fee":100,"seq_num":"3179774742626312","cond":"none","memo":"none","operations":[{"source_account":null,"body":{"invoke_host_function":{"host_function":{"invoke_contract":{"contract_address":"CA5DB3KDO4YINK6V2GY4ZQO6K4I7A2EBEUDQPSWG5YUUF3YC3LUQAB2P","function_name":"hello","args":[{"string":"fnando"}]}},"auth":[]}}}],"ext":"v0"},"signatures":[]}}
```

### Why

Because build-only implies getting the xdr back, so it makes no sense detecting invocations as read-only in this case.

### Known limitations

N/A
