### PR TITLE
Add `stellar tx new path-payment-strict-receive`. 

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1649,6 +1649,7 @@ Create a new transaction
 * `manage-data` — Set, modify, or delete account data entries
 * `manage-sell-offer` — Create, update, or delete a sell offer
 * `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
+* `path-payment-strict-receive` — Send a payment with a different asset using path finding, specifying the receive amount
 * `payment` — Send asset to destination account
 * `set-options` — Set account options like flags, signers, and home domain
 * `set-trustline-flags` — Configure authorization and trustline flags for an asset
@@ -1939,6 +1940,40 @@ Send a payment with a different asset using path finding, specifying the send am
 * `--destination <DESTINATION>` — Account that receives the payment
 * `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
 * `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
+* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
+
+
+
+## `stellar tx new path-payment-strict-receive`
+
+Send a payment with a different asset using path finding, specifying the receive amount
+
+**Usage:** `stellar tx new path-payment-strict-receive [OPTIONS] --source-account <SOURCE_ACCOUNT> --send-asset <SEND_ASSET> --send-max <SEND_MAX> --destination <DESTINATION> --dest-asset <DEST_ASSET> --dest-amount <DEST_AMOUNT>`
+
+###### **Options:**
+
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+* `--send-max <SEND_MAX>` — Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+* `--destination <DESTINATION>` — Account that receives the payment
+* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+* `--dest-amount <DEST_AMOUNT>` — Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset
 * `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 

--- a/cmd/crates/soroban-test/tests/it/integration/tx/operations.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/operations.rs
@@ -946,3 +946,299 @@ async fn create_passive_sell_offer() {
         "Should have one additional sub-entry for the passive offer"
     );
 }
+
+#[tokio::test]
+async fn path_payment_strict_send() {
+    let sandbox = &TestEnv::new();
+    let (test, issuer) = setup_accounts(sandbox);
+
+    // Create recipient account
+    let recipient = new_account(sandbox, "recipient");
+
+    // Create market maker account that will provide liquidity
+    let market_maker = new_account(sandbox, "market_maker");
+
+    // Create USD asset issued by the issuer (test1)
+    let usd_asset = format!("USD:{issuer}");
+
+    let limit = 100_000_000_000; // 10,000 units
+    let initial_balance = 50_000_000_000; // 5,000 units
+
+    // Setup trustlines and issue USD to test account
+    issue_asset(sandbox, &test, &usd_asset, limit, initial_balance).await;
+
+    // Setup trustlines and issue USD to market maker
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "change-trust",
+            "--source",
+            "market_maker",
+            "--line",
+            &usd_asset,
+        ])
+        .assert()
+        .success();
+
+    // Authorize market maker's trustline
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "set-trustline-flags",
+            "--asset",
+            &usd_asset,
+            "--trustor",
+            &market_maker,
+            "--set-authorize",
+            "--source",
+            "test1",
+        ])
+        .assert()
+        .success();
+
+    // Issue USD to market maker
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "payment",
+            "--destination",
+            &market_maker,
+            "--asset",
+            &usd_asset,
+            "--amount",
+            initial_balance.to_string().as_str(),
+            "--source=test1",
+        ])
+        .assert()
+        .success();
+
+    // Setup trustlines for recipient account
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "change-trust",
+            "--source",
+            "recipient",
+            "--line",
+            &usd_asset,
+        ])
+        .assert()
+        .success();
+
+    // Authorize recipient's trustline
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "set-trustline-flags",
+            "--asset",
+            &usd_asset,
+            "--trustor",
+            &recipient,
+            "--set-authorize",
+            "--source",
+            "test1",
+        ])
+        .assert()
+        .success();
+
+    // Market maker creates a sell offer: sell USD for XLM at 1:2 ratio
+    // This provides liquidity for XLM -> USD path payments
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "manage-sell-offer",
+            "--source",
+            "market_maker",
+            "--selling",
+            &usd_asset,
+            "--buying",
+            "native",
+            "--amount",
+            "10000000000", // 1,000 USD for sale (within the 5,000 USD balance)
+            "--price",
+            "1:2", // 1 USD = 2 XLM (USD is worth more than XLM)
+        ])
+        .assert()
+        .success();
+
+    let client = sandbox.network.rpc_client().unwrap();
+    let test_balance_before = client.get_account(&test).await.unwrap().balance;
+    let recipient_balance_before = client.get_account(&recipient).await.unwrap().balance;
+
+    // Test path-payment-strict-send (send exactly 10 XLM, receive variable USD)
+    // At 1 USD = 2 XLM, 10 XLM should get us about 5 USD
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "path-payment-strict-send",
+            "--send-asset",
+            "native",
+            "--send-amount",
+            "100000000", // Send exactly 10 XLM
+            "--destination",
+            &recipient,
+            "--dest-asset",
+            &usd_asset,
+            "--dest-min",
+            "40000000", // Minimum 4 USD to receive (allowing for spread)
+        ])
+        .assert()
+        .success();
+
+    // Verify balances changed as expected
+    let test_balance_after = client.get_account(&test).await.unwrap().balance;
+    let recipient_balance_after = client.get_account(&recipient).await.unwrap().balance;
+
+    // Test account should have less XLM (sent 10 XLM + fees)
+    assert!(
+        test_balance_after < test_balance_before,
+        "Test account should have less XLM after sending"
+    );
+    let xlm_sent = test_balance_before - test_balance_after;
+    assert!(xlm_sent >= 100000000, "Should have sent at least 10 XLM");
+
+    // Recipient account balance should be the same (they received USD, not XLM)
+    assert_eq!(
+        recipient_balance_after, recipient_balance_before,
+        "Recipient XLM balance should be unchanged"
+    );
+}
+
+#[tokio::test]
+async fn path_payment_strict_receive() {
+    let sandbox = &TestEnv::new();
+    let (test, issuer) = setup_accounts(sandbox);
+
+    // Create recipient account
+    let recipient = new_account(sandbox, "recipient");
+
+    // Create market maker account that will provide liquidity
+    let market_maker = new_account(sandbox, "market_maker");
+
+    // Create USD asset issued by the issuer (test1)
+    let usd_asset = format!("USD:{issuer}");
+
+    let limit = 100_000_000_000; // 10,000 units
+    let initial_balance = 50_000_000_000; // 5,000 units
+
+    // Setup trustlines and issue USD to test account
+    issue_asset(sandbox, &test, &usd_asset, limit, initial_balance).await;
+
+    // Setup trustlines and issue USD to market maker
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "change-trust",
+            "--source",
+            "market_maker",
+            "--line",
+            &usd_asset,
+        ])
+        .assert()
+        .success();
+
+    // Authorize market maker's trustline
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "set-trustline-flags",
+            "--asset",
+            &usd_asset,
+            "--trustor",
+            &market_maker,
+            "--set-authorize",
+            "--source",
+            "test1",
+        ])
+        .assert()
+        .success();
+
+    // Issue USD to market maker
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "payment",
+            "--destination",
+            &market_maker,
+            "--asset",
+            &usd_asset,
+            "--amount",
+            initial_balance.to_string().as_str(),
+            "--source=test1",
+        ])
+        .assert()
+        .success();
+
+    // Market maker creates a buy offer: buy USD with XLM at 2:1 ratio
+    // This provides liquidity for USD -> XLM path payments
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "manage-buy-offer",
+            "--source",
+            "market_maker",
+            "--selling",
+            "native",
+            "--buying",
+            &usd_asset,
+            "--amount",
+            "1000000000", // Want to buy 100 USD
+            "--price",
+            "2:1", // 2 XLM = 1 USD
+        ])
+        .assert()
+        .success();
+
+    let client = sandbox.network.rpc_client().unwrap();
+    let test_balance_before = client.get_account(&test).await.unwrap().balance;
+    let recipient_balance_before = client.get_account(&recipient).await.unwrap().balance;
+
+    // Test path-payment-strict-receive (send variable USD, receive exactly 4 XLM)
+    // At 2 XLM = 1 USD, we need about 2 USD to get 4 XLM
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "path-payment-strict-receive",
+            "--send-asset",
+            &usd_asset,
+            "--send-max",
+            "300000000", // Max 30 USD to send (generous buffer)
+            "--destination",
+            &recipient,
+            "--dest-asset",
+            "native",
+            "--dest-amount",
+            "40000000", // Exactly 4 XLM to receive
+        ])
+        .assert()
+        .success();
+
+    // Verify balances changed as expected
+    let test_balance_after = client.get_account(&test).await.unwrap().balance;
+    let recipient_balance_after = client.get_account(&recipient).await.unwrap().balance;
+
+    // Test account balance should be slightly lower due to fees (they sent USD, not XLM)
+    assert!(
+        test_balance_after <= test_balance_before,
+        "Test account balance should be same or slightly lower due to fees"
+    );
+
+    // Recipient should have received exactly 4 XLM
+    let xlm_received = recipient_balance_after - recipient_balance_before;
+    assert_eq!(
+        xlm_received, 40000000,
+        "Recipient should have received exactly 4 XLM"
+    );
+}

--- a/cmd/soroban-cli/src/commands/tx/help.rs
+++ b/cmd/soroban-cli/src/commands/tx/help.rs
@@ -8,6 +8,8 @@ pub const MANAGE_DATA: &str = "Set, modify, or delete account data entries";
 pub const MANAGE_SELL_OFFER: &str = "Create, update, or delete a sell offer";
 pub const PATH_PAYMENT_STRICT_SEND: &str =
     "Send a payment with a different asset using path finding, specifying the send amount";
+pub const PATH_PAYMENT_STRICT_RECEIVE: &str =
+    "Send a payment with a different asset using path finding, specifying the receive amount";
 pub const PAYMENT: &str = "Send asset to destination account";
 pub const SET_OPTIONS: &str = "Set account options like flags, signers, and home domain";
 pub const SET_TRUSTLINE_FLAGS: &str = "Configure authorization and trustline flags for an asset";

--- a/cmd/soroban-cli/src/commands/tx/new/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/mod.rs
@@ -11,6 +11,7 @@ pub mod create_passive_sell_offer;
 pub mod manage_buy_offer;
 pub mod manage_data;
 pub mod manage_sell_offer;
+pub mod path_payment_strict_receive;
 pub mod path_payment_strict_send;
 pub mod payment;
 pub mod set_options;
@@ -37,6 +38,8 @@ pub enum Cmd {
     ManageSellOffer(manage_sell_offer::Cmd),
     #[command(about = super::help::PATH_PAYMENT_STRICT_SEND)]
     PathPaymentStrictSend(path_payment_strict_send::Cmd),
+    #[command(about = super::help::PATH_PAYMENT_STRICT_RECEIVE)]
+    PathPaymentStrictReceive(path_payment_strict_receive::Cmd),
     #[command(about = super::help::PAYMENT)]
     Payment(payment::Cmd),
     #[command(about = super::help::SET_OPTIONS)]
@@ -64,6 +67,7 @@ impl TryFrom<&Cmd> for OperationBody {
             Cmd::ManageData(cmd) => cmd.into(),
             Cmd::ManageSellOffer(cmd) => cmd.try_into()?,
             Cmd::PathPaymentStrictSend(cmd) => cmd.try_into()?,
+            Cmd::PathPaymentStrictReceive(cmd) => cmd.try_into()?,
             Cmd::Payment(cmd) => cmd.try_into()?,
             Cmd::SetOptions(cmd) => cmd.try_into()?,
             Cmd::SetTrustlineFlags(cmd) => cmd.try_into()?,
@@ -84,6 +88,7 @@ impl Cmd {
             Cmd::ManageData(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::ManageSellOffer(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::PathPaymentStrictSend(cmd) => cmd.tx.handle_and_print(op, global_args).await,
+            Cmd::PathPaymentStrictReceive(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::Payment(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::SetOptions(cmd) => cmd.tx.handle_and_print(op, global_args).await,
             Cmd::SetTrustlineFlags(cmd) => cmd.tx.handle_and_print(op, global_args).await,

--- a/cmd/soroban-cli/src/commands/tx/new/path_payment_strict_receive.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/path_payment_strict_receive.rs
@@ -1,0 +1,83 @@
+use clap::{command, Parser};
+
+use crate::{commands::tx, config::address, tx::builder, xdr};
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub tx: tx::Args,
+    #[clap(flatten)]
+    pub op: Args,
+}
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct Args {
+    /// Asset to send (pay with)
+    #[arg(long)]
+    pub send_asset: builder::Asset,
+
+    /// Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops).
+    #[arg(long)]
+    pub send_max: builder::Amount,
+
+    /// Account that receives the payment
+    #[arg(long)]
+    pub destination: address::UnresolvedMuxedAccount,
+
+    /// Asset that the destination will receive
+    #[arg(long)]
+    pub dest_asset: builder::Asset,
+
+    /// Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset.
+    #[arg(long)]
+    pub dest_amount: builder::Amount,
+
+    /// List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM.
+    #[arg(long, value_delimiter = ',')]
+    pub path: Vec<builder::Asset>,
+}
+
+impl TryFrom<&Cmd> for xdr::OperationBody {
+    type Error = tx::args::Error;
+    fn try_from(
+        Cmd {
+            tx,
+            op:
+                Args {
+                    send_asset,
+                    send_max,
+                    destination,
+                    dest_asset,
+                    dest_amount,
+                    path,
+                },
+        }: &Cmd,
+    ) -> Result<Self, Self::Error> {
+        // Validate path length (max 5 assets)
+        if path.len() > 5 {
+            return Err(tx::args::Error::InvalidPath(
+                "Path cannot contain more than 5 assets".to_string(),
+            ));
+        }
+
+        let path_assets: Result<Vec<xdr::Asset>, _> =
+            path.iter().map(|asset| tx.resolve_asset(asset)).collect();
+        let path_assets = path_assets?;
+
+        let path_vec = path_assets.try_into().map_err(|_| {
+            tx::args::Error::InvalidPath("Failed to convert path to VecM".to_string())
+        })?;
+
+        Ok(xdr::OperationBody::PathPaymentStrictReceive(
+            xdr::PathPaymentStrictReceiveOp {
+                send_asset: tx.resolve_asset(send_asset)?,
+                send_max: send_max.into(),
+                destination: tx.resolve_muxed_address(destination)?,
+                dest_asset: tx.resolve_asset(dest_asset)?,
+                dest_amount: dest_amount.into(),
+                path: path_vec,
+            },
+        ))
+    }
+}


### PR DESCRIPTION
### What

Add support for PATH_PAYMENT_STRICT_RECEIVE operation.

```console
$ stellar tx new path-payment-strict-receive --send-asset native --send-max 1000000 --destination default --dest-asset USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --dest-amount 1000 --build-only | stellar xdr decode --type TransactionEnvelope --output json-formatted
{
  "tx": {
    "tx": {
      "source_account": "GDMHFOFH7IQSGGTIUYOUORZ3K2ZDP6PYNZDOL2AKSK7MRLPX5HF7DEA4",
      "fee": 100,
      "seq_num": "3179774742626317",
      "cond": "none",
      "memo": "none",
      "operations": [
        {
          "source_account": null,
          "body": {
            "path_payment_strict_receive": {
              "send_asset": "native",
              "send_max": "1000000",
              "destination": "GCNV6VMPZNHQTACVZC4AE75SJAFLHP7USOQWGE2HWMLXDKP6XOLGJR7S",
              "dest_asset": {
                "credit_alphanum4": {
                  "asset_code": "USDC",
                  "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                }
              },
              "dest_amount": "1000",
              "path": []
            }
          }
        }
      ],
      "ext": "v0"
    },
    "signatures": []
  }
}
```

### Why

#2088

### Known limitations

N/A
