### PR TITLE
Stub out `EventV0` specs so bindings still generate

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^14.0.0-rc.3",
+    "@stellar/stellar-sdk": "^14.1.1",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^13.x",
+    "@stellar/stellar-sdk": "^14.0.0-rc.3",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^14.0.0-rc.3",
+    "@stellar/stellar-sdk": "^14.1.1",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^13.x",
+    "@stellar/stellar-sdk": "^14.0.0-rc.3",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -301,6 +301,7 @@ pub fn entry_to_method_type(entry: &Entry) -> String {
 ",
             )
         }
+        Entry::Event { doc: _, name: _ } => String::new(),
     }
 }
 

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^14.0.0-rc.3",
+    "@stellar/stellar-sdk": "^14.1.1",
     "buffer": "6.0.3"
   },
   "devDependencies": {

--- a/cmd/crates/soroban-spec-typescript/src/types.rs
+++ b/cmd/crates/soroban-spec-typescript/src/types.rs
@@ -258,7 +258,7 @@ impl From<&ScSpecEntry> for Entry {
             },
             ScSpecEntry::EventV0(e) => Entry::Event {
                 doc: format!(
-                    "%s\nWarning: This is a stub; events are not supported yet",
+                    "{}\nWarning: This is a stub; events are not supported yet",
                     e.doc.to_utf8_string_lossy()
                 ),
                 name: e.name.to_utf8_string_lossy(),

--- a/cmd/crates/soroban-spec-typescript/src/types.rs
+++ b/cmd/crates/soroban-spec-typescript/src/types.rs
@@ -169,6 +169,10 @@ pub enum Entry {
         name: String,
         cases: Vec<ErrorEnumCase>,
     },
+    Event {
+        doc: String,
+        name: String,
+    },
 }
 
 impl From<&ScSpecTypeDef> for Type {
@@ -252,7 +256,13 @@ impl From<&ScSpecEntry> for Entry {
                 name: e.name.to_utf8_string_lossy(),
                 cases: e.cases.iter().map(Into::into).collect(),
             },
-            ScSpecEntry::EventV0(_) => todo!("EventV0 is not implemented yet"),
+            ScSpecEntry::EventV0(e) => Entry::Event {
+                doc: format!(
+                    "%s\nWarning: This is a stub; events are not supported yet",
+                    e.doc.to_utf8_string_lossy()
+                ),
+                name: e.name.to_utf8_string_lossy(),
+            },
         }
     }
 }


### PR DESCRIPTION
### What
Adds a stub to the `EventV0` branch of `ScSpecEntry`.

### Why
Bindings fail to generate if your wasm uses the new `#[contractevent]` macro, but they shouldn't:

```
$ stellar contract bindings typescript --output-dir testing --wasm target/wasm32v1-none/release/events.wasm 
ℹ️ Loading contract spec from file...

thread 'main' panicked at /home/george/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/soroban-spec-typescript-23.0.0/src/types.rs:255:40:
not yet implemented: EventV0 is not implemented yet
```

We should still let them be generated, even though there aren't bindings for the events themselves.

### Known limitations
n/a, I confirmed that building this branch and running the above commands generates bindings.