### PR TITLE
Add missing operations to `tx op add`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -2237,8 +2237,15 @@ Add Operation to a transaction
 * `account-merge` — Transfer XLM balance to another account and remove source account
 * `bump-sequence` — Bump sequence number to invalidate older transactions
 * `change-trust` — Create, update, or delete a trustline
+* `claim-claimable-balance` — Claim a claimable balance by its balance ID
 * `create-account` — Create and fund a new account
+* `create-claimable-balance` — Create a claimable balance that can be claimed by specified accounts
+* `create-passive-sell-offer` — Create a passive sell offer on the Stellar DEX
+* `manage-buy-offer` — Create, update, or delete a buy offer
 * `manage-data` — Set, modify, or delete account data entries
+* `manage-sell-offer` — Create, update, or delete a sell offer
+* `path-payment-strict-receive` — Send a payment with a different asset using path finding, specifying the receive amount
+* `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
 * `payment` — Send asset to destination account
 * `set-options` — Set account options like flags, signers, and home domain
 * `set-trustline-flags` — Configure authorization and trustline flags for an asset
@@ -2350,6 +2357,40 @@ Create, update, or delete a trustline
 
 
 
+## `stellar tx operation add claim-claimable-balance`
+
+Claim a claimable balance by its balance ID
+
+**Usage:** `stellar tx operation add claim-claimable-balance [OPTIONS] --source-account <SOURCE_ACCOUNT> --balance-id <BALANCE_ID> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to claim (64-character hex string)
+
+
+
 ## `stellar tx operation add create-account`
 
 Create and fund a new account
@@ -2387,6 +2428,121 @@ Create and fund a new account
 
 
 
+## `stellar tx operation add create-claimable-balance`
+
+Create a claimable balance that can be claimed by specified accounts
+
+**Usage:** `stellar tx operation add create-claimable-balance [OPTIONS] --source-account <SOURCE_ACCOUNT> --amount <AMOUNT> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--asset <ASSET>` — Asset to be held in the ClaimableBalanceEntry
+
+  Default value: `native`
+* `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
+* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants. Examples: - --claimant alice (unconditional) - --claimant 'bob:{"before_absolute_time":"1735689599"}' - --claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'
+
+
+
+## `stellar tx operation add create-passive-sell-offer`
+
+Create a passive sell offer on the Stellar DEX
+
+**Usage:** `stellar tx operation add create-passive-sell-offer [OPTIONS] --source-account <SOURCE_ACCOUNT> --selling <SELLING> --buying <BUYING> --amount <AMOUNT> --price <PRICE> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--selling <SELLING>` — Asset to sell
+* `--buying <BUYING>` — Asset to buy
+* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+
+
+
+## `stellar tx operation add manage-buy-offer`
+
+Create, update, or delete a buy offer
+
+**Usage:** `stellar tx operation add manage-buy-offer [OPTIONS] --source-account <SOURCE_ACCOUNT> --selling <SELLING> --buying <BUYING> --amount <AMOUNT> --price <PRICE> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--selling <SELLING>` — Asset to sell
+* `--buying <BUYING>` — Asset to buy
+* `--amount <AMOUNT>` — Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+* `--price <PRICE>` — Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+  Default value: `0`
+
+
+
 ## `stellar tx operation add manage-data`
 
 Set, modify, or delete account data entries
@@ -2419,6 +2575,124 @@ Set, modify, or delete account data entries
 * `--sign-with-ledger` — Sign with a ledger wallet
 * `--data-name <DATA_NAME>` — String up to 64 bytes long. If this is a new Name it will add the given name/value pair to the account. If this Name is already present then the associated value will be modified
 * `--data-value <DATA_VALUE>` — Up to 64 bytes long hex string If not present then the existing Name will be deleted. If present then this value will be set in the `DataEntry`
+
+
+
+## `stellar tx operation add manage-sell-offer`
+
+Create, update, or delete a sell offer
+
+**Usage:** `stellar tx operation add manage-sell-offer [OPTIONS] --source-account <SOURCE_ACCOUNT> --selling <SELLING> --buying <BUYING> --amount <AMOUNT> --price <PRICE> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--selling <SELLING>` — Asset to sell
+* `--buying <BUYING>` — Asset to buy
+* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+  Default value: `0`
+
+
+
+## `stellar tx operation add path-payment-strict-receive`
+
+Send a payment with a different asset using path finding, specifying the receive amount
+
+**Usage:** `stellar tx operation add path-payment-strict-receive [OPTIONS] --source-account <SOURCE_ACCOUNT> --send-asset <SEND_ASSET> --send-max <SEND_MAX> --destination <DESTINATION> --dest-asset <DEST_ASSET> --dest-amount <DEST_AMOUNT> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+* `--send-max <SEND_MAX>` — Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+* `--destination <DESTINATION>` — Account that receives the payment
+* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+* `--dest-amount <DEST_AMOUNT>` — Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset
+* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
+
+
+
+## `stellar tx operation add path-payment-strict-send`
+
+Send a payment with a different asset using path finding, specifying the send amount
+
+**Usage:** `stellar tx operation add path-payment-strict-send [OPTIONS] --source-account <SOURCE_ACCOUNT> --send-asset <SEND_ASSET> --send-amount <SEND_AMOUNT> --destination <DESTINATION> --dest-asset <DEST_ASSET> --dest-min <DEST_MIN> [TX_XDR]`
+
+###### **Arguments:**
+
+* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+
+###### **Options:**
+
+* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+
+  Default value: `100`
+* `--cost` — Output the cost execution to stderr
+* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+* `--build-only` — Build the transaction and only write the base64 xdr to stdout
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `-n`, `--network <NETWORK>` — Name of network to use from config
+* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+* `--global` — ⚠️ Deprecated: global config is always on
+* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+* `--sign-with-lab` — Sign with https://lab.stellar.org
+* `--sign-with-ledger` — Sign with a ledger wallet
+* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+* `--send-amount <SEND_AMOUNT>` — Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+* `--destination <DESTINATION>` — Account that receives the payment
+* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+* `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
+* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 
 

--- a/cmd/soroban-cli/src/commands/tx/op/add/claim_claimable_balance.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/claim_claimable_balance.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::claim_claimable_balance;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: claim_claimable_balance::Cmd,
+}

--- a/cmd/soroban-cli/src/commands/tx/op/add/create_claimable_balance.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/create_claimable_balance.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::create_claimable_balance;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: create_claimable_balance::Cmd,
+}

--- a/cmd/soroban-cli/src/commands/tx/op/add/create_passive_sell_offer.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/create_passive_sell_offer.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::create_passive_sell_offer;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: create_passive_sell_offer::Cmd,
+}

--- a/cmd/soroban-cli/src/commands/tx/op/add/manage_buy_offer.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/manage_buy_offer.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::manage_buy_offer;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: manage_buy_offer::Cmd,
+}

--- a/cmd/soroban-cli/src/commands/tx/op/add/manage_sell_offer.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/manage_sell_offer.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::manage_sell_offer;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: manage_sell_offer::Cmd,
+}

--- a/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
@@ -7,8 +7,15 @@ mod account_merge;
 mod args;
 mod bump_sequence;
 mod change_trust;
+mod claim_claimable_balance;
 mod create_account;
+mod create_claimable_balance;
+mod create_passive_sell_offer;
+mod manage_buy_offer;
 mod manage_data;
+mod manage_sell_offer;
+mod path_payment_strict_receive;
+mod path_payment_strict_send;
 mod payment;
 mod set_options;
 mod set_trustline_flags;
@@ -22,10 +29,24 @@ pub enum Cmd {
     BumpSequence(bump_sequence::Cmd),
     #[command(about = help::CHANGE_TRUST)]
     ChangeTrust(change_trust::Cmd),
+    #[command(about = help::CLAIM_CLAIMABLE_BALANCE)]
+    ClaimClaimableBalance(claim_claimable_balance::Cmd),
     #[command(about = help::CREATE_ACCOUNT)]
     CreateAccount(create_account::Cmd),
+    #[command(about = help::CREATE_CLAIMABLE_BALANCE)]
+    CreateClaimableBalance(create_claimable_balance::Cmd),
+    #[command(about = help::CREATE_PASSIVE_SELL_OFFER)]
+    CreatePassiveSellOffer(create_passive_sell_offer::Cmd),
+    #[command(about = help::MANAGE_BUY_OFFER)]
+    ManageBuyOffer(manage_buy_offer::Cmd),
     #[command(about = help::MANAGE_DATA)]
     ManageData(manage_data::Cmd),
+    #[command(about = help::MANAGE_SELL_OFFER)]
+    ManageSellOffer(manage_sell_offer::Cmd),
+    #[command(about = help::PATH_PAYMENT_STRICT_RECEIVE)]
+    PathPaymentStrictReceive(path_payment_strict_receive::Cmd),
+    #[command(about = help::PATH_PAYMENT_STRICT_SEND)]
+    PathPaymentStrictSend(path_payment_strict_send::Cmd),
     #[command(about = help::PAYMENT)]
     Payment(payment::Cmd),
     #[command(about = help::SET_OPTIONS)]
@@ -53,8 +74,23 @@ impl TryFrom<&Cmd> for OperationBody {
             Cmd::AccountMerge(account_merge::Cmd { op, .. }) => op.try_into()?,
             Cmd::BumpSequence(bump_sequence::Cmd { op, .. }) => op.into(),
             Cmd::ChangeTrust(change_trust::Cmd { op, .. }) => op.try_into()?,
+            Cmd::ClaimClaimableBalance(claim_claimable_balance::Cmd { op, .. }) => op.try_into()?,
             Cmd::CreateAccount(create_account::Cmd { op, .. }) => op.try_into()?,
+            Cmd::CreateClaimableBalance(create_claimable_balance::Cmd { op, .. }) => {
+                op.try_into()?
+            }
+            Cmd::CreatePassiveSellOffer(create_passive_sell_offer::Cmd { op, .. }) => {
+                op.try_into()?
+            }
+            Cmd::ManageBuyOffer(manage_buy_offer::Cmd { op, .. }) => op.try_into()?,
             Cmd::ManageData(manage_data::Cmd { op, .. }) => op.into(),
+            Cmd::ManageSellOffer(manage_sell_offer::Cmd { op, .. }) => op.try_into()?,
+            Cmd::PathPaymentStrictReceive(path_payment_strict_receive::Cmd { op, .. }) => {
+                op.try_into()?
+            }
+            Cmd::PathPaymentStrictSend(path_payment_strict_send::Cmd { op, .. }) => {
+                op.try_into()?
+            }
             Cmd::Payment(payment::Cmd { op, .. }) => op.try_into()?,
             Cmd::SetOptions(set_options::Cmd { op, .. }) => op.try_into()?,
             Cmd::SetTrustlineFlags(set_trustline_flags::Cmd { op, .. }) => op.try_into()?,
@@ -81,12 +117,47 @@ impl Cmd {
                 tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
+            Cmd::ClaimClaimableBalance(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
             Cmd::CreateAccount(cmd) => cmd.op.tx.add_op(
                 op,
                 tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
+            Cmd::CreateClaimableBalance(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
+            Cmd::CreatePassiveSellOffer(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
+            Cmd::ManageBuyOffer(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
             Cmd::ManageData(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
+            Cmd::ManageSellOffer(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
+            Cmd::PathPaymentStrictReceive(cmd) => cmd.op.tx.add_op(
+                op,
+                tx_envelope_from_input(&cmd.args.tx_xdr)?,
+                cmd.args.source(),
+            ),
+            Cmd::PathPaymentStrictSend(cmd) => cmd.op.tx.add_op(
                 op,
                 tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),

--- a/cmd/soroban-cli/src/commands/tx/op/add/path_payment_strict_receive.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/path_payment_strict_receive.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::path_payment_strict_receive;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: path_payment_strict_receive::Cmd,
+}

--- a/cmd/soroban-cli/src/commands/tx/op/add/path_payment_strict_send.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/path_payment_strict_send.rs
@@ -1,0 +1,10 @@
+use crate::commands::tx::new::path_payment_strict_send;
+
+#[derive(clap::Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub args: super::args::Args,
+    #[command(flatten)]
+    pub op: path_payment_strict_send::Cmd,
+}


### PR DESCRIPTION
### What

I added these commands but didn't know we had to add them to `tx op add` as well.

```console
$ stellar tx op add --help
Add Operation to a transaction

Usage: stellar tx operation add [OPTIONS] <COMMAND>

Commands:
  account-merge                Transfer XLM balance to another account and remove source account
  bump-sequence                Bump sequence number to invalidate older transactions
  change-trust                 Create, update, or delete a trustline
  claim-claimable-balance      Claim a claimable balance by its balance ID
  create-account               Create and fund a new account
  create-claimable-balance     Create a claimable balance that can be claimed by specified accounts
  create-passive-sell-offer    Create a passive sell offer on the Stellar DEX
  manage-buy-offer             Create, update, or delete a buy offer
  manage-data                  Set, modify, or delete account data entries
  manage-sell-offer            Create, update, or delete a sell offer
  path-payment-strict-receive  Send a payment with a different asset using path finding, specifying the receive amount
  path-payment-strict-send     Send a payment with a different asset using path finding, specifying the send amount
  payment                      Send asset to destination account
  set-options                  Set account options like flags, signers, and home domain
  set-trustline-flags          Configure authorization and trustline flags for an asset

$ stellar tx new --help
Create a new transaction

Usage: stellar tx new [OPTIONS] <COMMAND>

Commands:
  account-merge                Transfer XLM balance to another account and remove source account
  bump-sequence                Bump sequence number to invalidate older transactions
  change-trust                 Create, update, or delete a trustline
  claim-claimable-balance      Claim a claimable balance by its balance ID
  create-account               Create and fund a new account
  create-claimable-balance     Create a claimable balance that can be claimed by specified accounts
  create-passive-sell-offer    Create a passive sell offer on the Stellar DEX
  manage-buy-offer             Create, update, or delete a buy offer
  manage-data                  Set, modify, or delete account data entries
  manage-sell-offer            Create, update, or delete a sell offer
  path-payment-strict-send     Send a payment with a different asset using path finding, specifying the send amount
  path-payment-strict-receive  Send a payment with a different asset using path finding, specifying the receive amount
  payment                      Send asset to destination account
  set-options                  Set account options like flags, signers, and home domain
  set-trustline-flags          Configure authorization and trustline flags for an asset
```

### Why

So all operations are available on both `tx new` and `tx op add`.

### Known limitations

N/A
