### PR TITLE
Add WASM fetch by hash support

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -485,11 +485,12 @@ Deploy a wasm contract
 
 Fetch a contract's Wasm binary
 
-**Usage:** `stellar contract fetch [OPTIONS] --id <CONTRACT_ID>`
+**Usage:** `stellar contract fetch [OPTIONS]`
 
 ###### **Options:**
 
 * `--id <CONTRACT_ID>` — Contract ID to fetch
+* `--wasm-hash <WASM_HASH>` — Wasm to fetch
 * `-o`, `--out-file <OUT_FILE>` — Where to write output otherwise stdout is used
 * `--global` — ⚠️ Deprecated: global config is always on
 * `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings

--- a/cmd/crates/soroban-test/tests/it/integration.rs
+++ b/cmd/crates/soroban-test/tests/it/integration.rs
@@ -1,5 +1,6 @@
 mod bindings;
 mod constructor;
+mod contract;
 mod cookbook;
 mod custom_types;
 mod dotenv;

--- a/cmd/crates/soroban-test/tests/it/integration/contract/fetch.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/contract/fetch.rs
@@ -1,0 +1,54 @@
+use crate::integration::util::{deploy_contract, DeployOptions, HELLO_WORLD};
+
+use soroban_test::TestEnv;
+
+#[tokio::test]
+async fn tx_fetch_with_hash() {
+    let sandbox = &TestEnv::new();
+    let test_account_alias = "test";
+    let wasm_bytes = HELLO_WORLD.bytes();
+    let wasm_hash = HELLO_WORLD.hash().unwrap();
+    let _contract_id = deploy_contract(
+        sandbox,
+        HELLO_WORLD,
+        DeployOptions {
+            deployer: Some(test_account_alias.to_string()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    sandbox
+        .new_assert_cmd("contract")
+        .arg("fetch")
+        .arg("--wasm-hash")
+        .arg(wasm_hash.to_string())
+        .assert()
+        .success()
+        .stdout(predicates::ord::eq(wasm_bytes));
+}
+
+#[tokio::test]
+async fn tx_fetch_with_id() {
+    let sandbox = &TestEnv::new();
+    let test_account_alias = "test";
+    let wasm_bytes = HELLO_WORLD.bytes();
+    let contract_id = deploy_contract(
+        sandbox,
+        HELLO_WORLD,
+        DeployOptions {
+            deployer: Some(test_account_alias.to_string()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    sandbox
+        .new_assert_cmd("contract")
+        .arg("fetch")
+        .arg("--id")
+        .arg(contract_id.clone())
+        .assert()
+        .success()
+        .stdout(predicates::ord::eq(wasm_bytes));
+}

--- a/cmd/crates/soroban-test/tests/it/integration/contract/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/contract/mod.rs
@@ -1,0 +1,1 @@
+mod fetch;

--- a/cmd/soroban-cli/src/commands/contract/fetch.rs
+++ b/cmd/soroban-cli/src/commands/contract/fetch.rs
@@ -13,7 +13,7 @@ use crate::{
         self, locator,
         network::{self, Network},
     },
-    wasm, Pwd,
+    wasm, xdr, Pwd,
 };
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -22,7 +22,10 @@ use crate::{
 pub struct Cmd {
     /// Contract ID to fetch
     #[arg(long = "id", env = "STELLAR_CONTRACT_ID")]
-    pub contract_id: config::UnresolvedContract,
+    pub contract_id: Option<config::UnresolvedContract>,
+    /// Wasm to fetch
+    #[arg(long = "wasm-hash", conflicts_with = "contract_id")]
+    pub wasm_hash: Option<String>,
     /// Where to write output otherwise stdout is used
     #[arg(long, short = 'o')]
     pub out_file: Option<std::path::PathBuf>,
@@ -63,6 +66,10 @@ pub enum Error {
     CannotCreateContractDir(PathBuf),
     #[error(transparent)]
     Wasm(#[from] wasm::Error),
+    #[error("wasm hash is invalid {0:?}")]
+    InvalidWasmHash(String),
+    #[error("must provide one of --wasm-hash, or --id")]
+    MissingArg,
 }
 
 impl From<Infallible> for Error {
@@ -111,12 +118,21 @@ impl NetworkRunnable for Cmd {
         config: Option<&config::Args>,
     ) -> Result<Vec<u8>, Error> {
         let network = config.map_or_else(|| self.network(), |c| Ok(c.get_network()?))?;
-        Ok(wasm::fetch_from_contract(
-            &self
-                .contract_id
-                .resolve_contract_id(&self.locator, &network.network_passphrase)?,
-            &network,
-        )
-        .await?)
+        if let Some(contract_id) = &self.contract_id {
+            Ok(wasm::fetch_from_contract(
+                &contract_id.resolve_contract_id(&self.locator, &network.network_passphrase)?,
+                &network,
+            )
+            .await?)
+        } else if let Some(wasm_hash) = &self.wasm_hash {
+            let hash = hex::decode(wasm_hash)
+                .map_err(|_| Error::InvalidWasmHash(wasm_hash.clone()))?
+                .try_into()
+                .map_err(|_| Error::InvalidWasmHash(wasm_hash.clone()))?;
+            let hash = xdr::Hash(hash);
+            Ok(wasm::fetch_from_wasm_hash(hash, &network).await?)
+        } else {
+            Err(Error::MissingArg)
+        }
     }
 }

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -138,3 +138,9 @@ pub async fn fetch_from_contract(
     }
     Err(UnexpectedContractToken(Box::new(data_entry)))
 }
+
+pub async fn fetch_from_wasm_hash(hash: Hash, network: &Network) -> Result<Vec<u8>, Error> {
+    tracing::trace!(?network);
+    let client = network.rpc_client()?;
+    Ok(get_remote_wasm_from_hash(&client, &hash).await?)
+}


### PR DESCRIPTION
### What
  Support fetch contract wasm using a hash instead of contract ID. Add new --wasm-hash argument to contract fetch command.

  ### Why
  Enable fetching WASM files directly by their content hash for faster deployment and verification. Support hash-based retrieval alongside existing ID-based approach.

Close #2223