### PR TITLE
fix: Handle missing args gracefully on default `stellar tx fetch`

### DIFF
--- a/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/mod.rs
@@ -57,6 +57,8 @@ pub enum Error {
     Envelope(#[from] envelope::Error),
     #[error(transparent)]
     NotSupported(#[from] fee::Error),
+    #[error("the following required argument was not provided: {0}")]
+    MissingArg(String),
 }
 
 impl Cmd {
@@ -73,10 +75,10 @@ impl Cmd {
                             .default
                             .hash
                             .clone()
-                            .expect("Transaction hash is required but was not provided."),
-                        network: self.default.network.clone().unwrap(),
+                            .ok_or(Error::MissingArg("--hash <HASH>".to_string()))?,
+                        network: self.default.network.clone().unwrap_or_default(),
                     },
-                    output: self.default.output.unwrap(),
+                    output: self.default.output.unwrap_or_default(),
                 }
                 .run(global_args)
                 .await?;


### PR DESCRIPTION
### What

Instead of unwrapping (and panicking) when there are missing args passed to `stellar tx fetch`, this PR handles missing args more gracefully.

### Why

To improve the messaging when a user forgets to pass an arg in the default `stellar tx fetch` case, which defaults to fetching an envelope.

### Known limitations

N/A