### PR TITLE
Add support for identities as signer on `tx new set-options`.

### DIFF
--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -164,4 +164,15 @@ impl Args {
     pub fn resolve_asset(&self, asset: &builder::Asset) -> Result<xdr::Asset, Error> {
         Ok(asset.resolve(&self.config.locator)?)
     }
+
+    pub fn resolve_signer_key(
+        &self,
+        signer_account: &UnresolvedMuxedAccount,
+    ) -> Result<xdr::SignerKey, Error> {
+        let resolved_account = self.resolve_account_id(signer_account)?;
+        let signer_key = match resolved_account.0 {
+            xdr::PublicKey::PublicKeyTypeEd25519(uint256) => xdr::SignerKey::Ed25519(uint256),
+        };
+        Ok(signer_key)
+    }
 }

--- a/cmd/soroban-cli/src/commands/tx/new/revoke_sponsorship.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/revoke_sponsorship.rs
@@ -96,13 +96,10 @@ impl TryFrom<&Cmd> for xdr::OperationBody {
 
         let revoke_op = if let Some(signer_key) = &cmd.op.signer_key {
             // Signer sponsorship
-            let resolved_account = cmd.tx.resolve_account_id(signer_key)?;
-            let signer_key = match resolved_account.0 {
-                xdr::PublicKey::PublicKeyTypeEd25519(uint256) => xdr::SignerKey::Ed25519(uint256),
-            };
+            let resolved_signer_key = cmd.tx.resolve_signer_key(signer_key)?;
             xdr::RevokeSponsorshipOp::Signer(xdr::RevokeSponsorshipOpSigner {
                 account_id: account_id_key,
-                signer_key,
+                signer_key: resolved_signer_key,
             })
         } else if let Some(asset) = &cmd.op.asset {
             // Trustline sponsorship

--- a/cmd/soroban-cli/src/commands/tx/new/set_options.rs
+++ b/cmd/soroban-cli/src/commands/tx/new/set_options.rs
@@ -37,7 +37,7 @@ pub struct Args {
     pub home_domain: Option<xdr::StringM<32>>,
     #[arg(long, requires = "signer_weight")]
     /// Add, update, or remove a signer from an account.
-    pub signer: Option<xdr::SignerKey>,
+    pub signer: Option<address::UnresolvedMuxedAccount>,
     #[arg(long = "signer-weight", requires = "signer")]
     /// Signer weight is a number from 0-255 (inclusive). The signer is deleted if the weight is 0.
     pub signer_weight: Option<u8>,
@@ -107,11 +107,12 @@ impl TryFrom<&Cmd> for xdr::OperationBody {
             clear_flag(xdr::AccountFlags::ClawbackEnabledFlag);
         }
 
-        let signer = if let (Some(key), Some(signer_weight)) =
-            (cmd.signer.clone(), cmd.signer_weight.as_ref())
+        let signer = if let (Some(signer_account), Some(signer_weight)) =
+            (cmd.signer.as_ref(), cmd.signer_weight.as_ref())
         {
+            let signer_key = tx.resolve_signer_key(signer_account)?;
             Some(xdr::Signer {
-                key,
+                key: signer_key,
                 weight: u32::from(*signer_weight),
             })
         } else {


### PR DESCRIPTION
### What

```console
# before
$ stellar tx new set-options --signer sponsor --signer-weight=20
error: invalid value 'sponsor' for '--signer <SIGNER>': xdr value invalid

# after
$ stellar tx new set-options --signer sponsor --signer-weight=20 --build-only
AAAAAgAAAACkBZuRlmsx0id9DepMyDU50OLurzdOysfTio7sxz6HzwAAAGQAANJ2AAAAAwAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAIogPEBhv4JY/n4BwiL6KsNVbNk/LyVwhverKE31ymPPAAAAFAAAAAAAAAAA
```

### Why

Fix #2214.

### Known limitations

N/A
