### PR TITLE
Add `stellar tx new path-payment-strict-send`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1648,6 +1648,7 @@ Create a new transaction
 * `manage-buy-offer` — Create, update, or delete a buy offer
 * `manage-data` — Set, modify, or delete account data entries
 * `manage-sell-offer` — Create, update, or delete a sell offer
+* `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
 * `payment` — Send asset to destination account
 * `set-options` — Set account options like flags, signers, and home domain
 * `set-trustline-flags` — Configure authorization and trustline flags for an asset
@@ -1905,6 +1906,40 @@ Create, update, or delete a sell offer
 * `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
 
   Default value: `0`
+
+
+
+## `stellar tx new path-payment-strict-send`
+
+Send a payment with a different asset using path finding, specifying the send amount
+
+**Usage:** `stellar tx new path-payment-strict-send [OPTIONS] --source-account <SOURCE_ACCOUNT> --send-asset <SEND_ASSET> --send-amount <SEND_AMOUNT> --destination <DESTINATION> --dest-asset <DEST_ASSET> --dest-min <DEST_MIN>`
+
+###### **Options:**
+
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+* `--send-amount <SEND_AMOUNT>` — Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+* `--destination <DESTINATION>` — Account that receives the payment
+* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+* `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
+* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 
 

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -44,6 +44,8 @@ pub enum Error {
     TxXdr(#[from] super::xdr::Error),
     #[error("invalid price format: {0}")]
     InvalidPrice(String),
+    #[error("invalid path: {0}")]
+    InvalidPath(String),
 }
 
 impl Args {

--- a/cmd/soroban-cli/src/commands/tx/help.rs
+++ b/cmd/soroban-cli/src/commands/tx/help.rs
@@ -6,6 +6,8 @@ pub const CREATE_PASSIVE_SELL_OFFER: &str = "Create a passive sell offer on the 
 pub const MANAGE_BUY_OFFER: &str = "Create, update, or delete a buy offer";
 pub const MANAGE_DATA: &str = "Set, modify, or delete account data entries";
 pub const MANAGE_SELL_OFFER: &str = "Create, update, or delete a sell offer";
+pub const PATH_PAYMENT_STRICT_SEND: &str =
+    "Send a payment with a different asset using path finding, specifying the send amount";
 pub const PAYMENT: &str = "Send asset to destination account";
 pub const SET_OPTIONS: &str = "Set account options like flags, signers, and home domain";
 pub const SET_TRUSTLINE_FLAGS: &str = "Configure authorization and trustline flags for an asset";

--- a/cmd/soroban-cli/src/commands/tx/new/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/mod.rs
@@ -11,6 +11,7 @@ pub mod create_passive_sell_offer;
 pub mod manage_buy_offer;
 pub mod manage_data;
 pub mod manage_sell_offer;
+pub mod path_payment_strict_send;
 pub mod payment;
 pub mod set_options;
 pub mod set_trustline_flags;
@@ -34,6 +35,8 @@ pub enum Cmd {
     ManageData(manage_data::Cmd),
     #[command(about = super::help::MANAGE_SELL_OFFER)]
     ManageSellOffer(manage_sell_offer::Cmd),
+    #[command(about = super::help::PATH_PAYMENT_STRICT_SEND)]
+    PathPaymentStrictSend(path_payment_strict_send::Cmd),
     #[command(about = super::help::PAYMENT)]
     Payment(payment::Cmd),
     #[command(about = super::help::SET_OPTIONS)]
@@ -60,6 +63,7 @@ impl TryFrom<&Cmd> for OperationBody {
             Cmd::ManageBuyOffer(cmd) => cmd.try_into()?,
             Cmd::ManageData(cmd) => cmd.into(),
             Cmd::ManageSellOffer(cmd) => cmd.try_into()?,
+            Cmd::PathPaymentStrictSend(cmd) => cmd.try_into()?,
             Cmd::Payment(cmd) => cmd.try_into()?,
             Cmd::SetOptions(cmd) => cmd.try_into()?,
             Cmd::SetTrustlineFlags(cmd) => cmd.try_into()?,
@@ -79,6 +83,7 @@ impl Cmd {
             Cmd::ManageBuyOffer(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ManageData(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ManageSellOffer(cmd) => cmd.tx.handle_and_print(op, global_args).await,
+            Cmd::PathPaymentStrictSend(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::Payment(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::SetOptions(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::SetTrustlineFlags(cmd) => cmd.tx.handle_and_print(op, global_args).await,

--- a/cmd/soroban-cli/src/commands/tx/new/path_payment_strict_send.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/path_payment_strict_send.rs
@@ -1,0 +1,83 @@
+use clap::{command, Parser};
+
+use crate::{commands::tx, config::address, tx::builder, xdr};
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub tx: tx::Args,
+    #[clap(flatten)]
+    pub op: Args,
+}
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct Args {
+    /// Asset to send (pay with)
+    #[arg(long)]
+    pub send_asset: builder::Asset,
+
+    /// Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops).
+    #[arg(long)]
+    pub send_amount: builder::Amount,
+
+    /// Account that receives the payment
+    #[arg(long)]
+    pub destination: address::UnresolvedMuxedAccount,
+
+    /// Asset that the destination will receive
+    #[arg(long)]
+    pub dest_asset: builder::Asset,
+
+    /// Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met.
+    #[arg(long)]
+    pub dest_min: builder::Amount,
+
+    /// List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM.
+    #[arg(long, value_delimiter = ',')]
+    pub path: Vec<builder::Asset>,
+}
+
+impl TryFrom<&Cmd> for xdr::OperationBody {
+    type Error = tx::args::Error;
+    fn try_from(
+        Cmd {
+            tx,
+            op:
+                Args {
+                    send_asset,
+                    send_amount,
+                    destination,
+                    dest_asset,
+                    dest_min,
+                    path,
+                },
+        }: &Cmd,
+    ) -> Result<Self, Self::Error> {
+        // Validate path length (max 5 assets)
+        if path.len() > 5 {
+            return Err(tx::args::Error::InvalidPath(
+                "Path cannot contain more than 5 assets".to_string(),
+            ));
+        }
+
+        let path_assets: Result<Vec<xdr::Asset>, _> =
+            path.iter().map(|asset| tx.resolve_asset(asset)).collect();
+        let path_assets = path_assets?;
+
+        let path_vec = path_assets.try_into().map_err(|_| {
+            tx::args::Error::InvalidPath("Failed to convert path to VecM".to_string())
+        })?;
+
+        Ok(xdr::OperationBody::PathPaymentStrictSend(
+            xdr::PathPaymentStrictSendOp {
+                send_asset: tx.resolve_asset(send_asset)?,
+                send_amount: send_amount.into(),
+                destination: tx.resolve_muxed_address(destination)?,
+                dest_asset: tx.resolve_asset(dest_asset)?,
+                dest_min: dest_min.into(),
+                path: path_vec,
+            },
+        ))
+    }
+}


### PR DESCRIPTION
### What

Add support for PATH_PAYMENT_STRICT_SEND operation.

```console
$ stellar tx new path-payment-strict-send --send-asset native --send-amount 1000000 --destination default --dest-asset USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --dest-min 1000 --build-only | stellar xdr decode --type TransactionEnvelope --output json-formatte
d
{
  "tx": {
    "tx": {
      "source_account": "GDMHFOFH7IQSGGTIUYOUORZ3K2ZDP6PYNZDOL2AKSK7MRLPX5HF7DEA4",
      "fee": 100,
      "seq_num": "3179774742626317",
      "cond": "none",
      "memo": "none",
      "operations": [
        {
          "source_account": null,
          "body": {
            "path_payment_strict_send": {
              "send_asset": "native",
              "send_amount": "1000000",
              "destination": "GCNV6VMPZNHQTACVZC4AE75SJAFLHP7USOQWGE2HWMLXDKP6XOLGJR7S",
              "dest_asset": {
                "credit_alphanum4": {
                  "asset_code": "USDC",
                  "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                }
              },
              "dest_min": "1000",
              "path": []
            }
          }
        }
      ],
      "ext": "v0"
    },
    "signatures": []
  }
}
```

### Why

#2088

### Known limitations

N/A
