### PR TITLE
Add contract bindings subcommands for flutter, swift and php

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -269,6 +269,9 @@ Generate code client bindings for a contract
 * `typescript` — Generate a TypeScript / JavaScript package
 * `python` — Generate Python bindings
 * `java` — Generate Java bindings
+* `flutter` — Generate Flutter bindings
+* `swift` — Generate Swift bindings
+* `php` — Generate PHP bindings
 
 
 
@@ -331,6 +334,30 @@ Generate Python bindings
 Generate Java bindings
 
 **Usage:** `stellar contract bindings java`
+
+
+
+## `stellar contract bindings flutter`
+
+Generate Flutter bindings
+
+**Usage:** `stellar contract bindings flutter`
+
+
+
+## `stellar contract bindings swift`
+
+Generate Swift bindings
+
+**Usage:** `stellar contract bindings swift`
+
+
+
+## `stellar contract bindings php`
+
+Generate PHP bindings
+
+**Usage:** `stellar contract bindings php`
 
 
 

--- a/cmd/soroban-cli/src/commands/contract/bindings.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings.rs
@@ -1,7 +1,10 @@
+pub mod flutter;
 pub mod java;
 pub mod json;
+pub mod php;
 pub mod python;
 pub mod rust;
+pub mod swift;
 pub mod typescript;
 
 #[derive(Debug, clap::Subcommand)]
@@ -20,6 +23,15 @@ pub enum Cmd {
 
     /// Generate Java bindings
     Java(java::Cmd),
+
+    /// Generate Flutter bindings
+    Flutter(flutter::Cmd),
+
+    /// Generate Swift bindings
+    Swift(swift::Cmd),
+
+    /// Generate PHP bindings
+    Php(php::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -38,6 +50,15 @@ pub enum Error {
 
     #[error(transparent)]
     Java(#[from] java::Error),
+
+    #[error(transparent)]
+    Flutter(#[from] flutter::Error),
+
+    #[error(transparent)]
+    Swift(#[from] swift::Error),
+
+    #[error(transparent)]
+    Php(#[from] php::Error),
 }
 
 impl Cmd {
@@ -48,6 +69,9 @@ impl Cmd {
             Cmd::Typescript(ts) => ts.run().await?,
             Cmd::Python(python) => python.run()?,
             Cmd::Java(java) => java.run()?,
+            Cmd::Flutter(flutter) => flutter.run()?,
+            Cmd::Swift(swift) => swift.run()?,
+            Cmd::Php(php) => php.run()?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/bindings/flutter.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/flutter.rs
@@ -1,0 +1,19 @@
+use std::fmt::Debug;
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("flutter binding generation is not implemented in the stellar-cli, but is available via the tool located here: https://github.com/lightsail-network/stellar-contract-bindings")]
+    NotImplemented,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        Err(Error::NotImplemented)
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/bindings/php.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/php.rs
@@ -1,0 +1,19 @@
+use std::fmt::Debug;
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("php binding generation is not implemented in the stellar-cli, but is available via the tool located here: https://github.com/lightsail-network/stellar-contract-bindings")]
+    NotImplemented,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        Err(Error::NotImplemented)
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/bindings/swift.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/swift.rs
@@ -1,0 +1,19 @@
+use std::fmt::Debug;
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("swift binding generation is not implemented in the stellar-cli, but is available via the tool located here: https://github.com/lightsail-network/stellar-contract-bindings")]
+    NotImplemented,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        Err(Error::NotImplemented)
+    }
+}


### PR DESCRIPTION
### What

Adds contract bindings subcommands for `flutter`, `swift` and `php`. They display a link to the [`stellar-contract-bindings`](https://github.com/lightsail-network/stellar-contract-bindings) tool, similar to the subcommands for `python` and `java`.

### Why

Contract bindings generation is now supported in the `stellar-contract-bindings` tool and corresponding SDKs for `flutter`, `swift/ios` and `php`.

### Known limitations

The bindings are not generated by the cli. The cli only displays the link to the `stellar-contract-bindings` tool similar to `python` and `java`.
