### PR TITLE
Swap version checking, so it works if value is cached.

### DIFF
--- a/cmd/soroban-cli/src/upgrade_check.rs
+++ b/cmd/soroban-cli/src/upgrade_check.rs
@@ -87,7 +87,7 @@ pub async fn upgrade_check(quiet: bool) {
     let current_version = Version::parse(current_version).unwrap();
     let latest_version = get_latest_version(&current_version, &stats);
 
-    if *latest_version > current_version {
+    if current_version < *latest_version {
         let printer = Print::new(quiet);
         printer.warnln(format!(
             "A new release of stellar-cli is available: {current_version} -> {latest_version}"


### PR DESCRIPTION
### What

Swaps the version checking. This fixes the case where latest version is cached and the current version is greater than the cached value, showing the upgrade message to users that don't need it.

### Why

Close #2081.

### Known limitations

N/A
