### PR TITLE
Add `stellar tx new manage-sell-offer`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1645,6 +1645,7 @@ Create a new transaction
 * `change-trust` — Create, update, or delete a trustline
 * `create-account` — Create and fund a new account
 * `manage-data` — Set, modify, or delete account data entries
+* `manage-sell-offer` — Create, update, or delete a sell offer
 * `payment` — Send asset to destination account
 * `set-options` — Set account options like flags, signers, and home domain
 * `set-trustline-flags` — Configure authorization and trustline flags for an asset
@@ -1800,6 +1801,41 @@ Set, modify, or delete account data entries
 * `--sign-with-ledger` — Sign with a ledger wallet
 * `--data-name <DATA_NAME>` — String up to 64 bytes long. If this is a new Name it will add the given name/value pair to the account. If this Name is already present then the associated value will be modified
 * `--data-value <DATA_VALUE>` — Up to 64 bytes long hex string If not present then the existing Name will be deleted. If present then this value will be set in the `DataEntry`
+
+
+
+## `stellar tx new manage-sell-offer`
+
+Create, update, or delete a sell offer
+
+**Usage:** `stellar tx new manage-sell-offer [OPTIONS] --source-account <SOURCE_ACCOUNT> --selling <SELLING> --buying <BUYING> --amount <AMOUNT> --price <PRICE>`
+
+###### **Options:**
+
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--selling <SELLING>` — Asset to sell
+* `--buying <BUYING>` — Asset to buy
+* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+  Default value: `0`
 
 
 

--- a/cmd/crates/soroban-test/tests/it/integration/tx/operations.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/operations.rs
@@ -820,3 +820,45 @@ async fn multi_create_accounts() {
             assert_eq!(value.balance, 10_000_000);
         });
 }
+
+#[tokio::test]
+async fn manage_sell_offer() {
+    let sandbox = &TestEnv::new();
+    let client = sandbox.network.rpc_client().unwrap();
+    let (test, issuer) = setup_accounts(sandbox);
+    let asset = format!("USD:{issuer}");
+
+    // Create trustline and issue some USD to the test account
+    let limit = 100_000_000_000; // 10,000 USD
+    let initial_balance = 50_000_000_000; // 5,000 USD
+    issue_asset(sandbox, &test, &asset, limit, initial_balance).await;
+
+    let test_account_before = client.get_account(&test).await.unwrap();
+
+    // Create a new sell offer: sell 1000 USD for XLM at price 1:2 (0.5 USD per XLM)
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "manage-sell-offer",
+            "--selling",
+            &asset,
+            "--buying",
+            "native",
+            "--amount",
+            "10000000000", // 1000 USD in stroops
+            "--price",
+            "1:2", // 0.5 USD per XLM
+        ])
+        .assert()
+        .success();
+
+    let test_account_after = client.get_account(&test).await.unwrap();
+
+    // Account should have one more sub-entry (the offer)
+    assert_eq!(
+        test_account_before.num_sub_entries + 1,
+        test_account_after.num_sub_entries,
+        "Should have one additional sub-entry for the offer"
+    );
+}

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -42,6 +42,8 @@ pub enum Error {
     Asset(#[from] asset::Error),
     #[error(transparent)]
     TxXdr(#[from] super::xdr::Error),
+    #[error("invalid price format: {0}")]
+    InvalidPrice(String),
 }
 
 impl Args {

--- a/cmd/soroban-cli/src/commands/tx/help.rs
+++ b/cmd/soroban-cli/src/commands/tx/help.rs
@@ -3,6 +3,7 @@ pub const BUMP_SEQUENCE: &str = "Bump sequence number to invalidate older transa
 pub const CHANGE_TRUST: &str = "Create, update, or delete a trustline";
 pub const CREATE_ACCOUNT: &str = "Create and fund a new account";
 pub const MANAGE_DATA: &str = "Set, modify, or delete account data entries";
+pub const MANAGE_SELL_OFFER: &str = "Create, update, or delete a sell offer";
 pub const PAYMENT: &str = "Send asset to destination account";
 pub const SET_OPTIONS: &str = "Set account options like flags, signers, and home domain";
 pub const SET_TRUSTLINE_FLAGS: &str = "Configure authorization and trustline flags for an asset";

--- a/cmd/soroban-cli/src/commands/tx/new/manage_sell_offer.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/manage_sell_offer.rs
@@ -1,0 +1,81 @@
+use clap::{command, Parser};
+
+use crate::{commands::tx, tx::builder, xdr};
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub tx: tx::Args,
+
+    #[clap(flatten)]
+    pub op: Args,
+}
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct Args {
+    /// Asset to sell
+    #[arg(long)]
+    pub selling: builder::Asset,
+
+    /// Asset to buy
+    #[arg(long)]
+    pub buying: builder::Asset,
+
+    /// Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer.
+    #[arg(long)]
+    pub amount: builder::Amount,
+
+    /// Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+    #[arg(long)]
+    pub price: String,
+
+    /// Offer ID. If 0, will create new offer. Otherwise, will update existing offer.
+    #[arg(long, default_value = "0")]
+    pub offer_id: i64,
+}
+
+impl TryFrom<&Cmd> for xdr::OperationBody {
+    type Error = tx::args::Error;
+    fn try_from(
+        Cmd {
+            tx,
+            op:
+                Args {
+                    selling,
+                    buying,
+                    amount,
+                    price,
+                    offer_id,
+                },
+        }: &Cmd,
+    ) -> Result<Self, Self::Error> {
+        let price_parts: Vec<&str> = price.split(':').collect();
+        if price_parts.len() != 2 {
+            return Err(tx::args::Error::InvalidPrice(price.clone()));
+        }
+
+        let n: i32 = price_parts[0]
+            .parse()
+            .map_err(|_| tx::args::Error::InvalidPrice(price.clone()))?;
+        let d: i32 = price_parts[1]
+            .parse()
+            .map_err(|_| tx::args::Error::InvalidPrice(price.clone()))?;
+
+        if d == 0 {
+            return Err(tx::args::Error::InvalidPrice(
+                "denominator cannot be zero".to_string(),
+            ));
+        }
+
+        Ok(xdr::OperationBody::ManageSellOffer(
+            xdr::ManageSellOfferOp {
+                selling: tx.resolve_asset(selling)?,
+                buying: tx.resolve_asset(buying)?,
+                amount: amount.into(),
+                price: xdr::Price { n, d },
+                offer_id: *offer_id,
+            },
+        ))
+    }
+}

--- a/cmd/soroban-cli/src/commands/tx/new/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/mod.rs
@@ -8,6 +8,7 @@ pub mod bump_sequence;
 pub mod change_trust;
 pub mod create_account;
 pub mod manage_data;
+pub mod manage_sell_offer;
 pub mod payment;
 pub mod set_options;
 pub mod set_trustline_flags;
@@ -25,6 +26,8 @@ pub enum Cmd {
     CreateAccount(create_account::Cmd),
     #[command(about = super::help::MANAGE_DATA)]
     ManageData(manage_data::Cmd),
+    #[command(about = super::help::MANAGE_SELL_OFFER)]
+    ManageSellOffer(manage_sell_offer::Cmd),
     #[command(about = super::help::PAYMENT)]
     Payment(payment::Cmd),
     #[command(about = super::help::SET_OPTIONS)]
@@ -48,6 +51,7 @@ impl TryFrom<&Cmd> for OperationBody {
             Cmd::ChangeTrust(cmd) => cmd.try_into()?,
             Cmd::CreateAccount(cmd) => cmd.try_into()?,
             Cmd::ManageData(cmd) => cmd.into(),
+            Cmd::ManageSellOffer(cmd) => cmd.try_into()?,
             Cmd::Payment(cmd) => cmd.try_into()?,
             Cmd::SetOptions(cmd) => cmd.try_into()?,
             Cmd::SetTrustlineFlags(cmd) => cmd.try_into()?,
@@ -64,6 +68,7 @@ impl Cmd {
             Cmd::ChangeTrust(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::CreateAccount(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ManageData(cmd) => cmd.tx.handle_and_print(op, global_args).await,
+            Cmd::ManageSellOffer(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::Payment(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::SetOptions(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::SetTrustlineFlags(cmd) => cmd.tx.handle_and_print(op, global_args).await,


### PR DESCRIPTION
### What

Add support for MANAGE_SELL_OFFER operation.

```console
$ stellar tx new manage-sell-offer --selling native --buying USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --price 1:2 --amount 10000000 --build-only | stellar xdr decode --type TransactionEnvelope --output json-formatted
{
  "tx": {
    "tx": {
      "source_account": "GDMHFOFH7IQSGGTIUYOUORZ3K2ZDP6PYNZDOL2AKSK7MRLPX5HF7DEA4",
      "fee": 100,
      "seq_num": "3179774742626315",
      "cond": "none",
      "memo": "none",
      "operations": [
        {
          "source_account": null,
          "body": {
            "manage_sell_offer": {
              "selling": "native",
              "buying": {
                "credit_alphanum4": {
                  "asset_code": "USDC",
                  "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                }
              },
              "amount": "10000000",
              "price": {
                "n": 1,
                "d": 2
              },
              "offer_id": "0"
            }
          }
        }
      ],
      "ext": "v0"
    },
    "signatures": []
  }
}
```

### Why

#2088

### Known limitations

N/A
