### PR TITLE
 Optimize test build performance for soroban-test

### DIFF
--- a/cmd/crates/soroban-test/Cargo.toml
+++ b/cmd/crates/soroban-test/Cargo.toml
@@ -60,5 +60,11 @@ emulator-tests = ["stellar-ledger/emulator-tests"]
 version_lt_23 = []
 version_gte_23 = []
 
+[profile.dev]
+# Speeds up compilation in development.
+opt-level = 0
+
 [profile.dev.package."*"]
+# Speeds up compilation of dependencies in development.
+opt-level = 2
 debug = 0

--- a/cmd/crates/soroban-test/Cargo.toml
+++ b/cmd/crates/soroban-test/Cargo.toml
@@ -59,3 +59,6 @@ it = []
 emulator-tests = ["stellar-ledger/emulator-tests"]
 version_lt_23 = []
 version_gte_23 = []
+
+[profile.dev.package."*"]
+debug = 0


### PR DESCRIPTION
This commit introduces a development profile override in `cmd/crates/soroban-test/Cargo.toml` to significantly speed up local test execution.

By setting `debug = 0` for all dependency packages (`*`) in the `dev` profile, we prevent the generation of debug information for third-party crates during `cargo test` runs. This reduces the amount of data the linker has to process, leading to much faster link times, especially on macOS where linking can be a bottleneck.

This change only affects dependencies, preserving full debug capabilities for the `soroban-test` crate itself, while improving the developer feedback loop.
