### PR TITLE
Revert "Bump version to 23.1.0"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,8 +132,8 @@ jobs:
           - os: ubuntu-latest-8-cores
             target: x86_64-unknown-linux-gnu
             cargo-hack-feature-options:
-              --feature-powerset --skip version_lt_23,emulator-tests
-              --group-features default,version_gte_23 --ignore-unknown-features
+              --feature-powerset --skip version_gte_23,emulator-tests
+              --group-features default,version_lt_23 --ignore-unknown-features
             additional-deb-packages: libudev-dev libdbus-1-dev
           #        - os: ubuntu-jammy-8-cores-arm64
           #          target: aarch64-unknown-linux-gnu
@@ -142,13 +142,13 @@ jobs:
           - os: macos-13
             target: x86_64-apple-darwin
             cargo-hack-feature-options:
-              --feature-powerset --skip version_lt_23,emulator-tests
-              --group-features default,version_gte_23 --ignore-unknown-features
+              --feature-powerset --skip version_gte_23,emulator-tests
+              --group-features default,version_lt_23 --ignore-unknown-features
           - os: macos-latest
             target: aarch64-apple-darwin
             cargo-hack-feature-options:
-              --feature-powerset --skip version_lt_23,emulator-tests
-              --group-features default,version_gte_23 --ignore-unknown-features
+              --feature-powerset --skip version_gte_23,emulator-tests
+              --group-features default,version_lt_23 --ignore-unknown-features
           # Windows builds notes:
           #
           # The different features that need testing are split over unique

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-cli"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-hello"
-version = "23.1.0"
+version = "23.0.1"
 
 [[package]]
 name = "soroban-ledger-snapshot"
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-json"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-tools"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "base64 0.21.7",
  "ethnum",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-typescript"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -4879,18 +4879,18 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-bye"
-version = "23.1.0"
+version = "23.0.1"
 
 [[package]]
 name = "stellar-cli"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-cli",
 ]
 
 [[package]]
 name = "stellar-ledger"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -5256,49 +5256,49 @@ dependencies = [
 
 [[package]]
 name = "test_constructor"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_custom_account"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_custom_types"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_empty_constructor"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_hello_world"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_swap"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "test_token"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "test_udt"
-version = "23.1.0"
+version = "23.0.1"
 dependencies = [
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,28 +20,28 @@ exclude = [
 ]
 
 [workspace.package]
-version = "23.1.0"
+version = "23.0.1"
 rust-version = "1.89.0"
 
 # Dependencies located in this repo:
 [workspace.dependencies.soroban-cli]
-version = "=23.1.0"
+version = "=23.0.1"
 path = "cmd/soroban-cli"
 
 [workspace.dependencies.soroban-spec-json]
-version = "=23.1.0"
+version = "=23.0.1"
 path = "./cmd/crates/soroban-spec-json"
 
 [workspace.dependencies.soroban-spec-typescript]
-version = "23.1.0"
+version = "23.0.1"
 path = "./cmd/crates/soroban-spec-typescript"
 
 [workspace.dependencies.soroban-spec-tools]
-version = "23.1.0"
+version = "23.0.1"
 path = "./cmd/crates/soroban-spec-tools"
 
 [workspace.dependencies.stellar-ledger]
-version = "=23.1.0"
+version = "=23.0.1"
 path = "cmd/crates/stellar-ledger"
 
 # Dependencies from the rs-stellar-xdr repo:

--- a/cmd/crates/soroban-test/tests/fixtures/bye/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/bye/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar-bye"
-version = "23.1.0"
+version = "23.0.1"
 edition = "2021"
 publish = false
 

--- a/cmd/crates/soroban-test/tests/fixtures/hello/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/hello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soroban-hello"
-version = "23.1.0"
+version = "23.0.1"
 edition = "2021"
 publish = false
 

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/constructor/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/constructor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_constructor"
-version = "23.1.0"
+version = "23.0.1"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_custom_account"
-version = "23.1.0"
+version = "23.0.1"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_custom_types"
-version = "23.1.0"
+version = "23.0.1"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/empty_constructor/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/empty_constructor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_empty_constructor"
-version = "23.1.0"
+version = "23.0.1"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_hello_world"
-version = "23.1.0"
+version = "23.0.1"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/swap/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_swap"
-version = "23.1.0"
+version = "23.0.1"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/token/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_token"
-version = "23.1.0"
+version = "23.0.1"
 description = "Soroban standard token contract"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Reverts stellar/stellar-cli#2167

accidently hit merge button (had enabled squash and merge) and merged into main while debugging errors in the release branch