### PR TITLE
Ignore SAC deployment test that fails

### DIFF
--- a/cookbook/deploy-stellar-asset-contract.mdx
+++ b/cookbook/deploy-stellar-asset-contract.mdx
@@ -15,7 +15,7 @@ The Stellar Asset Contract can be deployed for any possible Stellar asset, eithe
 
 To perform the deploy, use the following command:
 
-```bash cookbooktest.fail cookbooktest.stderr="contract already exists"
+```bash cookbooktest.ignore
 stellar contract asset deploy \
     --source S... \
     --network testnet \


### PR DESCRIPTION
### What
  Ignore the cookbook test for deploying Stellar Asset Contract that sometimes fails locally when rerunning cookbook tests repeatedly.

  ### Why
  Locally the test will fail, but on CI it will succeed, so we can't really assert on either.