### PR TITLE
Hack fix to the address resolution in the snapshot create command

### DIFF
--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -421,7 +421,11 @@ impl Cmd {
         network_passphrase: &str,
     ) -> Option<Either<AccountId, ScAddress>> {
         if let Some(contract) = self.resolve_contract(address, network_passphrase) {
-            Some(Either::Right(contract))
+            match contract {
+                ScAddress::Contract(_) => Some(Either::Right(contract)),
+                ScAddress::Account(a) => Some(Either::Left(a)),
+                _ => panic!("address type unsupported")
+            }
         } else {
             self.resolve_account_sync(address).map(Either::Left)
         }


### PR DESCRIPTION
### What

Hack fix to the address resolution in the snapshot create command.

### Why

To unblock @kalepail affected by https://github.com/stellar/stellar-cli/issues/2207.

### Known limitations

This change probably doesn't address the full issue with address resolution. I see multiple functions that all seem to have a mistaken assumption that ScAdderss only contains contract addresses, when it can also contain an account address. This PR is just open teporarily to unblock @kalepail and isn't intended for merging. But it may help inform the final fix for the issue too.

### Usage

To use this change instead of the release stellar-cli, install from source using the following command:

```
cargo install --locked --git https://github.com/stellar/stellar-cli --branch snapshot-address-resolution stellar-cli
```