### PR TITLE
modify claimant examples to be more docs-friendly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,4 +13,4 @@ jobs:
   docs-validation:
     uses: stellar/stellar-docs/.github/workflows/build.yml@main
     with:
-      stellar-cli-ref: ${{ github.ref }}
+      stellar-cli-ref: ${{ github.sha }}

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1895,7 +1895,11 @@ Create a claimable balance that can be claimed by specified accounts
 
   Default value: `native`
 * `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
-* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants. Examples: - --claimant alice (unconditional) - --claimant 'bob:{"before_absolute_time":"1735689599"}' - --claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'
+* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants.
+
+   Examples:
+
+   - `--claimant alice (unconditional)` - `--claimant 'bob:{"before_absolute_time":"1735689599"}'` - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
 
 
 
@@ -2462,7 +2466,11 @@ Create a claimable balance that can be claimed by specified accounts
 
   Default value: `native`
 * `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
-* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants. Examples: - --claimant alice (unconditional) - --claimant 'bob:{"before_absolute_time":"1735689599"}' - --claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'
+* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants.
+
+   Examples:
+
+   - `--claimant alice (unconditional)` - `--claimant 'bob:{"before_absolute_time":"1735689599"}'` - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
 
 
 

--- a/cmd/soroban-cli/src/commands/tx/new/create_claimable_balance.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/create_claimable_balance.rs
@@ -36,10 +36,12 @@ pub struct Args {
 
     /// Claimants of the claimable balance. Format: account_id or account_id:predicate_json
     /// Can be specified multiple times for multiple claimants.
+    ///
     /// Examples:
-    /// - --claimant alice (unconditional)
-    /// - --claimant 'bob:{"before_absolute_time":"1735689599"}'
-    /// - --claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'
+    ///
+    /// - `--claimant alice (unconditional)`
+    /// - `--claimant 'bob:{"before_absolute_time":"1735689599"}'`
+    /// - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
     #[arg(long = "claimant", action = clap::ArgAction::Append)]
     pub claimants: Vec<String>,
 }


### PR DESCRIPTION
### What

Changing the way the `--claimant` examples are presented.

### Why

Docs builds are currently failing to parse the examples as-is.

### Known limitations

N/A
