### PR TITLE
Add `stellar tx new manage-buy-offer`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1644,6 +1644,7 @@ Create a new transaction
 * `bump-sequence` — Bump sequence number to invalidate older transactions
 * `change-trust` — Create, update, or delete a trustline
 * `create-account` — Create and fund a new account
+* `manage-buy-offer` — Create, update, or delete a buy offer
 * `manage-data` — Set, modify, or delete account data entries
 * `manage-sell-offer` — Create, update, or delete a sell offer
 * `payment` — Send asset to destination account
@@ -1771,6 +1772,41 @@ Create and fund a new account
 * `--starting-balance <STARTING_BALANCE>` — Initial balance in stroops of the account, default 1 XLM
 
   Default value: `10_000_000`
+
+
+
+## `stellar tx new manage-buy-offer`
+
+Create, update, or delete a buy offer
+
+**Usage:** `stellar tx new manage-buy-offer [OPTIONS] --source-account <SOURCE_ACCOUNT> --selling <SELLING> --buying <BUYING> --amount <AMOUNT> --price <PRICE>`
+
+###### **Options:**
+
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--selling <SELLING>` — Asset to sell
+* `--buying <BUYING>` — Asset to buy
+* `--amount <AMOUNT>` — Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+* `--price <PRICE>` — Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+  Default value: `0`
 
 
 

--- a/cmd/crates/soroban-test/tests/it/integration/tx/operations.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/operations.rs
@@ -862,3 +862,45 @@ async fn manage_sell_offer() {
         "Should have one additional sub-entry for the offer"
     );
 }
+
+#[tokio::test]
+async fn manage_buy_offer() {
+    let sandbox = &TestEnv::new();
+    let client = sandbox.network.rpc_client().unwrap();
+    let (test, issuer) = setup_accounts(sandbox);
+    let asset = format!("EUR:{issuer}");
+
+    // Create trustline and issue some EUR to the test account
+    let limit = 100_000_000_000; // 10,000 EUR
+    let initial_balance = 50_000_000_000; // 5,000 EUR
+    issue_asset(sandbox, &test, &asset, limit, initial_balance).await;
+
+    let test_account_before = client.get_account(&test).await.unwrap();
+
+    // Create a new buy offer: buy 1000 EUR with XLM at price 2:1 (2 XLM per EUR)
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "manage-buy-offer",
+            "--selling",
+            "native",
+            "--buying",
+            &asset,
+            "--amount",
+            "10000000000", // 1000 EUR in stroops
+            "--price",
+            "2:1", // 2 XLM per EUR
+        ])
+        .assert()
+        .success();
+
+    let test_account_after = client.get_account(&test).await.unwrap();
+
+    // Account should have one more sub-entry (the offer)
+    assert_eq!(
+        test_account_before.num_sub_entries + 1,
+        test_account_after.num_sub_entries,
+        "Should have one additional sub-entry for the offer"
+    );
+}

--- a/cmd/soroban-cli/src/commands/tx/help.rs
+++ b/cmd/soroban-cli/src/commands/tx/help.rs
@@ -2,6 +2,7 @@ pub const ACCOUNT_MERGE: &str = "Transfer XLM balance to another account and rem
 pub const BUMP_SEQUENCE: &str = "Bump sequence number to invalidate older transactions";
 pub const CHANGE_TRUST: &str = "Create, update, or delete a trustline";
 pub const CREATE_ACCOUNT: &str = "Create and fund a new account";
+pub const MANAGE_BUY_OFFER: &str = "Create, update, or delete a buy offer";
 pub const MANAGE_DATA: &str = "Set, modify, or delete account data entries";
 pub const MANAGE_SELL_OFFER: &str = "Create, update, or delete a sell offer";
 pub const PAYMENT: &str = "Send asset to destination account";

--- a/cmd/soroban-cli/src/commands/tx/new/manage_buy_offer.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/manage_buy_offer.rs
@@ -1,0 +1,79 @@
+use clap::{command, Parser};
+
+use crate::{commands::tx, tx::builder, xdr};
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub tx: tx::Args,
+
+    #[clap(flatten)]
+    pub op: Args,
+}
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct Args {
+    /// Asset to sell
+    #[arg(long)]
+    pub selling: builder::Asset,
+
+    /// Asset to buy
+    #[arg(long)]
+    pub buying: builder::Asset,
+
+    /// Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer.
+    #[arg(long)]
+    pub amount: builder::Amount,
+
+    /// Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+    #[arg(long)]
+    pub price: String,
+
+    /// Offer ID. If 0, will create new offer. Otherwise, will update existing offer.
+    #[arg(long, default_value = "0")]
+    pub offer_id: i64,
+}
+
+impl TryFrom<&Cmd> for xdr::OperationBody {
+    type Error = tx::args::Error;
+    fn try_from(
+        Cmd {
+            tx,
+            op:
+                Args {
+                    selling,
+                    buying,
+                    amount,
+                    price,
+                    offer_id,
+                },
+        }: &Cmd,
+    ) -> Result<Self, Self::Error> {
+        let price_parts: Vec<&str> = price.split(':').collect();
+        if price_parts.len() != 2 {
+            return Err(tx::args::Error::InvalidPrice(price.clone()));
+        }
+
+        let n: i32 = price_parts[0]
+            .parse()
+            .map_err(|_| tx::args::Error::InvalidPrice(price.clone()))?;
+        let d: i32 = price_parts[1]
+            .parse()
+            .map_err(|_| tx::args::Error::InvalidPrice(price.clone()))?;
+
+        if d == 0 {
+            return Err(tx::args::Error::InvalidPrice(
+                "denominator cannot be zero".to_string(),
+            ));
+        }
+
+        Ok(xdr::OperationBody::ManageBuyOffer(xdr::ManageBuyOfferOp {
+            selling: tx.resolve_asset(selling)?,
+            buying: tx.resolve_asset(buying)?,
+            buy_amount: amount.into(),
+            price: xdr::Price { n, d },
+            offer_id: *offer_id,
+        }))
+    }
+}

--- a/cmd/soroban-cli/src/commands/tx/new/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/mod.rs
@@ -7,6 +7,7 @@ pub mod account_merge;
 pub mod bump_sequence;
 pub mod change_trust;
 pub mod create_account;
+pub mod manage_buy_offer;
 pub mod manage_data;
 pub mod manage_sell_offer;
 pub mod payment;
@@ -24,6 +25,8 @@ pub enum Cmd {
     ChangeTrust(change_trust::Cmd),
     #[command(about = super::help::CREATE_ACCOUNT)]
     CreateAccount(create_account::Cmd),
+    #[command(about = super::help::MANAGE_BUY_OFFER)]
+    ManageBuyOffer(manage_buy_offer::Cmd),
     #[command(about = super::help::MANAGE_DATA)]
     ManageData(manage_data::Cmd),
     #[command(about = super::help::MANAGE_SELL_OFFER)]
@@ -50,6 +53,7 @@ impl TryFrom<&Cmd> for OperationBody {
             Cmd::BumpSequence(cmd) => cmd.into(),
             Cmd::ChangeTrust(cmd) => cmd.try_into()?,
             Cmd::CreateAccount(cmd) => cmd.try_into()?,
+            Cmd::ManageBuyOffer(cmd) => cmd.try_into()?,
             Cmd::ManageData(cmd) => cmd.into(),
             Cmd::ManageSellOffer(cmd) => cmd.try_into()?,
             Cmd::Payment(cmd) => cmd.try_into()?,
@@ -67,6 +71,7 @@ impl Cmd {
             Cmd::BumpSequence(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ChangeTrust(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::CreateAccount(cmd) => cmd.tx.handle_and_print(op, global_args).await,
+            Cmd::ManageBuyOffer(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ManageData(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ManageSellOffer(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::Payment(cmd) => cmd.tx.handle_and_print(op, global_args).await,


### PR DESCRIPTION
### What

Add support for MANAGE_BUY_OFFER operation.

```console
$ stellar tx new manage-buy-offer --selling native --buying USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --price 1:2 --amount 10000000 --build-only | stellar xdr decode --type TransactionEnvelope --output json-formatted
{
  "tx": {
    "tx": {
      "source_account": "GDMHFOFH7IQSGGTIUYOUORZ3K2ZDP6PYNZDOL2AKSK7MRLPX5HF7DEA4",
      "fee": 100,
      "seq_num": "3179774742626317",
      "cond": "none",
      "memo": "none",
      "operations": [
        {
          "source_account": null,
          "body": {
            "manage_buy_offer": {
              "selling": "native",
              "buying": {
                "credit_alphanum4": {
                  "asset_code": "USDC",
                  "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                }
              },
              "buy_amount": "10000000",
              "price": {
                "n": 1,
                "d": 2
              },
              "offer_id": "0"
            }
          }
        }
      ],
      "ext": "v0"
    },
    "signatures": []
  }
}
```

### Why

#2088

### Known limitations

N/A
