### PR TITLE
change cookbook docs links

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -2,5 +2,8 @@
 
 set -ex
 
-cargo fmt --check || (cargo fmt && exit 1)
-make generate-full-help-doc
+make docs > /dev/null
+make fmt > /dev/null
+
+set +x
+git diff --exit-code > /dev/null || (echo "\nERROR: Staged files were modified by hooks. Please review and stage the changes." && exit 1)

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -10,4 +10,4 @@ cargo clippy --all -- -Dwarnings
 
 cargo build
 cargo test --all || (echo "might need to rebuild make build-snapshot" && exit 1)
-make generate-full-help-doc
+make docs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@
 Stellar CLI is a Rust-based command-line tool for interacting with the Stellar network. It's organized as a Cargo workspace with multiple crates and uses both Cargo and Make for build automation.
 
 ### Bootstrap and Build
+
 - Install system dependencies: `sudo apt-get update && sudo apt-get install -y libudev-dev libdbus-1-dev build-essential`
 - Install Rust toolchain: `rustup update` (Rust 1.89.0+ required)
 - Add WebAssembly target: `rustup target add wasm32v1-none`
@@ -14,16 +15,19 @@ Stellar CLI is a Rust-based command-line tool for interacting with the Stellar n
 - Install CLI: `make install` -- takes 3 minutes with potential network timeouts. NEVER CANCEL. Set timeout to 10+ minutes.
 
 ### Core Development Commands
+
 - Format code: `make fmt` -- takes 2 seconds
 - Run linting: `make check` -- takes 7 minutes. NEVER CANCEL. Set timeout to 15+ minutes.
 - Build main CLI only: `cargo build --bin stellar` -- takes 45 seconds. Use this for quick iterations.
 
 ### Testing
+
 - Test main soroban-cli library: `cargo test --package soroban-cli --lib` -- takes 52 seconds. NEVER CANCEL.
 - Test individual crates: `cargo test --package <crate-name>` -- typically takes 40 seconds per crate.
 - **WARNING**: Full test suite via `make test` requires building WebAssembly test fixtures and consumes significant memory and disk space. It may fail with "No space left on device" in constrained environments.
 
 ### CLI Usage and Validation
+
 - Test CLI installation: `stellar --version`
 - Basic CLI validation: `stellar --help`
 - Generate test keys: `stellar keys generate <name>`
@@ -39,6 +43,7 @@ Stellar CLI is a Rust-based command-line tool for interacting with the Stellar n
 ## Common Tasks
 
 ### Repository Structure
+
 ```
 /home/runner/work/stellar-cli/stellar-cli/
 ├── cmd/
@@ -55,6 +60,7 @@ Stellar CLI is a Rust-based command-line tool for interacting with the Stellar n
 ```
 
 ### Key Commands Reference
+
 ```bash
 # Development workflow
 cargo build --bin stellar        # Quick build (45s)
@@ -74,6 +80,7 @@ stellar keys address test      # Test key operations
 ```
 
 ### Build Time Expectations
+
 - **NEVER CANCEL** any build or test command before these timeouts:
   - `cargo build --bin stellar`: 2 minutes timeout minimum
   - `make install`: 10 minutes timeout (network issues common)
@@ -82,23 +89,28 @@ stellar keys address test      # Test key operations
   - Core library tests: 5 minutes timeout minimum
 
 ### Known Issues
+
 - **Network timeouts**: `make install` frequently encounters network timeouts with crates.io. This is normal in CI environments.
 - **Memory constraints**: Full workspace build and test may fail with OOM or "No space left on device" errors in constrained environments.
-- **Documentation generation**: `make generate-full-help-doc` may fail due to disk space constraints.
+- **Documentation generation**: `make docs` may fail due to disk space constraints.
 
 ### Working Around Constraints
+
 - Use `cargo build --bin stellar` instead of full workspace build for development
 - Test individual packages with `cargo test --package <name>` instead of full test suite
 - Use `cargo install --force --locked --path ./cmd/stellar-cli` as alternative to `make install`
 
 ## Critical Warnings
+
 - **NEVER CANCEL builds or tests** before the specified timeout periods
 - **Always validate changes** by building and testing the CLI before committing
 - **Network issues are common** - retry `make install` if it fails with timeouts
 - **Use surgical builds** when possible to avoid memory/disk issues
 
 ## CI/CD Integration
+
 The project uses GitHub Actions with workflows in `.github/workflows/`:
+
 - `rust.yml`: Main CI pipeline with formatting, linting, building, and testing
 - `e2e.yml`: End-to-end system tests
 - `binaries.yml`: Multi-platform binary builds

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  group:
+    ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,9 +31,8 @@ jobs:
     if: always()
     needs:
       [
-        fmt,
         cargo-deny,
-        check-generated-full-help-docs,
+        check-fmt,
         build-and-test,
         build-and-test-macos,
         build-and-test-windows,
@@ -43,16 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if:
-          contains(needs.*.result, 'failure') || contains(needs.*.result,
-          'cancelled')
+          contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
-
-  fmt:
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v5
-      - run: rustup update
-      - run: cargo fmt --all --check
 
   cargo-deny:
     runs-on: ubuntu-latest
@@ -67,15 +58,15 @@ jobs:
         with:
           command: check ${{ matrix.check }}
 
-  check-generated-full-help-docs:
+  check-fmt:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v5
       - uses: stellar/actions/rust-cache@main
-      - run: rustup update
       - run: sudo apt update && sudo apt install -y libudev-dev libdbus-1-dev
-      - run: make generate-full-help-doc
-      - run: git add -N . && git diff HEAD --exit-code
+      - run: rustup update
+      - run: npm install
+      - run: make check
 
   build-and-test:
     strategy:
@@ -96,9 +87,7 @@ jobs:
           rust-version: ${{ matrix.rust }}
 
   build-and-test-macos:
-    if:
-      github.ref == 'refs/heads/main' || startsWith(github.ref,
-      'refs/heads/release/') || startsWith(github.head_ref, 'release/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:
@@ -117,9 +106,7 @@ jobs:
           rust-version: ${{ matrix.rust }}
 
   build-and-test-windows:
-    if:
-      github.ref == 'refs/heads/main' || startsWith(github.ref,
-      'refs/heads/release/') || startsWith(github.head_ref, 'release/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     needs:
       [
         cargo-deny,
-        check-fmt,
+        check,
         build-and-test,
         build-and-test-macos,
         build-and-test-windows,
@@ -41,8 +41,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - if:
-          contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
 
   cargo-deny:
@@ -58,7 +57,7 @@ jobs:
         with:
           command: check ${{ matrix.check }}
 
-  check-fmt:
+  check:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,84 +2,76 @@
 
 Thanks for taking the time to improve stellar-cli!
 
-The following is a set of guidelines for contributions and may change over time.
-Feel free to suggest improvements to this document in a pull request.We want to make it as easy as possible to contribute changes that help the Stellar network grow and
-thrive. There are a few guidelines that we ask contributors to follow so that we can merge your
-changes quickly.
+The following is a set of guidelines for contributions and may change over time. Feel free to suggest improvements to this document in a pull request.We want to make it as easy as possible to contribute changes that help the Stellar network grow and thrive. There are a few guidelines that we ask contributors to follow so that we can merge your changes quickly.
 
 ## Getting Started
 
-* Make sure you have a [GitHub account](https://github.com/signup/free).
-* Create a GitHub issue for your contribution, assuming one does not already exist.
-  * Clearly describe the issue including steps to reproduce if it is a bug.
-* Fork the repository on GitHub.
+- Make sure you have a [GitHub account](https://github.com/signup/free).
+- Create a GitHub issue for your contribution, assuming one does not already exist.
+  - Clearly describe the issue including steps to reproduce if it is a bug.
+- Fork the repository on GitHub.
 
 ## Setting up development environment
 
 There are 2 ways to begin developing stellar-cli:
 
-### Installing all required dependencies 
+### Installing all required dependencies
 
-You may want to install all required dependencies locally. This includes installing `rustup`, `make`, `libudev`, `jq` from your package manager. After all dependencies are installed, you can start with running `make install` to build `stellar-cli` and install it! 
+You may want to install all required dependencies locally. This includes installing `rustup`, `make`, `libudev`, `jq` from your package manager. After all dependencies are installed, you can start with running `make install` to build `stellar-cli` and install it!
 
 ### Using `nix`
 
 If you don't want to install necessary dependencies from above, you can run development shell using [nix](https://nixos.org/guides/how-nix-works/) (make sure to [install](https://nixos.org/download/) version above 2.20). After installing `nix`, simply run `nix develop` that will start new `bash` session in your current terminal. If you want to use different shell (e.g. `zsh`) you can run `nix develop -c zsh`
 
 This session will have:
+
 1. All required dependencies installed
 2. `stellar` alias (overwriting your existing `stellar` installed via cargo, if any)
 3. Configured auto-complete for the working git branch
 
 You can add extra configuration in your `local.sh` file (for example, if you want to export some extra variables for your devshell you can put following in your `local.sh`:
+
 ```shell
 #!/usr/bin/env bash
 export STELLAR_NETWORK=testnet
 ```
-Note that all of dependencies and configurations mentioned above is available only in your local development shell, not outside of it.
 
+Note that all of dependencies and configurations mentioned above is available only in your local development shell, not outside of it.
 
 ### Minor Changes
 
 #### Documentation
 
-For small changes to comments and documentation, it is not
-always necessary to create a new GitHub issue. In this case, it is
-appropriate to start the first line of a commit with 'doc' instead of
-an issue number.
+For small changes to comments and documentation, it is not always necessary to create a new GitHub issue. In this case, it is appropriate to start the first line of a commit with 'doc' instead of an issue number.
 
 ## Finding things to work on
 
-The first place to start is always looking over the current GitHub issues for the project you are
-interested in contributing to. Issues marked with [help wanted][help-wanted] are usually pretty
-self-contained and a good place to get started.
+The first place to start is always looking over the current GitHub issues for the project you are interested in contributing to. Issues marked with [help wanted][help-wanted] are usually pretty self-contained and a good place to get started.
 
-Stellar.org also uses these same GitHub issues to keep track of what we are working on. If you see
-any issues that are assigned to a particular person or have the `in progress` label, that means
-someone is currently working on that issue this issue in the next week or two.
+Stellar.org also uses these same GitHub issues to keep track of what we are working on. If you see any issues that are assigned to a particular person or have the `in progress` label, that means someone is currently working on that issue this issue in the next week or two.
 
 Of course, feel free to create a new issue if you think something needs to be added or fixed.
 
-
 ## Making Changes
 
-* Fork the stellar-cli repo to your own Github account
+- Fork the stellar-cli repo to your own Github account
 
-* List the current configured remote repository for your fork. Your git remote
-should initially look like this. 
-   ```
-   $ git remote -v
-   > origin  https://github.com/YOUR_USERNAME/stellar-cli.git (fetch)
-   > origin  https://github.com/YOUR_USERNAME/stellar-cli.git (push)
-   ```
+- List the current configured remote repository for your fork. Your git remote should initially look like this.
 
-* Set the `stellar/stellar-cli` repo as the remote upstream repository that will
-sync with your fork. 
+  ```
+  $ git remote -v
+  > origin  https://github.com/YOUR_USERNAME/stellar-cli.git (fetch)
+  > origin  https://github.com/YOUR_USERNAME/stellar-cli.git (push)
+  ```
+
+- Set the `stellar/stellar-cli` repo as the remote upstream repository that will sync with your fork.
+
   ```
   git remote add upstream https://github.com/stellar/stellar-cli.git
   ```
 
-* Verify the new upstream repository you've specified for your fork.
+- Verify the new upstream repository you've specified for your fork.
+
   ```
   $ git remote -v
   > origin    https://github.com/YOUR_USERNAME/stellar-cli.git (fetch)
@@ -88,38 +80,33 @@ sync with your fork.
   > upstream  https://github.com/stellar/stellar-cli.git (push)
   ```
 
-* Add git hooks for commits and pushes so that checks run before pushing:
+- Add git hooks for commits and pushes so that checks run before pushing:
+
   ```
   ./install_githooks.sh
   ```
 
-* Create a topic branch for your changes in your local repo. When you push you should be able
-to create PR based on upstream stellar/stellar-cli.
+- Create a topic branch for your changes in your local repo. When you push you should be able to create PR based on upstream stellar/stellar-cli.
 
-* Make sure you have added the necessary tests for your changes and make sure all tests pass.
-
+- Make sure you have added the necessary tests for your changes and make sure all tests pass.
 
 ## Submitting Changes
 
-* All content, comments, pull requests and other contributions must comply with the
-  [Stellar Code of Conduct][coc].
-* Push your changes to a topic branch in your fork of the repository.
-* Submit a pull request to the repo in the Stellar organization.
-  * Include a descriptive [commit message][commit-msg].
-  * Changes contributed via pull request should focus on a single issue at a time.
-  * Rebase your local changes against the master branch. Resolve any conflicts that arise.
+- All content, comments, pull requests and other contributions must comply with the [Stellar Code of Conduct][coc].
+- Push your changes to a topic branch in your fork of the repository.
+- Submit a pull request to the repo in the Stellar organization.
+  - Include a descriptive [commit message][commit-msg].
+  - Changes contributed via pull request should focus on a single issue at a time.
+  - Rebase your local changes against the master branch. Resolve any conflicts that arise.
 
-
-At this point you're waiting on us. We like to at least comment on pull requests within three
-business days (typically, one business day). We may suggest some changes, improvements or
-alternatives.
+At this point you're waiting on us. We like to at least comment on pull requests within three business days (typically, one business day). We may suggest some changes, improvements or alternatives.
 
 # Additional Resources
 
-* #dev-discussion channel on [Discord](https://discord.gg/BYPXtmwX)
+- #dev-discussion channel on [Discord](https://discord.gg/BYPXtmwX)
 
 This document is inspired by:
 
-[help-wanted]: https://github.com/stellar/stellar-cli/contribute 
+[help-wanted]: https://github.com/stellar/stellar-cli/contribute
 [commit-msg]: https://github.com/erlang/otp/wiki/Writing-good-commit-messages
 [coc]: https://github.com/stellar/.github/blob/master/CODE_OF_CONDUCT.md

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -38,41 +38,38 @@ Anything after the `--` double dash (the "slop") is parsed as arguments to the c
 
     stellar contract invoke --id CCR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OTE2 --source alice --network testnet -- hello --to world
 
-
 **Usage:** `stellar [OPTIONS] <COMMAND>`
 
 ###### **Subcommands:**
 
-* `contract` — Tools for smart contract developers
-* `doctor` — Diagnose and troubleshoot CLI and network issues
-* `events` — Watch the network for contract events
-* `env` — Prints the environment variables
-* `keys` — Create and manage identities including keys and addresses
-* `network` — Configure connection to networks
-* `container` — Start local networks in containers
-* `config` — Manage cli configuration
-* `snapshot` — Download a snapshot of a ledger from an archive
-* `tx` — Sign, Simulate, and Send transactions
-* `xdr` — Decode and encode XDR
-* `completion` — Print shell completion code for the specified shell
-* `cache` — Cache for transactions and contract specs
-* `version` — Print version information
-* `plugin` — The subcommand for CLI plugins
-* `ledger` — Fetch ledger information
-* `fee-stats` — Fetch network feestats
+- `contract` — Tools for smart contract developers
+- `doctor` — Diagnose and troubleshoot CLI and network issues
+- `events` — Watch the network for contract events
+- `env` — Prints the environment variables
+- `keys` — Create and manage identities including keys and addresses
+- `network` — Configure connection to networks
+- `container` — Start local networks in containers
+- `config` — Manage cli configuration
+- `snapshot` — Download a snapshot of a ledger from an archive
+- `tx` — Sign, Simulate, and Send transactions
+- `xdr` — Decode and encode XDR
+- `completion` — Print shell completion code for the specified shell
+- `cache` — Cache for transactions and contract specs
+- `version` — Print version information
+- `plugin` — The subcommand for CLI plugins
+- `ledger` — Fetch ledger information
+- `fee-stats` — Fetch network feestats
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `-f`, `--filter-logs <FILTER_LOGS>` — Filter logs output. To turn on `stellar_cli::log::footprint=debug` or off `=off`. Can also use env var `RUST_LOG`
-* `-q`, `--quiet` — Do not write logs to stderr including `INFO`
-* `-v`, `--verbose` — Log DEBUG events
-* `--very-verbose` [alias: `vv`] — Log DEBUG and TRACE events
-* `--list` — List installed plugins. E.g. `stellar-hello`
-* `--no-cache` — Do not cache your simulations and transactions
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `-f`, `--filter-logs <FILTER_LOGS>` — Filter logs output. To turn on `stellar_cli::log::footprint=debug` or off `=off`. Can also use env var `RUST_LOG`
+- `-q`, `--quiet` — Do not write logs to stderr including `INFO`
+- `-v`, `--verbose` — Log DEBUG events
+- `--very-verbose` [alias: `vv`] — Log DEBUG and TRACE events
+- `--list` — List installed plugins. E.g. `stellar-hello`
+- `--no-cache` — Do not cache your simulations and transactions
 
 ## `stellar contract`
 
@@ -82,25 +79,23 @@ Tools for smart contract developers
 
 ###### **Subcommands:**
 
-* `asset` — Utilities to deploy a Stellar Asset Contract or get its id
-* `alias` — Utilities to manage contract aliases
-* `bindings` — Generate code client bindings for a contract
-* `build` — Build a contract from source
-* `extend` — Extend the time to live ledger of a contract-data ledger entry
-* `deploy` — Deploy a wasm contract
-* `fetch` — Fetch a contract's Wasm binary
-* `id` — Generate the contract id for a given contract or asset
-* `info` — Access info about contracts
-* `init` — Initialize a Soroban contract project
-* `inspect` — (Deprecated in favor of `contract info` subcommand) Inspect a WASM file listing contract functions, meta, etc
-* `upload` — Install a WASM file to the ledger without creating a contract instance
-* `install` — (Deprecated in favor of `contract upload` subcommand) Install a WASM file to the ledger without creating a contract instance
-* `invoke` — Invoke a contract function
-* `optimize` — Optimize a WASM file
-* `read` — Print the current value of a contract-data ledger entry
-* `restore` — Restore an evicted value for a contract-data legder entry
-
-
+- `asset` — Utilities to deploy a Stellar Asset Contract or get its id
+- `alias` — Utilities to manage contract aliases
+- `bindings` — Generate code client bindings for a contract
+- `build` — Build a contract from source
+- `extend` — Extend the time to live ledger of a contract-data ledger entry
+- `deploy` — Deploy a wasm contract
+- `fetch` — Fetch a contract's Wasm binary
+- `id` — Generate the contract id for a given contract or asset
+- `info` — Access info about contracts
+- `init` — Initialize a Soroban contract project
+- `inspect` — (Deprecated in favor of `contract info` subcommand) Inspect a WASM file listing contract functions, meta, etc
+- `upload` — Install a WASM file to the ledger without creating a contract instance
+- `install` — (Deprecated in favor of `contract upload` subcommand) Install a WASM file to the ledger without creating a contract instance
+- `invoke` — Invoke a contract function
+- `optimize` — Optimize a WASM file
+- `read` — Print the current value of a contract-data ledger entry
+- `restore` — Restore an evicted value for a contract-data legder entry
 
 ## `stellar contract asset`
 
@@ -110,10 +105,8 @@ Utilities to deploy a Stellar Asset Contract or get its id
 
 ###### **Subcommands:**
 
-* `id` — Get Id of builtin Soroban Asset Contract. Deprecated, use `stellar contract id asset` instead
-* `deploy` — Deploy builtin Soroban Asset Contract
-
-
+- `id` — Get Id of builtin Soroban Asset Contract. Deprecated, use `stellar contract id asset` instead
+- `deploy` — Deploy builtin Soroban Asset Contract
 
 ## `stellar contract asset id`
 
@@ -123,15 +116,13 @@ Get Id of builtin Soroban Asset Contract. Deprecated, use `stellar contract id a
 
 ###### **Options:**
 
-* `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar contract asset deploy`
 
@@ -141,27 +132,26 @@ Deploy builtin Soroban Asset Contract
 
 ###### **Options:**
 
-* `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--alias <ALIAS>` — The alias that will be used to save the assets's id. Whenever used, `--alias` will always overwrite the existing contract id configuration without asking for confirmation
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--alias <ALIAS>` — The alias that will be used to save the assets's id. Whenever used, `--alias` will always overwrite the existing contract id configuration without asking for confirmation
 
 ## `stellar contract alias`
 
@@ -171,12 +161,10 @@ Utilities to manage contract aliases
 
 ###### **Subcommands:**
 
-* `remove` — Remove contract alias
-* `add` — Add contract alias
-* `show` — Show the contract id associated with a given alias
-* `ls` — List all aliases
-
-
+- `remove` — Remove contract alias
+- `add` — Add contract alias
+- `show` — Show the contract id associated with a given alias
+- `ls` — List all aliases
 
 ## `stellar contract alias remove`
 
@@ -186,18 +174,16 @@ Remove contract alias
 
 ###### **Arguments:**
 
-* `<ALIAS>` — The contract alias that will be removed
+- `<ALIAS>` — The contract alias that will be removed
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar contract alias add`
 
@@ -207,20 +193,18 @@ Add contract alias
 
 ###### **Arguments:**
 
-* `<ALIAS>` — The contract alias that will be used
+- `<ALIAS>` — The contract alias that will be used
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--overwrite` — Overwrite the contract alias if it already exists
-* `--id <CONTRACT_ID>` — The contract id that will be associated with the alias
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--overwrite` — Overwrite the contract alias if it already exists
+- `--id <CONTRACT_ID>` — The contract id that will be associated with the alias
 
 ## `stellar contract alias show`
 
@@ -230,18 +214,16 @@ Show the contract id associated with a given alias
 
 ###### **Arguments:**
 
-* `<ALIAS>` — The contract alias that will be displayed
+- `<ALIAS>` — The contract alias that will be displayed
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar contract alias ls`
 
@@ -251,10 +233,8 @@ List all aliases
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar contract bindings`
 
@@ -264,16 +244,14 @@ Generate code client bindings for a contract
 
 ###### **Subcommands:**
 
-* `json` — Generate Json Bindings
-* `rust` — Generate Rust bindings
-* `typescript` — Generate a TypeScript / JavaScript package
-* `python` — Generate Python bindings
-* `java` — Generate Java bindings
-* `flutter` — Generate Flutter bindings
-* `swift` — Generate Swift bindings
-* `php` — Generate PHP bindings
-
-
+- `json` — Generate Json Bindings
+- `rust` — Generate Rust bindings
+- `typescript` — Generate a TypeScript / JavaScript package
+- `python` — Generate Python bindings
+- `java` — Generate Java bindings
+- `flutter` — Generate Flutter bindings
+- `swift` — Generate Swift bindings
+- `php` — Generate PHP bindings
 
 ## `stellar contract bindings json`
 
@@ -283,9 +261,7 @@ Generate Json Bindings
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Path to wasm binary
-
-
+- `--wasm <WASM>` — Path to wasm binary
 
 ## `stellar contract bindings rust`
 
@@ -295,9 +271,7 @@ Generate Rust bindings
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Path to wasm binary
-
-
+- `--wasm <WASM>` — Path to wasm binary
 
 ## `stellar contract bindings typescript`
 
@@ -307,19 +281,17 @@ Generate a TypeScript / JavaScript package
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
-* `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
-* `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--output-dir <OUTPUT_DIR>` — Where to place generated project
-* `--overwrite` — Whether to overwrite output directory if it already exists
-
-
+- `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
+- `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
+- `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--output-dir <OUTPUT_DIR>` — Where to place generated project
+- `--overwrite` — Whether to overwrite output directory if it already exists
 
 ## `stellar contract bindings python`
 
@@ -327,15 +299,11 @@ Generate Python bindings
 
 **Usage:** `stellar contract bindings python`
 
-
-
 ## `stellar contract bindings java`
 
 Generate Java bindings
 
 **Usage:** `stellar contract bindings java`
-
-
 
 ## `stellar contract bindings flutter`
 
@@ -343,23 +311,17 @@ Generate Flutter bindings
 
 **Usage:** `stellar contract bindings flutter`
 
-
-
 ## `stellar contract bindings swift`
 
 Generate Swift bindings
 
 **Usage:** `stellar contract bindings swift`
 
-
-
 ## `stellar contract bindings php`
 
 Generate PHP bindings
 
 **Usage:** `stellar contract bindings php`
-
-
 
 ## `stellar contract build`
 
@@ -375,25 +337,26 @@ To view the commands that will be executed, without executing them, use the --pr
 
 ###### **Options:**
 
-* `--manifest-path <MANIFEST_PATH>` — Path to Cargo.toml
-* `--package <PACKAGE>` — Package to build
+- `--manifest-path <MANIFEST_PATH>` — Path to Cargo.toml
+- `--package <PACKAGE>` — Package to build
 
-   If omitted, all packages that build for crate-type cdylib are built.
-* `--profile <PROFILE>` — Build with the specified profile
+  If omitted, all packages that build for crate-type cdylib are built.
+
+- `--profile <PROFILE>` — Build with the specified profile
 
   Default value: `release`
-* `--features <FEATURES>` — Build with the list of features activated, space or comma separated
-* `--all-features` — Build with the all features activated
-* `--no-default-features` — Build with the default feature not activated
-* `--out-dir <OUT_DIR>` — Directory to copy wasm files to
 
-   If provided, wasm files can be found in the cargo target directory, and the specified directory.
+- `--features <FEATURES>` — Build with the list of features activated, space or comma separated
+- `--all-features` — Build with the all features activated
+- `--no-default-features` — Build with the default feature not activated
+- `--out-dir <OUT_DIR>` — Directory to copy wasm files to
 
-   If ommitted, wasm files are written only to the cargo target directory.
-* `--print-commands-only` — Print commands to build without executing them
-* `--meta <META>` — Add key-value to contract meta (adds the meta to the `contractmetav0` custom section)
+  If provided, wasm files can be found in the cargo target directory, and the specified directory.
 
+  If ommitted, wasm files are written only to the cargo target directory.
 
+- `--print-commands-only` — Print commands to build without executing them
+- `--meta <META>` — Add key-value to contract meta (adds the meta to the `contractmetav0` custom section)
 
 ## `stellar contract extend`
 
@@ -405,42 +368,39 @@ If no keys are specified the contract itself is extended.
 
 ###### **Options:**
 
-* `--ledgers-to-extend <LEDGERS_TO_EXTEND>` — Number of ledgers to extend the entries
-* `--ttl-ledger-only` — Only print the new Time To Live ledger
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be extended
-* `--key <KEY>` — Storage key (symbols only)
-* `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
-* `--wasm <WASM>` — Path to Wasm file of contract code to extend
-* `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to extend
-* `--durability <DURABILITY>` — Storage entry durability
+- `--ledgers-to-extend <LEDGERS_TO_EXTEND>` — Number of ledgers to extend the entries
+- `--ttl-ledger-only` — Only print the new Time To Live ledger
+- `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be extended
+- `--key <KEY>` — Storage key (symbols only)
+- `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
+- `--wasm <WASM>` — Path to Wasm file of contract code to extend
+- `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to extend
+- `--durability <DURABILITY>` — Storage entry durability
 
   Default value: `persistent`
 
   Possible values:
-  - `persistent`:
-    Persistent
-  - `temporary`:
-    Temporary
+  - `persistent`: Persistent
+  - `temporary`: Temporary
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
 
 ## `stellar contract deploy`
 
@@ -450,36 +410,36 @@ Deploy a wasm contract
 
 ###### **Arguments:**
 
-* `<CONTRACT_CONSTRUCTOR_ARGS>` — If provided, will be passed to the contract's `__constructor` function with provided arguments for that function as `--arg-name value`
+- `<CONTRACT_CONSTRUCTOR_ARGS>` — If provided, will be passed to the contract's `__constructor` function with provided arguments for that function as `--arg-name value`
 
 ###### **Options:**
 
-* `--wasm <WASM>` — WASM file to deploy
-* `--wasm-hash <WASM_HASH>` — Hash of the already installed/deployed WASM file
-* `--salt <SALT>` — Custom salt 32-byte salt for the token id
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--wasm <WASM>` — WASM file to deploy
+- `--wasm-hash <WASM_HASH>` — Hash of the already installed/deployed WASM file
+- `--salt <SALT>` — Custom salt 32-byte salt for the token id
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
   Default value: `false`
-* `--alias <ALIAS>` — The alias that will be used to save the contract's id. Whenever used, `--alias` will always overwrite the existing contract id configuration without asking for confirmation
 
-
+- `--alias <ALIAS>` — The alias that will be used to save the contract's id. Whenever used, `--alias` will always overwrite the existing contract id configuration without asking for confirmation
 
 ## `stellar contract fetch`
 
@@ -489,17 +449,15 @@ Fetch a contract's Wasm binary
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to fetch
-* `--wasm-hash <WASM_HASH>` — Wasm to fetch
-* `-o`, `--out-file <OUT_FILE>` — Where to write output otherwise stdout is used
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-
-
+- `--id <CONTRACT_ID>` — Contract ID to fetch
+- `--wasm-hash <WASM_HASH>` — Wasm to fetch
+- `-o`, `--out-file <OUT_FILE>` — Where to write output otherwise stdout is used
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar contract id`
 
@@ -509,10 +467,8 @@ Generate the contract id for a given contract or asset
 
 ###### **Subcommands:**
 
-* `asset` — Deploy builtin Soroban Asset Contract
-* `wasm` — Deploy normal Wasm Contract
-
-
+- `asset` — Deploy builtin Soroban Asset Contract
+- `wasm` — Deploy normal Wasm Contract
 
 ## `stellar contract id asset`
 
@@ -522,15 +478,13 @@ Deploy builtin Soroban Asset Contract
 
 ###### **Options:**
 
-* `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar contract id wasm`
 
@@ -540,20 +494,18 @@ Deploy normal Wasm Contract
 
 ###### **Options:**
 
-* `--salt <SALT>` — ID of the Soroban contract
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-
-
+- `--salt <SALT>` — ID of the Soroban contract
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
 
 ## `stellar contract info`
 
@@ -563,12 +515,10 @@ Access info about contracts
 
 ###### **Subcommands:**
 
-* `interface` — Output the interface of a contract
-* `meta` — Output the metadata stored in a contract
-* `env-meta` — Output the env required metadata stored in a contract
-* `build` — Output the contract build information, if available
-
-
+- `interface` — Output the interface of a contract
+- `meta` — Output the metadata stored in a contract
+- `env-meta` — Output the env required metadata stored in a contract
+- `build` — Output the contract build information, if available
 
 ## `stellar contract info interface`
 
@@ -584,31 +534,24 @@ Outputs no data when no data is present in the contract.
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
-* `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
-* `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--output <OUTPUT>` — Format of the output
+- `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
+- `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
+- `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `rust`
 
   Possible values:
-  - `rust`:
-    Rust code output of the contract interface
-  - `xdr-base64`:
-    XDR output of the info entry
-  - `json`:
-    JSON output of the info entry (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the info entry
-
-
-
+  - `rust`: Rust code output of the contract interface
+  - `xdr-base64`: XDR output of the info entry
+  - `json`: JSON output of the info entry (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the info entry
 
 ## `stellar contract info meta`
 
@@ -624,31 +567,24 @@ Outputs no data when no data is present in the contract.
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
-* `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
-* `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--output <OUTPUT>` — Format of the output
+- `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
+- `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
+- `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of the meta info entry
-  - `xdr-base64`:
-    XDR output of the info entry
-  - `json`:
-    JSON output of the info entry (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the info entry
-
-
-
+  - `text`: Text output of the meta info entry
+  - `xdr-base64`: XDR output of the info entry
+  - `json`: JSON output of the info entry (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the info entry
 
 ## `stellar contract info env-meta`
 
@@ -664,31 +600,24 @@ Outputs no data when no data is present in the contract.
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
-* `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
-* `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--output <OUTPUT>` — Format of the output
+- `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
+- `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
+- `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of the meta info entry
-  - `xdr-base64`:
-    XDR output of the info entry
-  - `json`:
-    JSON output of the info entry (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the info entry
-
-
-
+  - `text`: Text output of the meta info entry
+  - `xdr-base64`: XDR output of the info entry
+  - `json`: JSON output of the info entry (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the info entry
 
 ## `stellar contract info build`
 
@@ -700,17 +629,15 @@ If the contract has a meta entry like `source_repo=github:user/repo`, this comma
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
-* `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
-* `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--wasm <WASM>` — Wasm file path on local filesystem. Provide this OR `--wasm-hash` OR `--contract-id`
+- `--wasm-hash <WASM_HASH>` — Hash of Wasm blob on a network. Provide this OR `--wasm` OR `--contract-id`
+- `--contract-id <CONTRACT_ID>` [alias: `id`] — Contract ID/alias on a network. Provide this OR `--wasm-hash` OR `--wasm`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar contract init`
 
@@ -722,16 +649,15 @@ This command will create a Cargo workspace project and add a sample Stellar cont
 
 ###### **Arguments:**
 
-* `<PROJECT_PATH>`
+- `<PROJECT_PATH>`
 
 ###### **Options:**
 
-* `--name <NAME>` — An optional flag to specify a new contract's name.
+- `--name <NAME>` — An optional flag to specify a new contract's name.
 
   Default value: `hello-world`
-* `--overwrite` — Overwrite all existing files.
 
-
+- `--overwrite` — Overwrite all existing files.
 
 ## `stellar contract inspect`
 
@@ -741,23 +667,18 @@ This command will create a Cargo workspace project and add a sample Stellar cont
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Path to wasm binary
-* `--output <OUTPUT>` — Output just XDR in base64
+- `--wasm <WASM>` — Path to wasm binary
+- `--output <OUTPUT>` — Output just XDR in base64
 
   Default value: `docs`
 
   Possible values:
-  - `xdr-base64`:
-    XDR of array of contract spec entries
-  - `xdr-base64-array`:
-    Array of xdr of contract spec entries
-  - `docs`:
-    Pretty print of contract spec entries
+  - `xdr-base64`: XDR of array of contract spec entries
+  - `xdr-base64-array`: Array of xdr of contract spec entries
+  - `docs`: Pretty print of contract spec entries
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar contract upload`
 
@@ -767,29 +688,28 @@ Install a WASM file to the ledger without creating a contract instance
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--wasm <WASM>` — Path to wasm binary
-* `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--wasm <WASM>` — Path to wasm binary
+- `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
   Default value: `false`
-
-
 
 ## `stellar contract install`
 
@@ -799,29 +719,28 @@ Install a WASM file to the ledger without creating a contract instance
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--wasm <WASM>` — Path to wasm binary
-* `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--wasm <WASM>` — Path to wasm binary
+- `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
   Default value: `false`
-
-
 
 ## `stellar contract invoke`
 
@@ -835,43 +754,38 @@ stellar contract invoke ... -- --help
 
 ###### **Arguments:**
 
-* `<CONTRACT_FN_AND_ARGS>` — Function name as subcommand, then arguments for that function as `--arg-name value`
+- `<CONTRACT_FN_AND_ARGS>` — Function name as subcommand, then arguments for that function as `--arg-name value`
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to invoke
-* `--is-view` — View the result simulating and do not sign and submit transaction. Deprecated use `--send=no`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--id <CONTRACT_ID>` — Contract ID to invoke
+- `--is-view` — View the result simulating and do not sign and submit transaction. Deprecated use `--send=no`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--send <SEND>` — Whether or not to send a transaction
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--send <SEND>` — Whether or not to send a transaction
 
   Default value: `default`
 
   Possible values:
-  - `default`:
-    Send transaction if simulation indicates there are ledger writes, published events, or auth required, otherwise return simulation result
-  - `no`:
-    Do not send transaction, return simulation result
-  - `yes`:
-    Always send transaction
-
-
-
+  - `default`: Send transaction if simulation indicates there are ledger writes, published events, or auth required, otherwise return simulation result
+  - `no`: Do not send transaction, return simulation result
+  - `yes`: Always send transaction
 
 ## `stellar contract optimize`
 
@@ -881,10 +795,8 @@ Optimize a WASM file
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Path to one or more wasm binaries
-* `--wasm-out <WASM_OUT>` — Path to write the optimized WASM file to (defaults to same location as --wasm with .optimized.wasm suffix)
-
-
+- `--wasm <WASM>` — Path to one or more wasm binaries
+- `--wasm-out <WASM_OUT>` — Path to write the optimized WASM file to (defaults to same location as --wasm with .optimized.wasm suffix)
 
 ## `stellar contract read`
 
@@ -894,41 +806,34 @@ Print the current value of a contract-data ledger entry
 
 ###### **Options:**
 
-* `--output <OUTPUT>` — Type of output to generate
+- `--output <OUTPUT>` — Type of output to generate
 
   Default value: `string`
 
   Possible values:
-  - `string`:
-    String
-  - `json`:
-    Json
-  - `xdr`:
-    XDR
+  - `string`: String
+  - `json`: Json
+  - `xdr`: XDR
 
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be extended
-* `--key <KEY>` — Storage key (symbols only)
-* `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
-* `--wasm <WASM>` — Path to Wasm file of contract code to extend
-* `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to extend
-* `--durability <DURABILITY>` — Storage entry durability
+- `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be extended
+- `--key <KEY>` — Storage key (symbols only)
+- `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
+- `--wasm <WASM>` — Path to Wasm file of contract code to extend
+- `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to extend
+- `--durability <DURABILITY>` — Storage entry durability
 
   Default value: `persistent`
 
   Possible values:
-  - `persistent`:
-    Persistent
-  - `temporary`:
-    Temporary
+  - `persistent`: Persistent
+  - `temporary`: Temporary
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar contract restore`
 
@@ -940,42 +845,39 @@ If no keys are specificed the contract itself is restored.
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be extended
-* `--key <KEY>` — Storage key (symbols only)
-* `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
-* `--wasm <WASM>` — Path to Wasm file of contract code to extend
-* `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to extend
-* `--durability <DURABILITY>` — Storage entry durability
+- `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be extended
+- `--key <KEY>` — Storage key (symbols only)
+- `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
+- `--wasm <WASM>` — Path to Wasm file of contract code to extend
+- `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to extend
+- `--durability <DURABILITY>` — Storage entry durability
 
   Default value: `persistent`
 
   Possible values:
-  - `persistent`:
-    Persistent
-  - `temporary`:
-    Temporary
+  - `persistent`: Persistent
+  - `temporary`: Temporary
 
-* `--ledgers-to-extend <LEDGERS_TO_EXTEND>` — Number of ledgers to extend the entry
-* `--ttl-ledger-only` — Only print the new Time To Live ledger
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--ledgers-to-extend <LEDGERS_TO_EXTEND>` — Number of ledgers to extend the entry
+- `--ttl-ledger-only` — Only print the new Time To Live ledger
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
 
 ## `stellar doctor`
 
@@ -985,10 +887,8 @@ Diagnose and troubleshoot CLI and network issues
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar events`
 
@@ -998,47 +898,45 @@ Watch the network for contract events
 
 ###### **Options:**
 
-* `--start-ledger <START_LEDGER>` — The first ledger sequence number in the range to pull events https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/ledger-headers#ledger-sequence
-* `--cursor <CURSOR>` — The cursor corresponding to the start of the event range
-* `--output <OUTPUT>` — Output formatting options for event stream
+- `--start-ledger <START_LEDGER>` — The first ledger sequence number in the range to pull events https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/ledger-headers#ledger-sequence
+- `--cursor <CURSOR>` — The cursor corresponding to the start of the event range
+- `--output <OUTPUT>` — Output formatting options for event stream
 
   Default value: `pretty`
 
   Possible values:
-  - `pretty`:
-    Colorful, human-oriented console output
-  - `plain`:
-    Human-oriented console output without colors
-  - `json`:
-    JSON formatted console output
+  - `pretty`: Colorful, human-oriented console output
+  - `plain`: Human-oriented console output without colors
+  - `json`: JSON formatted console output
 
-* `-c`, `--count <COUNT>` — The maximum number of events to display (defer to the server-defined limit)
+- `-c`, `--count <COUNT>` — The maximum number of events to display (defer to the server-defined limit)
 
   Default value: `10`
-* `--id <CONTRACT_IDS>` — A set of (up to 5) contract IDs to filter events on. This parameter can be passed multiple times, e.g. `--id C123.. --id C456..`, or passed with multiple parameters, e.g. `--id C123 C456`.
 
-   Though the specification supports multiple filter objects (i.e. combinations of type, IDs, and topics), only one set can be specified on the command-line today, though that set can have multiple IDs/topics.
-* `--topic <TOPIC_FILTERS>` — A set of (up to 4) topic filters to filter event topics on. A single topic filter can contain 1-4 different segment filters, separated by commas, with an asterisk (`*` character) indicating a wildcard segment.
+- `--id <CONTRACT_IDS>` — A set of (up to 5) contract IDs to filter events on. This parameter can be passed multiple times, e.g. `--id C123.. --id C456..`, or passed with multiple parameters, e.g. `--id C123 C456`.
 
-   **Example:** topic filter with two segments: `--topic "AAAABQAAAAdDT1VOVEVSAA==,*"`
+  Though the specification supports multiple filter objects (i.e. combinations of type, IDs, and topics), only one set can be specified on the command-line today, though that set can have multiple IDs/topics.
 
-   **Example:** two topic filters with one and two segments each: `--topic "AAAABQAAAAdDT1VOVEVSAA==" --topic '*,*'`
+- `--topic <TOPIC_FILTERS>` — A set of (up to 4) topic filters to filter event topics on. A single topic filter can contain 1-4 different segment filters, separated by commas, with an asterisk (`*` character) indicating a wildcard segment.
 
-   Note that all of these topic filters are combined with the contract IDs into a single filter (i.e. combination of type, IDs, and topics).
-* `--type <EVENT_TYPE>` — Specifies which type of contract events to display
+  **Example:** topic filter with two segments: `--topic "AAAABQAAAAdDT1VOVEVSAA==,*"`
+
+  **Example:** two topic filters with one and two segments each: `--topic "AAAABQAAAAdDT1VOVEVSAA==" --topic '*,*'`
+
+  Note that all of these topic filters are combined with the contract IDs into a single filter (i.e. combination of type, IDs, and topics).
+
+- `--type <EVENT_TYPE>` — Specifies which type of contract events to display
 
   Default value: `all`
 
   Possible values: `all`, `contract`, `system`
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar env`
 
@@ -1054,16 +952,14 @@ If there are no environment variables in use, prints the defaults.
 
 ###### **Arguments:**
 
-* `<NAME>` — Env variable name to get the value of.
+- `<NAME>` — Env variable name to get the value of.
 
-   E.g.: $ stellar env STELLAR_ACCOUNT
+  E.g.: $ stellar env STELLAR_ACCOUNT
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar keys`
 
@@ -1073,16 +969,14 @@ Create and manage identities including keys and addresses
 
 ###### **Subcommands:**
 
-* `add` — Add a new identity (keypair, ledger, OS specific secure store)
-* `public-key` — Given an identity return its address (public key)
-* `fund` — Fund an identity on a test network
-* `generate` — Generate a new identity using a 24-word seed phrase The seed phrase can be stored in a config file (default) or in an OS-specific secure store
-* `ls` — List identities
-* `rm` — Remove an identity
-* `secret` — Output an identity's secret key
-* `use` — Set the default identity that will be used on all commands. This allows you to skip `--source-account` or setting a environment variable, while reusing this value in all commands that require it
-
-
+- `add` — Add a new identity (keypair, ledger, OS specific secure store)
+- `public-key` — Given an identity return its address (public key)
+- `fund` — Fund an identity on a test network
+- `generate` — Generate a new identity using a 24-word seed phrase The seed phrase can be stored in a config file (default) or in an OS-specific secure store
+- `ls` — List identities
+- `rm` — Remove an identity
+- `secret` — Output an identity's secret key
+- `use` — Set the default identity that will be used on all commands. This allows you to skip `--source-account` or setting a environment variable, while reusing this value in all commands that require it
 
 ## `stellar keys add`
 
@@ -1092,22 +986,21 @@ Add a new identity (keypair, ledger, OS specific secure store)
 
 ###### **Arguments:**
 
-* `<NAME>` — Name of identity
+- `<NAME>` — Name of identity
 
 ###### **Options:**
 
-* `--secret-key` — (deprecated) Enter secret (S) key when prompted
-* `--seed-phrase` — (deprecated) Enter key using 12-24 word seed phrase
-* `--secure-store` — Save the new key in your OS's credential secure store.
+- `--secret-key` — (deprecated) Enter secret (S) key when prompted
+- `--seed-phrase` — (deprecated) Enter key using 12-24 word seed phrase
+- `--secure-store` — Save the new key in your OS's credential secure store.
 
-   On Mac this uses Keychain, on Windows it is Secure Store Service, and on *nix platforms it uses a combination of the kernel keyutils and DBus-based Secret Service.
+  On Mac this uses Keychain, on Windows it is Secure Store Service, and on \*nix platforms it uses a combination of the kernel keyutils and DBus-based Secret Service.
 
-   This only supports seed phrases for now.
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--public-key <PUBLIC_KEY>` — Add a public key, ed25519, or muxed account, e.g. G1.., M2..
+  This only supports seed phrases for now.
 
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--public-key <PUBLIC_KEY>` — Add a public key, ed25519, or muxed account, e.g. G1.., M2..
 
 ## `stellar keys public-key`
 
@@ -1119,15 +1012,13 @@ Given an identity return its address (public key)
 
 ###### **Arguments:**
 
-* `<NAME>` — Name of identity to lookup, default test identity used if not provided
+- `<NAME>` — Name of identity to lookup, default test identity used if not provided
 
 ###### **Options:**
 
-* `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar keys fund`
 
@@ -1137,19 +1028,17 @@ Fund an identity on a test network
 
 ###### **Arguments:**
 
-* `<NAME>` — Name of identity to lookup, default test identity used if not provided
+- `<NAME>` — Name of identity to lookup, default test identity used if not provided
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar keys generate`
 
@@ -1159,28 +1048,28 @@ Generate a new identity using a 24-word seed phrase The seed phrase can be store
 
 ###### **Arguments:**
 
-* `<NAME>` — Name of identity
+- `<NAME>` — Name of identity
 
 ###### **Options:**
 
-* `--seed <SEED>` — Optional seed to use when generating seed phrase. Random otherwise
-* `-s`, `--as-secret` — Output the generated identity as a secret key
-* `--secure-store` — Save the new key in your OS's credential secure store.
+- `--seed <SEED>` — Optional seed to use when generating seed phrase. Random otherwise
+- `-s`, `--as-secret` — Output the generated identity as a secret key
+- `--secure-store` — Save the new key in your OS's credential secure store.
 
-   On Mac this uses Keychain, on Windows it is Secure Store Service, and on *nix platforms it uses a combination of the kernel keyutils and DBus-based Secret Service.
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--hd-path <HD_PATH>` — When generating a secret key, which `hd_path` should be used from the original `seed_phrase`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--fund` — Fund generated key pair
+  On Mac this uses Keychain, on Windows it is Secure Store Service, and on \*nix platforms it uses a combination of the kernel keyutils and DBus-based Secret Service.
+
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--hd-path <HD_PATH>` — When generating a secret key, which `hd_path` should be used from the original `seed_phrase`
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--fund` — Fund generated key pair
 
   Default value: `false`
-* `--overwrite` — Overwrite existing identity if it already exists
 
-
+- `--overwrite` — Overwrite existing identity if it already exists
 
 ## `stellar keys ls`
 
@@ -1190,11 +1079,9 @@ List identities
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `-l`, `--long`
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `-l`, `--long`
 
 ## `stellar keys rm`
 
@@ -1204,14 +1091,12 @@ Remove an identity
 
 ###### **Arguments:**
 
-* `<NAME>` — Identity to remove
+- `<NAME>` — Identity to remove
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar keys secret`
 
@@ -1221,16 +1106,14 @@ Output an identity's secret key
 
 ###### **Arguments:**
 
-* `<NAME>` — Name of identity to lookup, default is test identity
+- `<NAME>` — Name of identity to lookup, default is test identity
 
 ###### **Options:**
 
-* `--phrase` — Output seed phrase instead of private key
-* `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--phrase` — Output seed phrase instead of private key
+- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar keys use`
 
@@ -1240,14 +1123,12 @@ Set the default identity that will be used on all commands. This allows you to s
 
 ###### **Arguments:**
 
-* `<NAME>` — Set the default network name
+- `<NAME>` — Set the default network name
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar network`
 
@@ -1257,15 +1138,13 @@ Configure connection to networks
 
 ###### **Subcommands:**
 
-* `add` — Add a new network
-* `rm` — Remove a network
-* `ls` — List networks
-* `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
-* `health` — Fetch the health of the configured RPC
-* `info` — Checks the health of the configured RPC
-* `settings` — Fetch the network's config settings
-
-
+- `add` — Add a new network
+- `rm` — Remove a network
+- `ls` — List networks
+- `use` — Set the default network that will be used on all commands. This allows you to skip `--network` or setting a environment variable, while reusing this value in all commands that require it
+- `health` — Fetch the health of the configured RPC
+- `info` — Checks the health of the configured RPC
+- `settings` — Fetch the network's config settings
 
 ## `stellar network add`
 
@@ -1275,17 +1154,15 @@ Add a new network
 
 ###### **Arguments:**
 
-* `<NAME>` — Name of network
+- `<NAME>` — Name of network
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — Optional header (e.g. API Key) to include in requests to the RPC
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — Optional header (e.g. API Key) to include in requests to the RPC
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar network rm`
 
@@ -1295,14 +1172,12 @@ Remove a network
 
 ###### **Arguments:**
 
-* `<NAME>` — Network to remove
+- `<NAME>` — Network to remove
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar network ls`
 
@@ -1312,11 +1187,9 @@ List networks
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `-l`, `--long` — Get more info about the networks
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `-l`, `--long` — Get more info about the networks
 
 ## `stellar network use`
 
@@ -1326,14 +1199,12 @@ Set the default network that will be used on all commands. This allows you to sk
 
 ###### **Arguments:**
 
-* `<NAME>` — Set the default network name
+- `<NAME>` — Set the default network name
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar network health`
 
@@ -1343,26 +1214,20 @@ Fetch the health of the configured RPC
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--output <OUTPUT>` — Format of the output
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of network health status
-  - `json`:
-    JSON result of the RPC request
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the RPC request
-
-
-
+  - `text`: Text output of network health status
+  - `json`: JSON result of the RPC request
+  - `json-formatted`: Formatted (multiline) JSON output of the RPC request
 
 ## `stellar network info`
 
@@ -1372,26 +1237,20 @@ Checks the health of the configured RPC
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--output <OUTPUT>` — Format of the output
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of network info
-  - `json`:
-    JSON result of the RPC request
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the RPC request
-
-
-
+  - `text`: Text output of network info
+  - `json`: JSON result of the RPC request
+  - `json-formatted`: Formatted (multiline) JSON output of the RPC request
 
 ## `stellar network settings`
 
@@ -1401,27 +1260,21 @@ Fetch the network's config settings
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--internal` — Include internal config settings that are not upgradeable and are internally maintained by the network
-* `--output <OUTPUT>` — Format of the output
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--internal` — Include internal config settings that are not upgradeable and are internally maintained by the network
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `json`
 
   Possible values:
-  - `xdr`:
-    XDR (`ConfigUpgradeSet` type)
-  - `json`:
-    JSON, XDR-JSON of the `ConfigUpgradeSet` XDR type
-  - `json-formatted`:
-    JSON formatted, XDR-JSON of the `ConfigUpgradeSet` XDR type
-
-
-
+  - `xdr`: XDR (`ConfigUpgradeSet` type)
+  - `json`: JSON, XDR-JSON of the `ConfigUpgradeSet` XDR type
+  - `json-formatted`: JSON formatted, XDR-JSON of the `ConfigUpgradeSet` XDR type
 
 ## `stellar container`
 
@@ -1431,11 +1284,9 @@ Start local networks in containers
 
 ###### **Subcommands:**
 
-* `logs` — Get logs from a running network container
-* `start` — Start a container running a Stellar node, RPC, API, and friendbot (faucet)
-* `stop` — Stop a network container started with `stellar container start`
-
-
+- `logs` — Get logs from a running network container
+- `start` — Start a container running a Stellar node, RPC, API, and friendbot (faucet)
+- `stop` — Stop a network container started with `stellar container start`
 
 ## `stellar container logs`
 
@@ -1445,15 +1296,13 @@ Get logs from a running network container
 
 ###### **Arguments:**
 
-* `<NAME>` — Container to get logs from
+- `<NAME>` — Container to get logs from
 
   Default value: `local`
 
 ###### **Options:**
 
-* `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
-
-
+- `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
 
 ## `stellar container start`
 
@@ -1469,23 +1318,21 @@ By default, when starting a testnet container, without any optional arguments, i
 
 ###### **Arguments:**
 
-* `<NETWORK>` — Network to start. Default is `local`
+- `<NETWORK>` — Network to start. Default is `local`
 
   Possible values: `local`, `testnet`, `futurenet`, `pubnet`
 
-
 ###### **Options:**
 
-* `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
-* `--name <NAME>` — Optional argument to specify the container name
-* `-l`, `--limits <LIMITS>` — Optional argument to specify the limits for the local network only
-* `-p`, `--ports-mapping <PORTS_MAPPING>` — Argument to specify the `HOST_PORT:CONTAINER_PORT` mapping
+- `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
+- `--name <NAME>` — Optional argument to specify the container name
+- `-l`, `--limits <LIMITS>` — Optional argument to specify the limits for the local network only
+- `-p`, `--ports-mapping <PORTS_MAPPING>` — Argument to specify the `HOST_PORT:CONTAINER_PORT` mapping
 
   Default value: `8000:8000`
-* `-t`, `--image-tag-override <IMAGE_TAG_OVERRIDE>` — Optional argument to override the default docker image tag for the given network
-* `--protocol-version <PROTOCOL_VERSION>` — Optional argument to specify the protocol version for the local network only
 
-
+- `-t`, `--image-tag-override <IMAGE_TAG_OVERRIDE>` — Optional argument to override the default docker image tag for the given network
+- `--protocol-version <PROTOCOL_VERSION>` — Optional argument to specify the protocol version for the local network only
 
 ## `stellar container stop`
 
@@ -1495,15 +1342,13 @@ Stop a network container started with `stellar container start`
 
 ###### **Arguments:**
 
-* `<NAME>` — Container to stop
+- `<NAME>` — Container to stop
 
   Default value: `local`
 
 ###### **Options:**
 
-* `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
-
-
+- `-d`, `--docker-host <DOCKER_HOST>` — Optional argument to override the default docker host. This is useful when you are using a non-standard docker host path for your Docker-compatible container runtime, e.g. Docker Desktop defaults to $HOME/.docker/run/docker.sock instead of /var/run/docker.sock
 
 ## `stellar config`
 
@@ -1513,10 +1358,8 @@ Manage cli configuration
 
 ###### **Subcommands:**
 
-* `migrate` — Migrate the local configuration to the global directory
-* `dir` — Show the global configuration directory
-
-
+- `migrate` — Migrate the local configuration to the global directory
+- `dir` — Show the global configuration directory
 
 ## `stellar config migrate`
 
@@ -1526,10 +1369,8 @@ Migrate the local configuration to the global directory
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar config dir`
 
@@ -1543,10 +1384,8 @@ The location will depend on how your system is configured.
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar snapshot`
 
@@ -1556,9 +1395,7 @@ Download a snapshot of a ledger from an archive
 
 ###### **Subcommands:**
 
-* `create` — Create a ledger snapshot using a history archive
-
-
+- `create` — Create a ledger snapshot using a history archive
 
 ## `stellar snapshot create`
 
@@ -1578,25 +1415,24 @@ Any invalid contract id passed as `--address` will be ignored.
 
 ###### **Options:**
 
-* `--ledger <LEDGER>` — The ledger sequence number to snapshot. Defaults to latest history archived ledger
-* `--address <ADDRESS>` — Account or contract address/alias to include in the snapshot
-* `--wasm-hash <WASM_HASHES>` — WASM hashes to include in the snapshot
-* `--output <OUTPUT>` — Format of the out file
+- `--ledger <LEDGER>` — The ledger sequence number to snapshot. Defaults to latest history archived ledger
+- `--address <ADDRESS>` — Account or contract address/alias to include in the snapshot
+- `--wasm-hash <WASM_HASHES>` — WASM hashes to include in the snapshot
+- `--output <OUTPUT>` — Format of the out file
 
   Possible values: `json`
 
-* `--out <OUT>` — Out path that the snapshot is written to
+- `--out <OUT>` — Out path that the snapshot is written to
 
   Default value: `snapshot.json`
-* `--archive-url <ARCHIVE_URL>` — Archive URL
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
 
-
+- `--archive-url <ARCHIVE_URL>` — Archive URL
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar tx`
 
@@ -1606,19 +1442,17 @@ Sign, Simulate, and Send transactions
 
 ###### **Subcommands:**
 
-* `update` — Update the transaction
-* `edit` — Edit a transaction envelope from stdin. This command respects the environment variables `STELLAR_EDITOR`, `EDITOR` and `VISUAL`, in that order
-* `hash` — Calculate the hash of a transaction envelope
-* `new` — Create a new transaction
-* `operation` — Manipulate the operations in a transaction, including adding new operations
-* `send` — Send a transaction envelope to the network
-* `sign` — Sign a transaction envelope appending the signature to the envelope
-* `simulate` — Simulate a transaction envelope from stdin
-* `fetch` — Fetch a transaction from the network by hash If no subcommand is passed in, the transaction envelope will be returned
-* `decode` — Decode a transaction envelope from XDR to JSON
-* `encode` — Encode a transaction envelope from JSON to XDR
-
-
+- `update` — Update the transaction
+- `edit` — Edit a transaction envelope from stdin. This command respects the environment variables `STELLAR_EDITOR`, `EDITOR` and `VISUAL`, in that order
+- `hash` — Calculate the hash of a transaction envelope
+- `new` — Create a new transaction
+- `operation` — Manipulate the operations in a transaction, including adding new operations
+- `send` — Send a transaction envelope to the network
+- `sign` — Sign a transaction envelope appending the signature to the envelope
+- `simulate` — Simulate a transaction envelope from stdin
+- `fetch` — Fetch a transaction from the network by hash If no subcommand is passed in, the transaction envelope will be returned
+- `decode` — Decode a transaction envelope from XDR to JSON
+- `encode` — Encode a transaction envelope from JSON to XDR
 
 ## `stellar tx update`
 
@@ -1628,9 +1462,7 @@ Update the transaction
 
 ###### **Subcommands:**
 
-* `sequence-number` — Edit the sequence number on a transaction
-
-
+- `sequence-number` — Edit the sequence number on a transaction
 
 ## `stellar tx update sequence-number`
 
@@ -1642,9 +1474,7 @@ Edit the sequence number on a transaction
 
 ###### **Subcommands:**
 
-* `next` — Fetch the source account's seq-num and increment for the given tx
-
-
+- `next` — Fetch the source account's seq-num and increment for the given tx
 
 ## `stellar tx update sequence-number next`
 
@@ -1654,14 +1484,12 @@ Fetch the source account's seq-num and increment for the given tx
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar tx edit`
 
@@ -1677,8 +1505,6 @@ $ stellar tx new manage-data --data-name hello --build-only | stellar tx edit
 
 **Usage:** `stellar tx edit`
 
-
-
 ## `stellar tx hash`
 
 Calculate the hash of a transaction envelope
@@ -1687,16 +1513,14 @@ Calculate the hash of a transaction envelope
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar tx new`
 
@@ -1706,30 +1530,28 @@ Create a new transaction
 
 ###### **Subcommands:**
 
-* `account-merge` — Transfer XLM balance to another account and remove source account
-* `begin-sponsoring-future-reserves` — Begin sponsoring future reserves for another account
-* `bump-sequence` — Bump sequence number to invalidate older transactions
-* `change-trust` — Create, update, or delete a trustline
-* `claim-claimable-balance` — Claim a claimable balance by its balance ID
-* `clawback` — Clawback an asset from an account
-* `clawback-claimable-balance` — Clawback a claimable balance by its balance ID
-* `create-account` — Create and fund a new account
-* `create-claimable-balance` — Create a claimable balance that can be claimed by specified accounts
-* `create-passive-sell-offer` — Create a passive sell offer on the Stellar DEX
-* `end-sponsoring-future-reserves` — End sponsoring future reserves
-* `liquidity-pool-deposit` — Deposit assets into a liquidity pool
-* `liquidity-pool-withdraw` — Withdraw assets from a liquidity pool
-* `manage-buy-offer` — Create, update, or delete a buy offer
-* `manage-data` — Set, modify, or delete account data entries
-* `manage-sell-offer` — Create, update, or delete a sell offer
-* `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
-* `path-payment-strict-receive` — Send a payment with a different asset using path finding, specifying the receive amount
-* `payment` — Send asset to destination account
-* `revoke-sponsorship` — Revoke sponsorship of a ledger entry or signer
-* `set-options` — Set account options like flags, signers, and home domain
-* `set-trustline-flags` — Configure authorization and trustline flags for an asset
-
-
+- `account-merge` — Transfer XLM balance to another account and remove source account
+- `begin-sponsoring-future-reserves` — Begin sponsoring future reserves for another account
+- `bump-sequence` — Bump sequence number to invalidate older transactions
+- `change-trust` — Create, update, or delete a trustline
+- `claim-claimable-balance` — Claim a claimable balance by its balance ID
+- `clawback` — Clawback an asset from an account
+- `clawback-claimable-balance` — Clawback a claimable balance by its balance ID
+- `create-account` — Create and fund a new account
+- `create-claimable-balance` — Create a claimable balance that can be claimed by specified accounts
+- `create-passive-sell-offer` — Create a passive sell offer on the Stellar DEX
+- `end-sponsoring-future-reserves` — End sponsoring future reserves
+- `liquidity-pool-deposit` — Deposit assets into a liquidity pool
+- `liquidity-pool-withdraw` — Withdraw assets from a liquidity pool
+- `manage-buy-offer` — Create, update, or delete a buy offer
+- `manage-data` — Set, modify, or delete account data entries
+- `manage-sell-offer` — Create, update, or delete a sell offer
+- `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
+- `path-payment-strict-receive` — Send a payment with a different asset using path finding, specifying the receive amount
+- `payment` — Send asset to destination account
+- `revoke-sponsorship` — Revoke sponsorship of a ledger entry or signer
+- `set-options` — Set account options like flags, signers, and home domain
+- `set-trustline-flags` — Configure authorization and trustline flags for an asset
 
 ## `stellar tx new account-merge`
 
@@ -1739,26 +1561,25 @@ Transfer XLM balance to another account and remove source account
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--account <ACCOUNT>` — Muxed Account to merge with, e.g. `GBX...`, 'MBX...'
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--account <ACCOUNT>` — Muxed Account to merge with, e.g. `GBX...`, 'MBX...'
 
 ## `stellar tx new begin-sponsoring-future-reserves`
 
@@ -1768,26 +1589,25 @@ Begin sponsoring future reserves for another account
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--sponsored-id <SPONSORED_ID>` — Account that will be sponsored
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--sponsored-id <SPONSORED_ID>` — Account that will be sponsored
 
 ## `stellar tx new bump-sequence`
 
@@ -1797,26 +1617,25 @@ Bump sequence number to invalidate older transactions
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--bump-to <BUMP_TO>` — Sequence number to bump to
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--bump-to <BUMP_TO>` — Sequence number to bump to
 
 ## `stellar tx new change-trust`
 
@@ -1826,29 +1645,28 @@ Create, update, or delete a trustline
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--line <LINE>`
-* `--limit <LIMIT>` — Limit for the trust line, 0 to remove the trust line
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--line <LINE>`
+- `--limit <LIMIT>` — Limit for the trust line, 0 to remove the trust line
 
   Default value: `9223372036854775807`
-
-
 
 ## `stellar tx new claim-claimable-balance`
 
@@ -1858,26 +1676,25 @@ Claim a claimable balance by its balance ID
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to claim (64-character hex string)
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to claim (64-character hex string)
 
 ## `stellar tx new clawback`
 
@@ -1887,28 +1704,27 @@ Clawback an asset from an account
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--from <FROM>` — Account to clawback assets from, e.g. `GBX...`
-* `--asset <ASSET>` — Asset to clawback
-* `--amount <AMOUNT>` — Amount of the asset to clawback, in stroops. 1 stroop = 0.0000001 of the asset
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--from <FROM>` — Account to clawback assets from, e.g. `GBX...`
+- `--asset <ASSET>` — Asset to clawback
+- `--amount <AMOUNT>` — Amount of the asset to clawback, in stroops. 1 stroop = 0.0000001 of the asset
 
 ## `stellar tx new clawback-claimable-balance`
 
@@ -1918,26 +1734,25 @@ Clawback a claimable balance by its balance ID
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to clawback. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to clawback. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
 
 ## `stellar tx new create-account`
 
@@ -1947,29 +1762,28 @@ Create and fund a new account
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--destination <DESTINATION>` — Account Id to create, e.g. `GBX...`
-* `--starting-balance <STARTING_BALANCE>` — Initial balance in stroops of the account, default 1 XLM
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--destination <DESTINATION>` — Account Id to create, e.g. `GBX...`
+- `--starting-balance <STARTING_BALANCE>` — Initial balance in stroops of the account, default 1 XLM
 
   Default value: `10_000_000`
-
-
 
 ## `stellar tx new create-claimable-balance`
 
@@ -1979,34 +1793,33 @@ Create a claimable balance that can be claimed by specified accounts
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--asset <ASSET>` — Asset to be held in the ClaimableBalanceEntry
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--asset <ASSET>` — Asset to be held in the ClaimableBalanceEntry
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
-* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants.
 
-   Examples:
+- `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
+- `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants.
 
-   - `--claimant alice (unconditional)` - `--claimant 'bob:{"before_absolute_time":"1735689599"}'` - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
-
-
+  Examples:
+  - `--claimant alice (unconditional)` - `--claimant 'bob:{"before_absolute_time":"1735689599"}'` - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
 
 ## `stellar tx new create-passive-sell-offer`
 
@@ -2016,29 +1829,28 @@ Create a passive sell offer on the Stellar DEX
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--selling <SELLING>` — Asset to sell
-* `--buying <BUYING>` — Asset to buy
-* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
-* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--selling <SELLING>` — Asset to sell
+- `--buying <BUYING>` — Asset to buy
+- `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+- `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
 ## `stellar tx new end-sponsoring-future-reserves`
 
@@ -2048,25 +1860,24 @@ End sponsoring future reserves
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
 
 ## `stellar tx new liquidity-pool-deposit`
 
@@ -2076,34 +1887,34 @@ Deposit assets into a liquidity pool
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to deposit to
-* `--max-amount-a <MAX_AMOUNT_A>` — Maximum amount of the first asset to deposit, in stroops
-* `--max-amount-b <MAX_AMOUNT_B>` — Maximum amount of the second asset to deposit, in stroops
-* `--min-price <MIN_PRICE>` — Minimum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to deposit to
+- `--max-amount-a <MAX_AMOUNT_A>` — Maximum amount of the first asset to deposit, in stroops
+- `--max-amount-b <MAX_AMOUNT_B>` — Maximum amount of the second asset to deposit, in stroops
+- `--min-price <MIN_PRICE>` — Minimum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
   Default value: `1:1`
-* `--max-price <MAX_PRICE>` — Maximum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+
+- `--max-price <MAX_PRICE>` — Maximum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
   Default value: `1:1`
-
-
 
 ## `stellar tx new liquidity-pool-withdraw`
 
@@ -2113,29 +1924,28 @@ Withdraw assets from a liquidity pool
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to withdraw from
-* `--amount <AMOUNT>` — Amount of pool shares to withdraw, in stroops
-* `--min-amount-a <MIN_AMOUNT_A>` — Minimum amount of the first asset to receive, in stroops
-* `--min-amount-b <MIN_AMOUNT_B>` — Minimum amount of the second asset to receive, in stroops
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to withdraw from
+- `--amount <AMOUNT>` — Amount of pool shares to withdraw, in stroops
+- `--min-amount-a <MIN_AMOUNT_A>` — Minimum amount of the first asset to receive, in stroops
+- `--min-amount-b <MIN_AMOUNT_B>` — Minimum amount of the second asset to receive, in stroops
 
 ## `stellar tx new manage-buy-offer`
 
@@ -2145,32 +1955,31 @@ Create, update, or delete a buy offer
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--selling <SELLING>` — Asset to sell
-* `--buying <BUYING>` — Asset to buy
-* `--amount <AMOUNT>` — Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
-* `--price <PRICE>` — Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
-* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--selling <SELLING>` — Asset to sell
+- `--buying <BUYING>` — Asset to buy
+- `--amount <AMOUNT>` — Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+- `--price <PRICE>` — Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+- `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
 
   Default value: `0`
-
-
 
 ## `stellar tx new manage-data`
 
@@ -2180,27 +1989,26 @@ Set, modify, or delete account data entries
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--data-name <DATA_NAME>` — String up to 64 bytes long. If this is a new Name it will add the given name/value pair to the account. If this Name is already present then the associated value will be modified
-* `--data-value <DATA_VALUE>` — Up to 64 bytes long hex string If not present then the existing Name will be deleted. If present then this value will be set in the `DataEntry`
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--data-name <DATA_NAME>` — String up to 64 bytes long. If this is a new Name it will add the given name/value pair to the account. If this Name is already present then the associated value will be modified
+- `--data-value <DATA_VALUE>` — Up to 64 bytes long hex string If not present then the existing Name will be deleted. If present then this value will be set in the `DataEntry`
 
 ## `stellar tx new manage-sell-offer`
 
@@ -2210,32 +2018,31 @@ Create, update, or delete a sell offer
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--selling <SELLING>` — Asset to sell
-* `--buying <BUYING>` — Asset to buy
-* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
-* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
-* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--selling <SELLING>` — Asset to sell
+- `--buying <BUYING>` — Asset to buy
+- `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+- `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+- `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
 
   Default value: `0`
-
-
 
 ## `stellar tx new path-payment-strict-send`
 
@@ -2245,31 +2052,30 @@ Send a payment with a different asset using path finding, specifying the send am
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
-* `--send-amount <SEND_AMOUNT>` — Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
-* `--destination <DESTINATION>` — Account that receives the payment
-* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
-* `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
-* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+- `--send-amount <SEND_AMOUNT>` — Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+- `--destination <DESTINATION>` — Account that receives the payment
+- `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+- `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
+- `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 ## `stellar tx new path-payment-strict-receive`
 
@@ -2279,31 +2085,30 @@ Send a payment with a different asset using path finding, specifying the receive
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
-* `--send-max <SEND_MAX>` — Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
-* `--destination <DESTINATION>` — Account that receives the payment
-* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
-* `--dest-amount <DEST_AMOUNT>` — Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset
-* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+- `--send-max <SEND_MAX>` — Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+- `--destination <DESTINATION>` — Account that receives the payment
+- `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+- `--dest-amount <DEST_AMOUNT>` — Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset
+- `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 ## `stellar tx new payment`
 
@@ -2313,30 +2118,30 @@ Send asset to destination account
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--destination <DESTINATION>` — Account to send to, e.g. `GBX...`
-* `--asset <ASSET>` — Asset to send, default native, e.i. XLM
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--destination <DESTINATION>` — Account to send to, e.g. `GBX...`
+- `--asset <ASSET>` — Asset to send, default native, e.i. XLM
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
 
-
+- `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
 
 ## `stellar tx new revoke-sponsorship`
 
@@ -2346,32 +2151,31 @@ Revoke sponsorship of a ledger entry or signer
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--account-id <ACCOUNT_ID>` — Account ID (required for all sponsorship types)
-* `--asset <ASSET>` — Asset for trustline sponsorship (format: CODE:ISSUER)
-* `--data-name <DATA_NAME>` — Data name for data entry sponsorship
-* `--offer-id <OFFER_ID>` — Offer ID for offer sponsorship
-* `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Pool ID for liquidity pool sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): LAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-* `--claimable-balance-id <CLAIMABLE_BALANCE_ID>` — Claimable balance ID for claimable balance sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
-* `--signer-key <SIGNER_KEY>` — Signer key for signer sponsorship
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--account-id <ACCOUNT_ID>` — Account ID (required for all sponsorship types)
+- `--asset <ASSET>` — Asset for trustline sponsorship (format: CODE:ISSUER)
+- `--data-name <DATA_NAME>` — Data name for data entry sponsorship
+- `--offer-id <OFFER_ID>` — Offer ID for offer sponsorship
+- `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Pool ID for liquidity pool sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): LAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+- `--claimable-balance-id <CLAIMABLE_BALANCE_ID>` — Claimable balance ID for claimable balance sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
+- `--signer-key <SIGNER_KEY>` — Signer key for signer sponsorship
 
 ## `stellar tx new set-options`
 
@@ -2381,41 +2185,40 @@ Set account options like flags, signers, and home domain
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--inflation-dest <INFLATION_DEST>` — Account of the inflation destination
-* `--master-weight <MASTER_WEIGHT>` — A number from 0-255 (inclusive) representing the weight of the master key. If the weight of the master key is updated to 0, it is effectively disabled
-* `--low-threshold <LOW_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a low threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
-* `--med-threshold <MED_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a medium threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
-* `--high-threshold <HIGH_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a high threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
-* `--home-domain <HOME_DOMAIN>` — Sets the home domain of an account. See https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
-* `--signer <SIGNER>` — Add, update, or remove a signer from an account
-* `--signer-weight <SIGNER_WEIGHT>` — Signer weight is a number from 0-255 (inclusive). The signer is deleted if the weight is 0
-* `--set-required` — When enabled, an issuer must approve an account before that account can hold its asset. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-required-0x1
-* `--set-revocable` — When enabled, an issuer can revoke an existing trustline's authorization, thereby freezing the asset held by an account. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-revocable-0x2
-* `--set-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. https://developers.stellar.org/docs/tokens/control-asset-access#clawback-enabled-0x8
-* `--set-immutable` — With this setting, none of the other authorization flags (`AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`) can be set, and the issuing account can't be merged. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-immutable-0x4
-* `--clear-required`
-* `--clear-revocable`
-* `--clear-immutable`
-* `--clear-clawback-enabled`
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--inflation-dest <INFLATION_DEST>` — Account of the inflation destination
+- `--master-weight <MASTER_WEIGHT>` — A number from 0-255 (inclusive) representing the weight of the master key. If the weight of the master key is updated to 0, it is effectively disabled
+- `--low-threshold <LOW_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a low threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
+- `--med-threshold <MED_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a medium threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
+- `--high-threshold <HIGH_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a high threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
+- `--home-domain <HOME_DOMAIN>` — Sets the home domain of an account. See https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
+- `--signer <SIGNER>` — Add, update, or remove a signer from an account
+- `--signer-weight <SIGNER_WEIGHT>` — Signer weight is a number from 0-255 (inclusive). The signer is deleted if the weight is 0
+- `--set-required` — When enabled, an issuer must approve an account before that account can hold its asset. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-required-0x1
+- `--set-revocable` — When enabled, an issuer can revoke an existing trustline's authorization, thereby freezing the asset held by an account. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-revocable-0x2
+- `--set-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. https://developers.stellar.org/docs/tokens/control-asset-access#clawback-enabled-0x8
+- `--set-immutable` — With this setting, none of the other authorization flags (`AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`) can be set, and the issuing account can't be merged. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-immutable-0x4
+- `--clear-required`
+- `--clear-revocable`
+- `--clear-immutable`
+- `--clear-clawback-enabled`
 
 ## `stellar tx new set-trustline-flags`
 
@@ -2425,33 +2228,32 @@ Configure authorization and trustline flags for an asset
 
 ###### **Options:**
 
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--trustor <TRUSTOR>` — Account to set trustline flags for, e.g. `GBX...`, or alias, or muxed account, `M123...``
-* `--asset <ASSET>` — Asset to set trustline flags for
-* `--set-authorize` — Signifies complete authorization allowing an account to transact freely with the asset to make and receive payments and place orders
-* `--set-authorize-to-maintain-liabilities` — Denotes limited authorization that allows an account to maintain current orders but not to otherwise transact with the asset
-* `--set-trustline-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. See our section on Clawbacks: https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/clawbacks
-* `--clear-authorize`
-* `--clear-authorize-to-maintain-liabilities`
-* `--clear-trustline-clawback-enabled`
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--trustor <TRUSTOR>` — Account to set trustline flags for, e.g. `GBX...`, or alias, or muxed account, `M123...``
+- `--asset <ASSET>` — Asset to set trustline flags for
+- `--set-authorize` — Signifies complete authorization allowing an account to transact freely with the asset to make and receive payments and place orders
+- `--set-authorize-to-maintain-liabilities` — Denotes limited authorization that allows an account to maintain current orders but not to otherwise transact with the asset
+- `--set-trustline-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. See our section on Clawbacks: https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/clawbacks
+- `--clear-authorize`
+- `--clear-authorize-to-maintain-liabilities`
+- `--clear-trustline-clawback-enabled`
 
 ## `stellar tx operation`
 
@@ -2463,9 +2265,7 @@ Manipulate the operations in a transaction, including adding new operations
 
 ###### **Subcommands:**
 
-* `add` — Add Operation to a transaction
-
-
+- `add` — Add Operation to a transaction
 
 ## `stellar tx operation add`
 
@@ -2475,30 +2275,28 @@ Add Operation to a transaction
 
 ###### **Subcommands:**
 
-* `account-merge` — Transfer XLM balance to another account and remove source account
-* `begin-sponsoring-future-reserves` — Begin sponsoring future reserves for another account
-* `bump-sequence` — Bump sequence number to invalidate older transactions
-* `change-trust` — Create, update, or delete a trustline
-* `claim-claimable-balance` — Claim a claimable balance by its balance ID
-* `clawback` — Clawback an asset from an account
-* `clawback-claimable-balance` — Clawback a claimable balance by its balance ID
-* `create-account` — Create and fund a new account
-* `create-claimable-balance` — Create a claimable balance that can be claimed by specified accounts
-* `create-passive-sell-offer` — Create a passive sell offer on the Stellar DEX
-* `end-sponsoring-future-reserves` — End sponsoring future reserves
-* `liquidity-pool-deposit` — Deposit assets into a liquidity pool
-* `liquidity-pool-withdraw` — Withdraw assets from a liquidity pool
-* `manage-buy-offer` — Create, update, or delete a buy offer
-* `manage-data` — Set, modify, or delete account data entries
-* `manage-sell-offer` — Create, update, or delete a sell offer
-* `path-payment-strict-receive` — Send a payment with a different asset using path finding, specifying the receive amount
-* `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
-* `payment` — Send asset to destination account
-* `revoke-sponsorship` — Revoke sponsorship of a ledger entry or signer
-* `set-options` — Set account options like flags, signers, and home domain
-* `set-trustline-flags` — Configure authorization and trustline flags for an asset
-
-
+- `account-merge` — Transfer XLM balance to another account and remove source account
+- `begin-sponsoring-future-reserves` — Begin sponsoring future reserves for another account
+- `bump-sequence` — Bump sequence number to invalidate older transactions
+- `change-trust` — Create, update, or delete a trustline
+- `claim-claimable-balance` — Claim a claimable balance by its balance ID
+- `clawback` — Clawback an asset from an account
+- `clawback-claimable-balance` — Clawback a claimable balance by its balance ID
+- `create-account` — Create and fund a new account
+- `create-claimable-balance` — Create a claimable balance that can be claimed by specified accounts
+- `create-passive-sell-offer` — Create a passive sell offer on the Stellar DEX
+- `end-sponsoring-future-reserves` — End sponsoring future reserves
+- `liquidity-pool-deposit` — Deposit assets into a liquidity pool
+- `liquidity-pool-withdraw` — Withdraw assets from a liquidity pool
+- `manage-buy-offer` — Create, update, or delete a buy offer
+- `manage-data` — Set, modify, or delete account data entries
+- `manage-sell-offer` — Create, update, or delete a sell offer
+- `path-payment-strict-receive` — Send a payment with a different asset using path finding, specifying the receive amount
+- `path-payment-strict-send` — Send a payment with a different asset using path finding, specifying the send amount
+- `payment` — Send asset to destination account
+- `revoke-sponsorship` — Revoke sponsorship of a ledger entry or signer
+- `set-options` — Set account options like flags, signers, and home domain
+- `set-trustline-flags` — Configure authorization and trustline flags for an asset
 
 ## `stellar tx operation add account-merge`
 
@@ -2508,31 +2306,30 @@ Transfer XLM balance to another account and remove source account
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--account <ACCOUNT>` — Muxed Account to merge with, e.g. `GBX...`, 'MBX...'
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--account <ACCOUNT>` — Muxed Account to merge with, e.g. `GBX...`, 'MBX...'
 
 ## `stellar tx operation add begin-sponsoring-future-reserves`
 
@@ -2542,31 +2339,30 @@ Begin sponsoring future reserves for another account
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--sponsored-id <SPONSORED_ID>` — Account that will be sponsored
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--sponsored-id <SPONSORED_ID>` — Account that will be sponsored
 
 ## `stellar tx operation add bump-sequence`
 
@@ -2576,31 +2372,30 @@ Bump sequence number to invalidate older transactions
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--bump-to <BUMP_TO>` — Sequence number to bump to
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--bump-to <BUMP_TO>` — Sequence number to bump to
 
 ## `stellar tx operation add change-trust`
 
@@ -2610,34 +2405,33 @@ Create, update, or delete a trustline
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--line <LINE>`
-* `--limit <LIMIT>` — Limit for the trust line, 0 to remove the trust line
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--line <LINE>`
+- `--limit <LIMIT>` — Limit for the trust line, 0 to remove the trust line
 
   Default value: `9223372036854775807`
-
-
 
 ## `stellar tx operation add claim-claimable-balance`
 
@@ -2647,31 +2441,30 @@ Claim a claimable balance by its balance ID
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to claim (64-character hex string)
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to claim (64-character hex string)
 
 ## `stellar tx operation add clawback`
 
@@ -2681,33 +2474,32 @@ Clawback an asset from an account
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--from <FROM>` — Account to clawback assets from, e.g. `GBX...`
-* `--asset <ASSET>` — Asset to clawback
-* `--amount <AMOUNT>` — Amount of the asset to clawback, in stroops. 1 stroop = 0.0000001 of the asset
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--from <FROM>` — Account to clawback assets from, e.g. `GBX...`
+- `--asset <ASSET>` — Asset to clawback
+- `--amount <AMOUNT>` — Amount of the asset to clawback, in stroops. 1 stroop = 0.0000001 of the asset
 
 ## `stellar tx operation add clawback-claimable-balance`
 
@@ -2717,31 +2509,30 @@ Clawback a claimable balance by its balance ID
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to clawback. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--balance-id <BALANCE_ID>` — Balance ID of the claimable balance to clawback. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
 
 ## `stellar tx operation add create-account`
 
@@ -2751,34 +2542,33 @@ Create and fund a new account
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--destination <DESTINATION>` — Account Id to create, e.g. `GBX...`
-* `--starting-balance <STARTING_BALANCE>` — Initial balance in stroops of the account, default 1 XLM
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--destination <DESTINATION>` — Account Id to create, e.g. `GBX...`
+- `--starting-balance <STARTING_BALANCE>` — Initial balance in stroops of the account, default 1 XLM
 
   Default value: `10_000_000`
-
-
 
 ## `stellar tx operation add create-claimable-balance`
 
@@ -2788,39 +2578,38 @@ Create a claimable balance that can be claimed by specified accounts
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--asset <ASSET>` — Asset to be held in the ClaimableBalanceEntry
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--asset <ASSET>` — Asset to be held in the ClaimableBalanceEntry
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
-* `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants.
 
-   Examples:
+- `--amount <AMOUNT>` — Amount of asset to store in the entry, in stroops. 1 stroop = 0.0000001 of the asset
+- `--claimant <CLAIMANTS>` — Claimants of the claimable balance. Format: account_id or account_id:predicate_json Can be specified multiple times for multiple claimants.
 
-   - `--claimant alice (unconditional)` - `--claimant 'bob:{"before_absolute_time":"1735689599"}'` - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
-
-
+  Examples:
+  - `--claimant alice (unconditional)` - `--claimant 'bob:{"before_absolute_time":"1735689599"}'` - `--claimant 'charlie:{"and":[{"before_absolute_time":"1735689599"},{"before_relative_time":"3600"}]}'`
 
 ## `stellar tx operation add create-passive-sell-offer`
 
@@ -2830,34 +2619,33 @@ Create a passive sell offer on the Stellar DEX
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--selling <SELLING>` — Asset to sell
-* `--buying <BUYING>` — Asset to buy
-* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
-* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--selling <SELLING>` — Asset to sell
+- `--buying <BUYING>` — Asset to buy
+- `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+- `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
 ## `stellar tx operation add end-sponsoring-future-reserves`
 
@@ -2867,30 +2655,29 @@ End sponsoring future reserves
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
 
 ## `stellar tx operation add liquidity-pool-deposit`
 
@@ -2900,39 +2687,39 @@ Deposit assets into a liquidity pool
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to deposit to
-* `--max-amount-a <MAX_AMOUNT_A>` — Maximum amount of the first asset to deposit, in stroops
-* `--max-amount-b <MAX_AMOUNT_B>` — Maximum amount of the second asset to deposit, in stroops
-* `--min-price <MIN_PRICE>` — Minimum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to deposit to
+- `--max-amount-a <MAX_AMOUNT_A>` — Maximum amount of the first asset to deposit, in stroops
+- `--max-amount-b <MAX_AMOUNT_B>` — Maximum amount of the second asset to deposit, in stroops
+- `--min-price <MIN_PRICE>` — Minimum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
   Default value: `1:1`
-* `--max-price <MAX_PRICE>` — Maximum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+
+- `--max-price <MAX_PRICE>` — Maximum price for the first asset in terms of the second asset as "numerator:denominator" (e.g., "1:2" means 0.5)
 
   Default value: `1:1`
-
-
 
 ## `stellar tx operation add liquidity-pool-withdraw`
 
@@ -2942,34 +2729,33 @@ Withdraw assets from a liquidity pool
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to withdraw from
-* `--amount <AMOUNT>` — Amount of pool shares to withdraw, in stroops
-* `--min-amount-a <MIN_AMOUNT_A>` — Minimum amount of the first asset to receive, in stroops
-* `--min-amount-b <MIN_AMOUNT_B>` — Minimum amount of the second asset to receive, in stroops
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Liquidity pool ID to withdraw from
+- `--amount <AMOUNT>` — Amount of pool shares to withdraw, in stroops
+- `--min-amount-a <MIN_AMOUNT_A>` — Minimum amount of the first asset to receive, in stroops
+- `--min-amount-b <MIN_AMOUNT_B>` — Minimum amount of the second asset to receive, in stroops
 
 ## `stellar tx operation add manage-buy-offer`
 
@@ -2979,37 +2765,36 @@ Create, update, or delete a buy offer
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--selling <SELLING>` — Asset to sell
-* `--buying <BUYING>` — Asset to buy
-* `--amount <AMOUNT>` — Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
-* `--price <PRICE>` — Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
-* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--selling <SELLING>` — Asset to sell
+- `--buying <BUYING>` — Asset to buy
+- `--amount <AMOUNT>` — Amount of buying asset to purchase, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+- `--price <PRICE>` — Price of 1 unit of buying asset in terms of selling asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+- `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
 
   Default value: `0`
-
-
 
 ## `stellar tx operation add manage-data`
 
@@ -3019,32 +2804,31 @@ Set, modify, or delete account data entries
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--data-name <DATA_NAME>` — String up to 64 bytes long. If this is a new Name it will add the given name/value pair to the account. If this Name is already present then the associated value will be modified
-* `--data-value <DATA_VALUE>` — Up to 64 bytes long hex string If not present then the existing Name will be deleted. If present then this value will be set in the `DataEntry`
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--data-name <DATA_NAME>` — String up to 64 bytes long. If this is a new Name it will add the given name/value pair to the account. If this Name is already present then the associated value will be modified
+- `--data-value <DATA_VALUE>` — Up to 64 bytes long hex string If not present then the existing Name will be deleted. If present then this value will be set in the `DataEntry`
 
 ## `stellar tx operation add manage-sell-offer`
 
@@ -3054,37 +2838,36 @@ Create, update, or delete a sell offer
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--selling <SELLING>` — Asset to sell
-* `--buying <BUYING>` — Asset to buy
-* `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
-* `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
-* `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--selling <SELLING>` — Asset to sell
+- `--buying <BUYING>` — Asset to buy
+- `--amount <AMOUNT>` — Amount of selling asset to offer, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops). Use `0` to remove the offer
+- `--price <PRICE>` — Price of 1 unit of selling asset in terms of buying asset as "numerator:denominator" (e.g., "1:2" means 0.5)
+- `--offer-id <OFFER_ID>` — Offer ID. If 0, will create new offer. Otherwise, will update existing offer
 
   Default value: `0`
-
-
 
 ## `stellar tx operation add path-payment-strict-receive`
 
@@ -3094,36 +2877,35 @@ Send a payment with a different asset using path finding, specifying the receive
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
-* `--send-max <SEND_MAX>` — Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
-* `--destination <DESTINATION>` — Account that receives the payment
-* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
-* `--dest-amount <DEST_AMOUNT>` — Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset
-* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+- `--send-max <SEND_MAX>` — Maximum amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+- `--destination <DESTINATION>` — Account that receives the payment
+- `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+- `--dest-amount <DEST_AMOUNT>` — Exact amount of destination asset that the destination account will receive, in stroops. 1 stroop = 0.0000001 of the asset
+- `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 ## `stellar tx operation add path-payment-strict-send`
 
@@ -3133,36 +2915,35 @@ Send a payment with a different asset using path finding, specifying the send am
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--send-asset <SEND_ASSET>` — Asset to send (pay with)
-* `--send-amount <SEND_AMOUNT>` — Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
-* `--destination <DESTINATION>` — Account that receives the payment
-* `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
-* `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
-* `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--send-asset <SEND_ASSET>` — Asset to send (pay with)
+- `--send-amount <SEND_AMOUNT>` — Amount of send asset to deduct from sender's account, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
+- `--destination <DESTINATION>` — Account that receives the payment
+- `--dest-asset <DEST_ASSET>` — Asset that the destination will receive
+- `--dest-min <DEST_MIN>` — Minimum amount of destination asset that the destination account can receive. The operation will fail if this amount cannot be met
+- `--path <PATH>` — List of intermediate assets for the payment path, comma-separated (up to 5 assets). Each asset should be in the format 'code:issuer' or 'native' for XLM
 
 ## `stellar tx operation add payment`
 
@@ -3172,35 +2953,35 @@ Send asset to destination account
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--destination <DESTINATION>` — Account to send to, e.g. `GBX...`
-* `--asset <ASSET>` — Asset to send, default native, e.i. XLM
+
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--destination <DESTINATION>` — Account to send to, e.g. `GBX...`
+- `--asset <ASSET>` — Asset to send, default native, e.i. XLM
 
   Default value: `native`
-* `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
 
-
+- `--amount <AMOUNT>` — Amount of the aforementioned asset to send, in stroops. 1 stroop = 0.0000001 of the asset (e.g. 1 XLM = `10_000_000` stroops)
 
 ## `stellar tx operation add revoke-sponsorship`
 
@@ -3210,37 +2991,36 @@ Revoke sponsorship of a ledger entry or signer
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--account-id <ACCOUNT_ID>` — Account ID (required for all sponsorship types)
-* `--asset <ASSET>` — Asset for trustline sponsorship (format: CODE:ISSUER)
-* `--data-name <DATA_NAME>` — Data name for data entry sponsorship
-* `--offer-id <OFFER_ID>` — Offer ID for offer sponsorship
-* `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Pool ID for liquidity pool sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): LAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-* `--claimable-balance-id <CLAIMABLE_BALANCE_ID>` — Claimable balance ID for claimable balance sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
-* `--signer-key <SIGNER_KEY>` — Signer key for signer sponsorship
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--account-id <ACCOUNT_ID>` — Account ID (required for all sponsorship types)
+- `--asset <ASSET>` — Asset for trustline sponsorship (format: CODE:ISSUER)
+- `--data-name <DATA_NAME>` — Data name for data entry sponsorship
+- `--offer-id <OFFER_ID>` — Offer ID for offer sponsorship
+- `--liquidity-pool-id <LIQUIDITY_POOL_ID>` — Pool ID for liquidity pool sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): LAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+- `--claimable-balance-id <CLAIMABLE_BALANCE_ID>` — Claimable balance ID for claimable balance sponsorship. Accepts multiple formats: - API format with type prefix (72 chars): 000000006f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Direct hash format (64 chars): 6f2179b31311fa8064760b48942c8e166702ba0b8fbe7358c4fd570421840461 - Address format (base32): BAAMLBZI42AD52HKGIZOU7WFVZM6BPEJCLPL44QU2AT6TY3P57I5QDNYIA
+- `--signer-key <SIGNER_KEY>` — Signer key for signer sponsorship
 
 ## `stellar tx operation add set-options`
 
@@ -3250,46 +3030,45 @@ Set account options like flags, signers, and home domain
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--inflation-dest <INFLATION_DEST>` — Account of the inflation destination
-* `--master-weight <MASTER_WEIGHT>` — A number from 0-255 (inclusive) representing the weight of the master key. If the weight of the master key is updated to 0, it is effectively disabled
-* `--low-threshold <LOW_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a low threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
-* `--med-threshold <MED_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a medium threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
-* `--high-threshold <HIGH_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a high threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
-* `--home-domain <HOME_DOMAIN>` — Sets the home domain of an account. See https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
-* `--signer <SIGNER>` — Add, update, or remove a signer from an account
-* `--signer-weight <SIGNER_WEIGHT>` — Signer weight is a number from 0-255 (inclusive). The signer is deleted if the weight is 0
-* `--set-required` — When enabled, an issuer must approve an account before that account can hold its asset. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-required-0x1
-* `--set-revocable` — When enabled, an issuer can revoke an existing trustline's authorization, thereby freezing the asset held by an account. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-revocable-0x2
-* `--set-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. https://developers.stellar.org/docs/tokens/control-asset-access#clawback-enabled-0x8
-* `--set-immutable` — With this setting, none of the other authorization flags (`AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`) can be set, and the issuing account can't be merged. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-immutable-0x4
-* `--clear-required`
-* `--clear-revocable`
-* `--clear-immutable`
-* `--clear-clawback-enabled`
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--inflation-dest <INFLATION_DEST>` — Account of the inflation destination
+- `--master-weight <MASTER_WEIGHT>` — A number from 0-255 (inclusive) representing the weight of the master key. If the weight of the master key is updated to 0, it is effectively disabled
+- `--low-threshold <LOW_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a low threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
+- `--med-threshold <MED_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a medium threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
+- `--high-threshold <HIGH_THRESHOLD>` — A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have a high threshold. https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#multisig
+- `--home-domain <HOME_DOMAIN>` — Sets the home domain of an account. See https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
+- `--signer <SIGNER>` — Add, update, or remove a signer from an account
+- `--signer-weight <SIGNER_WEIGHT>` — Signer weight is a number from 0-255 (inclusive). The signer is deleted if the weight is 0
+- `--set-required` — When enabled, an issuer must approve an account before that account can hold its asset. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-required-0x1
+- `--set-revocable` — When enabled, an issuer can revoke an existing trustline's authorization, thereby freezing the asset held by an account. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-revocable-0x2
+- `--set-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. https://developers.stellar.org/docs/tokens/control-asset-access#clawback-enabled-0x8
+- `--set-immutable` — With this setting, none of the other authorization flags (`AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`) can be set, and the issuing account can't be merged. https://developers.stellar.org/docs/tokens/control-asset-access#authorization-immutable-0x4
+- `--clear-required`
+- `--clear-revocable`
+- `--clear-immutable`
+- `--clear-clawback-enabled`
 
 ## `stellar tx operation add set-trustline-flags`
 
@@ -3299,38 +3078,37 @@ Configure authorization and trustline flags for an asset
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
-* `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
+- `--operation-source-account <OPERATION_SOURCE_ACCOUNT>` [alias: `op-source`] — Source account used for the operation
+- `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
-* `--cost` — Output the cost execution to stderr
-* `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
-* `--build-only` — Build the transaction and only write the base64 xdr to stdout
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--trustor <TRUSTOR>` — Account to set trustline flags for, e.g. `GBX...`, or alias, or muxed account, `M123...``
-* `--asset <ASSET>` — Asset to set trustline flags for
-* `--set-authorize` — Signifies complete authorization allowing an account to transact freely with the asset to make and receive payments and place orders
-* `--set-authorize-to-maintain-liabilities` — Denotes limited authorization that allows an account to maintain current orders but not to otherwise transact with the asset
-* `--set-trustline-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. See our section on Clawbacks: https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/clawbacks
-* `--clear-authorize`
-* `--clear-authorize-to-maintain-liabilities`
-* `--clear-trustline-clawback-enabled`
 
-
+- `--cost` — Output the cost execution to stderr
+- `--instructions <INSTRUCTIONS>` — Number of instructions to simulate
+- `--build-only` — Build the transaction and only write the base64 xdr to stdout
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--trustor <TRUSTOR>` — Account to set trustline flags for, e.g. `GBX...`, or alias, or muxed account, `M123...``
+- `--asset <ASSET>` — Asset to set trustline flags for
+- `--set-authorize` — Signifies complete authorization allowing an account to transact freely with the asset to make and receive payments and place orders
+- `--set-authorize-to-maintain-liabilities` — Denotes limited authorization that allows an account to maintain current orders but not to otherwise transact with the asset
+- `--set-trustline-clawback-enabled` — Enables the issuing account to take back (burning) all of the asset. See our section on Clawbacks: https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/clawbacks
+- `--clear-authorize`
+- `--clear-authorize-to-maintain-liabilities`
+- `--clear-trustline-clawback-enabled`
 
 ## `stellar tx send`
 
@@ -3340,18 +3118,16 @@ Send a transaction envelope to the network
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar tx sign`
 
@@ -3361,22 +3137,20 @@ Sign a transaction envelope appending the signature to the envelope
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR, or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR, or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-
-
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar tx simulate`
 
@@ -3386,58 +3160,49 @@ Simulate a transaction envelope from stdin
 
 ###### **Arguments:**
 
-* `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
+- `<TX_XDR>` — Base-64 transaction envelope XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
-* `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
-* `--sign-with-lab` — Sign with https://lab.stellar.org
-* `--sign-with-ledger` — Sign with a ledger wallet
-
-
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `-s`, `--source-account <SOURCE_ACCOUNT>` [alias: `source`] — Account that where transaction originates from. Alias `source`. Can be an identity (--source alice), a public key (--source GDKW...), a muxed account (--source MDA…), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). If `--build-only` or `--sim-only` flags were NOT provided, this key will also be used to sign the final transaction. In that case, trying to sign with public key will fail
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
 
 ## `stellar tx fetch`
 
 Fetch a transaction from the network by hash If no subcommand is passed in, the transaction envelope will be returned
 
-**Usage:** `stellar tx fetch [OPTIONS]
-       fetch <COMMAND>`
+**Usage:** `stellar tx fetch [OPTIONS]        fetch <COMMAND>`
 
 ###### **Subcommands:**
 
-* `result` — Fetch the transaction result
-* `meta` — Fetch the transaction meta
-* `fee` — Fetch the transaction fee information
+- `result` — Fetch the transaction result
+- `meta` — Fetch the transaction meta
+- `fee` — Fetch the transaction fee information
 
 ###### **Options:**
 
-* `--hash <HASH>` — Hash of transaction to fetch
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
+- `--hash <HASH>` — Hash of transaction to fetch
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `json`
 
   Possible values:
-  - `json`:
-    JSON output of the ledger entry with parsed XDRs (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the ledger entry with parsed XDRs
-  - `xdr`:
-    Original RPC output (containing XDRs)
-
-
-
+  - `json`: JSON output of the ledger entry with parsed XDRs (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the ledger entry with parsed XDRs
+  - `xdr`: Original RPC output (containing XDRs)
 
 ## `stellar tx fetch result`
 
@@ -3447,25 +3212,19 @@ Fetch the transaction result
 
 ###### **Options:**
 
-* `--hash <HASH>` — Transaction hash to fetch
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
+- `--hash <HASH>` — Transaction hash to fetch
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `json`
 
   Possible values:
-  - `json`:
-    JSON output of the ledger entry with parsed XDRs (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the ledger entry with parsed XDRs
-  - `xdr`:
-    Original RPC output (containing XDRs)
-
-
-
+  - `json`: JSON output of the ledger entry with parsed XDRs (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the ledger entry with parsed XDRs
+  - `xdr`: Original RPC output (containing XDRs)
 
 ## `stellar tx fetch meta`
 
@@ -3475,25 +3234,19 @@ Fetch the transaction meta
 
 ###### **Options:**
 
-* `--hash <HASH>` — Transaction hash to fetch
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
+- `--hash <HASH>` — Transaction hash to fetch
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `json`
 
   Possible values:
-  - `json`:
-    JSON output of the ledger entry with parsed XDRs (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the ledger entry with parsed XDRs
-  - `xdr`:
-    Original RPC output (containing XDRs)
-
-
-
+  - `json`: JSON output of the ledger entry with parsed XDRs (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the ledger entry with parsed XDRs
+  - `xdr`: Original RPC output (containing XDRs)
 
 ## `stellar tx fetch fee`
 
@@ -3503,25 +3256,19 @@ Fetch the transaction fee information
 
 ###### **Options:**
 
-* `--hash <HASH>` — Transaction hash to fetch
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Output format for fee command
+- `--hash <HASH>` — Transaction hash to fetch
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Output format for fee command
 
   Default value: `table`
 
   Possible values:
-  - `json`:
-    JSON output of the ledger entry with parsed XDRs (one line, not formatted)
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the ledger entry with parsed XDRs
-  - `table`:
-    Formatted in a table comparing fee types
-
-
-
+  - `json`: JSON output of the ledger entry with parsed XDRs (one line, not formatted)
+  - `json-formatted`: Formatted (multiline) JSON output of the ledger entry with parsed XDRs
+  - `table`: Formatted in a table comparing fee types
 
 ## `stellar tx decode`
 
@@ -3531,24 +3278,21 @@ Decode a transaction envelope from XDR to JSON
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
+- `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--input <INPUT_FORMAT>`
+- `--input <INPUT_FORMAT>`
 
   Default value: `single-base64`
 
   Possible values: `single-base64`, `single`
 
-* `--output <OUTPUT_FORMAT>`
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `json`
 
   Possible values: `json`, `json-formatted`
-
-
-
 
 ## `stellar tx encode`
 
@@ -3558,24 +3302,21 @@ Encode a transaction envelope from JSON to XDR
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
+- `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--input <INPUT_FORMAT>`
+- `--input <INPUT_FORMAT>`
 
   Default value: `json`
 
   Possible values: `json`
 
-* `--output <OUTPUT_FORMAT>`
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `single-base64`
 
   Possible values: `single-base64`, `single`
-
-
-
 
 ## `stellar xdr`
 
@@ -3585,24 +3326,21 @@ Decode and encode XDR
 
 ###### **Subcommands:**
 
-* `types` — View information about types
-* `guess` — Guess the XDR type
-* `decode` — Decode XDR
-* `encode` — Encode XDR
-* `compare` — Compare two XDR values with each other
-* `generate` — Generate XDR values
-* `version` — Print version information
+- `types` — View information about types
+- `guess` — Guess the XDR type
+- `decode` — Decode XDR
+- `encode` — Encode XDR
+- `compare` — Compare two XDR values with each other
+- `generate` — Generate XDR values
+- `version` — Print version information
 
 ###### **Arguments:**
 
-* `<CHANNEL>` — Channel of XDR to operate on
+- `<CHANNEL>` — Channel of XDR to operate on
 
   Default value: `+curr`
 
   Possible values: `+curr`, `+next`
-
-
-
 
 ## `stellar xdr types`
 
@@ -3612,11 +3350,9 @@ View information about types
 
 ###### **Subcommands:**
 
-* `list` — 
-* `schema` — 
-* `schema-files` — Generate JSON schema files for the XDR types, writing a file for each type to the out directory
-
-
+- `list` —
+- `schema` —
+- `schema-files` — Generate JSON schema files for the XDR types, writing a file for each type to the out directory
 
 ## `stellar xdr types list`
 
@@ -3624,14 +3360,11 @@ View information about types
 
 ###### **Options:**
 
-* `--output <OUTPUT>`
+- `--output <OUTPUT>`
 
   Default value: `plain`
 
   Possible values: `plain`, `json`, `json-formatted`
-
-
-
 
 ## `stellar xdr types schema`
 
@@ -3639,15 +3372,12 @@ View information about types
 
 ###### **Options:**
 
-* `--type <TYPE>` — XDR type to decode
-* `--output <OUTPUT>`
+- `--type <TYPE>` — XDR type to decode
+- `--output <OUTPUT>`
 
   Default value: `json-schema-draft201909`
 
   Possible values: `json-schema-draft201909`
-
-
-
 
 ## `stellar xdr types schema-files`
 
@@ -3657,15 +3387,12 @@ Generate JSON schema files for the XDR types, writing a file for each type to th
 
 ###### **Options:**
 
-* `--out-dir <OUT_DIR>`
-* `--output <OUTPUT>`
+- `--out-dir <OUT_DIR>`
+- `--output <OUTPUT>`
 
   Default value: `json-schema-draft201909`
 
   Possible values: `json-schema-draft201909`
-
-
-
 
 ## `stellar xdr guess`
 
@@ -3677,27 +3404,25 @@ Prints a list of types that the XDR values can be decoded into.
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
+- `<INPUT>` — XDR or file containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--input <INPUT_FORMAT>`
+- `--input <INPUT_FORMAT>`
 
   Default value: `single-base64`
 
   Possible values: `single`, `single-base64`, `stream`, `stream-base64`, `stream-framed`
 
-* `--output <OUTPUT_FORMAT>`
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `list`
 
   Possible values: `list`
 
-* `--certainty <CERTAINTY>` — Certainty as an arbitrary value
+- `--certainty <CERTAINTY>` — Certainty as an arbitrary value
 
   Default value: `2`
-
-
 
 ## `stellar xdr decode`
 
@@ -3707,25 +3432,22 @@ Decode XDR
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
+- `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--type <TYPE>` — XDR type to decode
-* `--input <INPUT_FORMAT>`
+- `--type <TYPE>` — XDR type to decode
+- `--input <INPUT_FORMAT>`
 
   Default value: `stream-base64`
 
   Possible values: `single`, `single-base64`, `stream`, `stream-base64`, `stream-framed`
 
-* `--output <OUTPUT_FORMAT>`
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `json`
 
   Possible values: `json`, `json-formatted`, `text`, `rust-debug`, `rust-debug-formatted`
-
-
-
 
 ## `stellar xdr encode`
 
@@ -3735,25 +3457,22 @@ Encode XDR
 
 ###### **Arguments:**
 
-* `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
+- `<INPUT>` — XDR or files containing XDR to decode, or stdin if empty
 
 ###### **Options:**
 
-* `--type <TYPE>` — XDR type to encode
-* `--input <INPUT_FORMAT>`
+- `--type <TYPE>` — XDR type to encode
+- `--input <INPUT_FORMAT>`
 
   Default value: `json`
 
   Possible values: `json`
 
-* `--output <OUTPUT_FORMAT>`
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `single-base64`
 
   Possible values: `single`, `single-base64`, `stream`
-
-
-
 
 ## `stellar xdr compare`
 
@@ -3765,20 +3484,17 @@ Outputs: `-1` when the left XDR value is less than the right XDR value, `0` when
 
 ###### **Arguments:**
 
-* `<LEFT>` — XDR file to decode and compare with the right value
-* `<RIGHT>` — XDR file to decode and compare with the left value
+- `<LEFT>` — XDR file to decode and compare with the right value
+- `<RIGHT>` — XDR file to decode and compare with the left value
 
 ###### **Options:**
 
-* `--type <TYPE>` — XDR type of both inputs
-* `--input <INPUT>`
+- `--type <TYPE>` — XDR type of both inputs
+- `--input <INPUT>`
 
   Default value: `single-base64`
 
   Possible values: `single`, `single-base64`
-
-
-
 
 ## `stellar xdr generate`
 
@@ -3788,10 +3504,8 @@ Generate XDR values
 
 ###### **Subcommands:**
 
-* `default` — Generate default XDR values
-* `arbitrary` — Generate arbitrary XDR values
-
-
+- `default` — Generate default XDR values
+- `arbitrary` — Generate arbitrary XDR values
 
 ## `stellar xdr generate default`
 
@@ -3801,15 +3515,12 @@ Generate default XDR values
 
 ###### **Options:**
 
-* `--type <TYPE>` — XDR type to generate
-* `--output <OUTPUT_FORMAT>`
+- `--type <TYPE>` — XDR type to generate
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `single-base64`
 
   Possible values: `single`, `single-base64`, `json`, `json-formatted`, `text`
-
-
-
 
 ## `stellar xdr generate arbitrary`
 
@@ -3819,23 +3530,18 @@ Generate arbitrary XDR values
 
 ###### **Options:**
 
-* `--type <TYPE>` — XDR type to generate
-* `--output <OUTPUT_FORMAT>`
+- `--type <TYPE>` — XDR type to generate
+- `--output <OUTPUT_FORMAT>`
 
   Default value: `single-base64`
 
   Possible values: `single`, `single-base64`, `json`, `json-formatted`, `text`
-
-
-
 
 ## `stellar xdr version`
 
 Print version information
 
 **Usage:** `stellar xdr version`
-
-
 
 ## `stellar completion`
 
@@ -3847,17 +3553,13 @@ To enable autocomplete in the current bash shell, run: `source <(stellar complet
 
 To enable autocomplete permanently, run: `echo "source <(stellar completion --shell bash)" >> ~/.bashrc`
 
-
 **Usage:** `stellar completion --shell <SHELL>`
 
 ###### **Options:**
 
-* `--shell <SHELL>` — The shell type
+- `--shell <SHELL>` — The shell type
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
-
-
-
 
 ## `stellar cache`
 
@@ -3867,11 +3569,9 @@ Cache for transactions and contract specs
 
 ###### **Subcommands:**
 
-* `clean` — Delete the cache
-* `path` — Show the location of the cache
-* `actionlog` — Access details about cached actions like transactions, and simulations. (Experimental. May see breaking changes at any time.)
-
-
+- `clean` — Delete the cache
+- `path` — Show the location of the cache
+- `actionlog` — Access details about cached actions like transactions, and simulations. (Experimental. May see breaking changes at any time.)
 
 ## `stellar cache clean`
 
@@ -3879,15 +3579,11 @@ Delete the cache
 
 **Usage:** `stellar cache clean`
 
-
-
 ## `stellar cache path`
 
 Show the location of the cache
 
 **Usage:** `stellar cache path`
-
-
 
 ## `stellar cache actionlog`
 
@@ -3897,10 +3593,8 @@ Access details about cached actions like transactions, and simulations. (Experim
 
 ###### **Subcommands:**
 
-* `ls` — List cached actions (transactions, simulations)
-* `read` — Read cached action
-
-
+- `ls` — List cached actions (transactions, simulations)
+- `read` — Read cached action
 
 ## `stellar cache actionlog ls`
 
@@ -3910,11 +3604,9 @@ List cached actions (transactions, simulations)
 
 ###### **Options:**
 
-* `--global` — ⚠️ Deprecated: global config is always on
-* `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
-* `-l`, `--long`
-
-
+- `--global` — ⚠️ Deprecated: global config is always on
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+- `-l`, `--long`
 
 ## `stellar cache actionlog read`
 
@@ -3924,9 +3616,7 @@ Read cached action
 
 ###### **Options:**
 
-* `--id <ID>` — ID of the cache entry
-
-
+- `--id <ID>` — ID of the cache entry
 
 ## `stellar version`
 
@@ -3936,10 +3626,8 @@ Print version information
 
 ###### **Options:**
 
-* `--only-version` — Print only the version
-* `--only-version-major` — Print only the major version
-
-
+- `--only-version` — Print only the version
+- `--only-version-major` — Print only the major version
 
 ## `stellar plugin`
 
@@ -3949,10 +3637,8 @@ The subcommand for CLI plugins
 
 ###### **Subcommands:**
 
-* `search` — Search for CLI plugins using GitHub
-* `ls` — List installed plugins
-
-
+- `search` — Search for CLI plugins using GitHub
+- `ls` — List installed plugins
 
 ## `stellar plugin search`
 
@@ -3960,15 +3646,11 @@ Search for CLI plugins using GitHub
 
 **Usage:** `stellar plugin search`
 
-
-
 ## `stellar plugin ls`
 
 List installed plugins
 
 **Usage:** `stellar plugin ls`
-
-
 
 ## `stellar ledger`
 
@@ -3978,10 +3660,8 @@ Fetch ledger information
 
 ###### **Subcommands:**
 
-* `latest` — Get the latest ledger sequence and information from the network
-* `fetch` — 
-
-
+- `latest` — Get the latest ledger sequence and information from the network
+- `fetch` —
 
 ## `stellar ledger latest`
 
@@ -3991,24 +3671,18 @@ Get the latest ledger sequence and information from the network
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of network info
-  - `json`:
-    JSON result of the RPC request
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the RPC request
-
-
-
+  - `text`: Text output of network info
+  - `json`: JSON result of the RPC request
+  - `json-formatted`: Formatted (multiline) JSON output of the RPC request
 
 ## `stellar ledger fetch`
 
@@ -4016,41 +3690,34 @@ Get the latest ledger sequence and information from the network
 
 ###### **Arguments:**
 
-* `<SEQ>` — Ledger Sequence to start fetch (inclusive)
+- `<SEQ>` — Ledger Sequence to start fetch (inclusive)
 
 ###### **Options:**
 
-* `--limit <LIMIT>` — Number of ledgers to fetch
+- `--limit <LIMIT>` — Number of ledgers to fetch
 
   Default value: `1`
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of network info
-  - `json`:
-    JSON result of the RPC request
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the RPC request
+  - `text`: Text output of network info
+  - `json`: JSON result of the RPC request
+  - `json-formatted`: Formatted (multiline) JSON output of the RPC request
 
-* `--xdr-format <XDR_FORMAT>` — Format of the xdr in the output
+- `--xdr-format <XDR_FORMAT>` — Format of the xdr in the output
 
   Default value: `json`
 
   Possible values:
-  - `json`:
-    XDR fields will be fetched as json and accessible via the headerJson and metadataJson fields
-  - `xdr`:
-    XDR fields will be fetched as xdr and accessible via the headerXdr and metadataXdr fields
-
-
-
+  - `json`: XDR fields will be fetched as json and accessible via the headerJson and metadataJson fields
+  - `xdr`: XDR fields will be fetched as xdr and accessible via the headerXdr and metadataXdr fields
 
 ## `stellar fee-stats`
 
@@ -4060,22 +3727,15 @@ Fetch network feestats
 
 ###### **Options:**
 
-* `--rpc-url <RPC_URL>` — RPC server endpoint
-* `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
-* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `-n`, `--network <NETWORK>` — Name of network to use from config
-* `--output <OUTPUT>` — Format of the output
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+- `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
 
   Possible values:
-  - `text`:
-    Text output of network info
-  - `json`:
-    JSON result of the RPC request
-  - `json-formatted`:
-    Formatted (multiline) JSON output of the RPC request
-
-
-
-
+  - `text`: Text output of network info
+  - `json`: JSON result of the RPC request
+  - `json-formatted`: Formatted (multiline) JSON output of the RPC request

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,9 @@ build-test-wasms:
 
 build-test: build-test-wasms install
 
-generate-full-help-doc:
+docs:
 	cargo run --bin doc-gen
+	./node_modules/.bin/prettier --write --log-level warn FULL_HELP_DOCS.md
 
 test: build-test
 	cargo test --workspace --exclude soroban-test
@@ -56,12 +57,15 @@ e2e-test:
 
 check:
 	cargo clippy --all-targets
+	cargo fmt --all --check
+	./node_modules/.bin/prettier --check '**/*.md' --log-level warn
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 fmt:
 	cargo fmt --all
+	./node_modules/.bin/prettier --write '**/*.md' --log-level warn
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Stellar CLI (stellar-cli)
 
-[![Apache 2.0 licensed](https://img.shields.io/badge/license-apache%202.0-blue.svg)](LICENSE)
-[![Crates.io Version](https://img.shields.io/crates/v/stellar-cli?label=version&amp;color=04ac5b)](https://crates.io/crates/stellar-cli)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/stellar/stellar-cli)
+[![Apache 2.0 licensed](https://img.shields.io/badge/license-apache%202.0-blue.svg)](LICENSE) [![Crates.io Version](https://img.shields.io/crates/v/stellar-cli?label=version&color=04ac5b)](https://crates.io/crates/stellar-cli) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/stellar/stellar-cli)
 
 This repo is home to the Stellar CLI, the command-line multi-tool for running and deploying Stellar contracts on the Stellar network.
-
 
 ## Table of Contents
 
@@ -23,6 +20,7 @@ This repo is home to the Stellar CLI, the command-line multi-tool for running an
 For installation options see below, for usage instructions [see the full help docs](FULL_HELP_DOCS.md).
 
 ## Cookbook
+
 To understand how to get the most of the Stellar CLI, see the [Stellar CLI Cookbook](https://github.com/stellar/stellar-cli/tree/main/cookbook) for recipes and a collection of resources to teach you how to use the CLI. Examples of recipes included in the CLI cookbook include: send payments, manage contract lifecycle, extend contract instance/storage/wasm, and more.
 
 ## Install
@@ -34,58 +32,69 @@ brew install stellar-cli
 ```
 
 Install the latest version from source:
+
 ```
 cargo install --locked stellar-cli
 ```
 
 Install without features that depend on additional libraries:
+
 ```
 cargo install --locked stellar-cli --no-default-features
 ```
 
 Install or run the unreleased main branch with nix:
+
 ```
 $ nix run 'github:stellar/stellar-cli' -- --help
 or install
 $ nix profile install github:stellar/stellar-cli
 ```
 
-For additional information on how to install, see instructions here on the [Developer Docs](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install). 
+For additional information on how to install, see instructions here on the [Developer Docs](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install).
 
 Use GitHub Action:
+
 ```
 uses: stellar/stellar-cli@v23.0.1
 ```
 
 ## Autocomplete
+
 The Stellar CLI supports some autocompletion. To set up, run the following commands:
 
 ```
 stellar completion --shell <SHELL>
 ```
+
 Possible SHELL values are `bash`, `elvish`, `fish`, `powershell`, `zsh`, etc.
 
 To enable autocomplete in the current bash shell, run:
+
 ```bash
 source <(stellar completion --shell bash)
 ```
 
 To enable autocomplete permanently, run:
+
 ```bash
 echo "source <(stellar completion --shell bash)" >> ~/.bashrc
 ```
 
 ## Latest Release
+
 For the latest release, see [releases](https://github.com/stellar/stellar-cli/releases).
 
 ## Upcoming Features
+
 For upcoming features, please see the [project board](https://github.com/orgs/stellar/projects/50).
 
 ## To Contribute
+
 Find issues to contribute to [here](https://github.com/stellar/stellar-cli/contribute) and review [CONTRIBUTING.md](/CONTRIBUTING.md).
 
 ## Additional Developer Resources
+
 - Developer Docs CLI Examples: https://developers.stellar.org/docs/smart-contracts/guides/cli
 - Video Tutorial on `network container`, `keys`, and `contract init`: https://developers.stellar.org/meetings/2024/06/27
 - Video Tutorial on `alias` and `snapshot`: https://developers.stellar.org/meetings/2024/09/12
-

--- a/cmd/crates/soroban-spec-typescript/README.md
+++ b/cmd/crates/soroban-spec-typescript/README.md
@@ -1,4 +1,3 @@
 # soroban-spec-json
 
-Generation of TypeScript client bindings from Soroban contract specification /
-interface.
+Generation of TypeScript client bindings from Soroban contract specification / interface.

--- a/cmd/crates/soroban-spec-typescript/ts-tests/README.md
+++ b/cmd/crates/soroban-spec-typescript/ts-tests/README.md
@@ -1,5 +1,4 @@
-Testing TS Bindings behavior
-============================
+# Testing TS Bindings behavior
 
 To run the tests in here, make sure you're running a quickstart docker container locally, then change into this directory and:
 

--- a/cmd/crates/soroban-test/README.md
+++ b/cmd/crates/soroban-test/README.md
@@ -1,29 +1,19 @@
-Soroban Test
-============
+# Soroban Test
 
 Test framework wrapping Soroban CLI.
 
 Provides a way to run tests against a local sandbox; running against RPC endpoint _coming soon_.
 
-
-Overview
-========
+# Overview
 
 - `TestEnv` is a test environment for running tests isolated from each other.
 - `TestEnv::with_default` invokes a closure, which is passed a reference to a random `TestEnv`.
-- `TestEnv::new_assert_cmd` creates an `assert_cmd::Command` for a given subcommand and sets the current
-   directory to be the same as `TestEnv`.
-- `TestEnv::cmd` is a generic function which parses a command from a string.
-   Note, however, that it uses `shlex` to tokenize the string. This can cause issues
-   for commands which contain strings with `"`s. For example, `{"hello": "world"}` becomes
-   `{hello:world}`. For that reason it's recommended to use `TestEnv::cmd_arr` instead.
-- `TestEnv::cmd_arr` is a generic function which takes an array of `&str` which is passed directly to clap.
-   This is the preferred way since it ensures no string parsing footguns.
+- `TestEnv::new_assert_cmd` creates an `assert_cmd::Command` for a given subcommand and sets the current directory to be the same as `TestEnv`.
+- `TestEnv::cmd` is a generic function which parses a command from a string. Note, however, that it uses `shlex` to tokenize the string. This can cause issues for commands which contain strings with `"`s. For example, `{"hello": "world"}` becomes `{hello:world}`. For that reason it's recommended to use `TestEnv::cmd_arr` instead.
+- `TestEnv::cmd_arr` is a generic function which takes an array of `&str` which is passed directly to clap. This is the preferred way since it ensures no string parsing footguns.
 - `TestEnv::invoke` a convenience function for using the invoke command.
 
-
-Example
-=======
+# Example
 
 ```rs
 use soroban_test::{TestEnv, Wasm};
@@ -53,7 +43,6 @@ fn invoke() {
 }
 ```
 
-Integration tests in Crate
-==============
+# Integration tests in Crate
 
 Currently all tests that require an RPC server are hidden behind a `it` feature, [found here](./tests/it/integration). To allow Rust-Analyzer to see the tests in vscode, `.vscode/settings.json`. Without RA, you can't follow through definitions and more importantly see errors before running tests.

--- a/cmd/crates/soroban-test/tests/fixtures/workspace/README.md
+++ b/cmd/crates/soroban-test/tests/fixtures/workspace/README.md
@@ -3,6 +3,7 @@
 ## Project Structure
 
 This repository uses the recommended structure for a Soroban project:
+
 ```text
 .
 ├── contracts

--- a/cmd/soroban-cli/src/utils/contract-workspace-template/README.md
+++ b/cmd/soroban-cli/src/utils/contract-workspace-template/README.md
@@ -3,6 +3,7 @@
 ## Project Structure
 
 This repository uses the recommended structure for a Soroban project:
+
 ```text
 .
 ├── contracts

--- a/cookbook/asset-management.mdx
+++ b/cookbook/asset-management.mdx
@@ -309,5 +309,5 @@ Check the balance after the clawback.
 stellar contract invoke --id mycontract -- balance --id user
 ```
 
-[stellar-cli]: https://developers.stellar.org/docs/tools/cli
-[stellar tx new set-options]: https://developers.stellar.org/docs/tools/cli/stellar-cli#stellar-tx-new-set-options
+[stellar-cli]: ../stellar-cli.mdx
+[stellar tx new set-options]: ../stellar-cli.mdx#stellar-tx-new-set-options

--- a/cookbook/asset-management.mdx
+++ b/cookbook/asset-management.mdx
@@ -7,8 +7,7 @@ custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/asset
 
 The [stellar-cli] can be used to issue and administer assets on the Stellar network.
 
-The following guide assumes that the [stellar-cli] has been configured to use
-testnet, or a local test network. To use testnet, run the following command.
+The following guide assumes that the [stellar-cli] has been configured to use testnet, or a local test network. To use testnet, run the following command.
 
 ```bash
 stellar network use testnet
@@ -24,8 +23,7 @@ To create a Stellar Asset using the [stellar-cli] several steps take place:
 
 #### Issuer Creation
 
-To create an issuer, generate a key and fund it. Funding uses friendbot, the
-testnet faucet, and is only available on testnet.
+To create an issuer, generate a key and fund it. Funding uses friendbot, the testnet faucet, and is only available on testnet.
 
 ```bash
 stellar keys generate issuer
@@ -49,14 +47,9 @@ stellar keys use issuer
 
 #### Issuer Config
 
-Issuer accounts have several configuration flags that can be toggled and affect
-all assets issued by the issuer.
+Issuer accounts have several configuration flags that can be toggled and affect all assets issued by the issuer.
 
-In this guide the issuer account will be setup with the revocable and
-clawback-enabled features will be enabled. These features allow the
-asset admin to revoke authorisation to use an asset, which has the
-effect of freezing their balance, and to clawback, which has the effect
-of forcibly burning the asset.
+In this guide the issuer account will be setup with the revocable and clawback-enabled features will be enabled. These features allow the asset admin to revoke authorisation to use an asset, which has the effect of freezing their balance, and to clawback, which has the effect of forcibly burning the asset.
 
 ```bash
 stellar tx new set-options \
@@ -66,8 +59,7 @@ stellar tx new set-options \
 
 For other options, see the manual for the [stellar tx new set-options] command.
 
-To view the tx before sending, use the `--build-only` option and pipe the
-transaction through the tx edit command:
+To view the tx before sending, use the `--build-only` option and pipe the transaction through the tx edit command:
 
 ```bash cookbooktest.ignore="because piping isn't supported"
 stellar tx new set-options \
@@ -83,32 +75,27 @@ stellar tx new set-options \
 
 Choose an asset code 1 to 12 characters long.
 
-The asset code along with the issuer account address will uniquely identify the
-asset. An issuer can issue multiple assets, distinguished by their asset code.
+The asset code along with the issuer account address will uniquely identify the asset. An issuer can issue multiple assets, distinguished by their asset code.
 
 For the rest of this guide the asset code `ABC` will be used.
 
 #### Asset Contract Setup
 
-A built-in contract exists on network for every asset. It's address is reserved
-and can be calculated using the following command.
+A built-in contract exists on network for every asset. It's address is reserved and can be calculated using the following command.
 
 ```bash
 stellar contract asset id --asset ABC:issuer
 ```
 
-The contract is not deployed automatically. Anyone can deploy the contract, it
-is not an action requiring authorisation.
+The contract is not deployed automatically. Anyone can deploy the contract, it is not an action requiring authorisation.
 
 ##### Contract Deployment
 
 Deploy the built-in asset contract.
 
-The `--asset` option specifies the name of the asset, which is in the format
-`<asset-code>:<asset-issuer>`.
+The `--asset` option specifies the name of the asset, which is in the format `<asset-code>:<asset-issuer>`.
 
-The `--alias` option stores locally an alias that can be used in subsequent
-commands to reference the contract address.
+The `--alias` option stores locally an alias that can be used in subsequent commands to reference the contract address.
 
 ```bash
 stellar contract asset deploy --asset ABC:issuer --alias mycontract
@@ -122,8 +109,7 @@ stellar contract invoke --id mycontract -- name
 
 ##### Admin Setup
 
-At this point the issuer is the admin of the contract.
-Let's create another account that'll be the admin.
+At this point the issuer is the admin of the contract. Let's create another account that'll be the admin.
 
 ```bash
 stellar keys generate admin
@@ -167,8 +153,7 @@ stellar keys fund user
 stellar keys public-key user
 ```
 
-Using the user account, trust the asset so that the user account can
-hold the asset.
+Using the user account, trust the asset so that the user account can hold the asset.
 
 ```bash
 stellar keys use user
@@ -178,8 +163,7 @@ stellar keys use user
 stellar tx new change-trust --line ABC:issuer
 ```
 
-To mint the asset to the user, use the admin account, invoke the asset
-contract's `mint` function.
+To mint the asset to the user, use the admin account, invoke the asset contract's `mint` function.
 
 ```bash
 stellar keys use admin
@@ -197,8 +181,7 @@ stellar contract invoke --id mycontract -- balance --id user
 
 #### Transfer
 
-Generate and fund a second user account that the user account from the previous
-step can transfer the asset to.
+Generate and fund a second user account that the user account from the previous step can transfer the asset to.
 
 ```bash
 stellar keys generate user2
@@ -212,8 +195,7 @@ stellar keys fund user2
 stellar keys public-key user2
 ```
 
-Using the user2 account, trust the asset so that the new user account can hold
-the asset.
+Using the user2 account, trust the asset so that the new user account can hold the asset.
 
 ```bash
 stellar keys use user2
@@ -263,10 +245,7 @@ stellar contract invoke --id mycontract -- balance --id user
 
 #### Revoke Authorization / Freeze (Admin Only)
 
-An admin can revoke a user's authorisation to use the asset. The user will
-continue to hold the balance but will be unable to transfer it or create new
-payments. Any existing liabilities, such as those created by offers created on
-Stellar, will continue to exist and could still be executed.
+An admin can revoke a user's authorisation to use the asset. The user will continue to hold the balance but will be unable to transfer it or create new payments. Any existing liabilities, such as those created by offers created on Stellar, will continue to exist and could still be executed.
 
 Using the admin, invoke the asset contract's `set_authorized` function.
 
@@ -278,8 +257,7 @@ stellar keys use admin
 stellar contract invoke --id mycontract -- set_authorized --id user --authorize false
 ```
 
-Using the user account, invoke the asset contract's `transfer` function. The
-invocation will fail because they are no longer authorized to transfer.
+Using the user account, invoke the asset contract's `transfer` function. The invocation will fail because they are no longer authorized to transfer.
 
 ```bash
 stellar keys use user

--- a/cookbook/contract-lifecycle.mdx
+++ b/cookbook/contract-lifecycle.mdx
@@ -7,7 +7,7 @@ custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/contr
 
 To manage the lifecycle of a Stellar smart contract using the CLI, follow these steps:
 
-1. Set your preferred network. For this guide, we will use `testnet`. A list of available networks can be found [here](https://developers.stellar.org/docs/networks)
+1. Set your preferred network. For this guide, we will use `testnet`. A list of available networks can be found [here](../../../networks/README.mdx)
 
 ```bash
 stellar network use testnet
@@ -41,7 +41,7 @@ This will display the resulting contract ID, e.g.:
 CBB65ZLBQBZL5IYHDHEEPCVUUMFOQUZSQKAJFV36R7TZETCLWGFTRLOQ
 ```
 
-To learn more about how to build contract `.wasm` files, take a look at our [getting started tutorial](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup).
+To learn more about how to build contract `.wasm` files, take a look at our [getting started tutorial](../../../build/smart-contracts/getting-started/setup.mdx).
 
 5. Invoke a contract function:
 

--- a/cookbook/deploy-contract.mdx
+++ b/cookbook/deploy-contract.mdx
@@ -15,6 +15,4 @@ stellar contract deploy \
     --alias <alias>
 ```
 
-:::tip
-Optionally assign an alias by replacing `<alias>` with your desired alias name for the contract. The alias is a locally stored mapping to the contract address, and can be used in other stellar-cli commands in place of the address.
-:::
+:::tip Optionally assign an alias by replacing `<alias>` with your desired alias name for the contract. The alias is a locally stored mapping to the contract address, and can be used in other stellar-cli commands in place of the address. :::

--- a/cookbook/extend-contract-storage.mdx
+++ b/cookbook/extend-contract-storage.mdx
@@ -33,6 +33,6 @@ stellar contract extend \
 
 :::info
 
-Be sure to check out our [guide on creating XDR ledger keys](../rpc/generate-ledger-keys-python.mdx) for help generating them.
+Be sure to check out our [guide on creating XDR ledger keys](../../../build/guides/rpc/generate-ledger-keys-python.mdx) for help generating them.
 
 :::

--- a/cookbook/extend-contract-wasm.mdx
+++ b/cookbook/extend-contract-wasm.mdx
@@ -31,6 +31,6 @@ stellar contract extend \
 
 :::info
 
-You can learn more about finding the correct Wasm hash for a contract instance [here (JavaScript)](../rpc/retrieve-contract-code-js.mdx) and [here (Python)](../rpc/retrieve-contract-code-python.mdx).
+You can learn more about finding the correct Wasm hash for a contract instance [here (JavaScript)](../../../build/guides/rpc/retrieve-contract-code-js.mdx) and [here (Python)](../../../build/guides/rpc/retrieve-contract-code-python.mdx).
 
 :::

--- a/cookbook/install-wasm.mdx
+++ b/cookbook/install-wasm.mdx
@@ -1,13 +1,11 @@
 ---
 title: Upload Wasm bytecode
 hide_table_of_contents: true
-description:
-  Use the Stellar CLI to upload a compiled smart contract on the ledger
+description: Use the Stellar CLI to upload a compiled smart contract on the ledger
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/install-wasm.mdx
 ---
 
-To use the Stellar CLI to upload a compiled smart contract on the ledger, use
-the `stellar contract upload` command:
+To use the Stellar CLI to upload a compiled smart contract on the ledger, use the `stellar contract upload` command:
 
 ```bash
 stellar contract upload \
@@ -18,7 +16,6 @@ stellar contract upload \
 
 :::note
 
-Note this command will return the hash ID of the Wasm bytecode, rather than an
-address for a contract instance.
+Note this command will return the hash ID of the Wasm bytecode, rather than an address for a contract instance.
 
 :::

--- a/cookbook/payments-and-assets.mdx
+++ b/cookbook/payments-and-assets.mdx
@@ -7,7 +7,7 @@ custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/payme
 
 To send payments and work with assets using the Stellar CLI, follow these steps:
 
-1. Set your preferred network. For this guide, we will use `testnet`. A list of available networks can be found [here](https://developers.stellar.org/docs/networks)
+1. Set your preferred network. For this guide, we will use `testnet`. A list of available networks can be found [here](../../../networks/README.mdx)
 
 ```bash
 stellar network use testnet
@@ -59,4 +59,4 @@ stellar contract invoke --id <ASSET_CONTRACT_ID> -- transfer --to bob --from ali
 stellar contract invoke --id <ASSET_CONTRACT_ID> -- balance --id bob
 ```
 
-For more information on the functions available to the stellar asset contract, see the [token interface code](https://developers.stellar.org/docs/tokens/token-interface#code).
+For more information on the functions available to the stellar asset contract, see the [token interface code](../../../tokens/token-interface.mdx#code)

--- a/cookbook/restore-contract-storage.mdx
+++ b/cookbook/restore-contract-storage.mdx
@@ -29,6 +29,6 @@ stellar contract restore \
 
 :::info
 
-Be sure to check out our [guide on creating XDR ledger keys](../rpc/generate-ledger-keys-python.mdx) for help generating them.
+Be sure to check out our [guide on creating XDR ledger keys](../../../build/guides/rpc/generate-ledger-keys-python.mdx) for help generating them.
 
 :::

--- a/cookbook/tx-new-create-claimable-balance.mdx
+++ b/cookbook/tx-new-create-claimable-balance.mdx
@@ -1,14 +1,11 @@
 ---
 title: Create Claimable Balance
 hide_table_of_contents: true
-description:
-  Create claimable balances with various claim predicates using the Stellar CLI
+description: Create claimable balances with various claim predicates using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-new-create-claimable-balance.mdx
 ---
 
-Claimable balances allow you to send payments that can be claimed by the
-recipient based on specific conditions. This is useful for escrow-like
-functionality, conditional payments, or time-locked transfers.
+Claimable balances allow you to send payments that can be claimed by the recipient based on specific conditions. This is useful for escrow-like functionality, conditional payments, or time-locked transfers.
 
 ## Setup
 
@@ -83,8 +80,7 @@ stellar tx new create-claimable-balance \
 
 ### Before Relative Time
 
-Create a claimable balance that must be claimed within 1 hour (3600 seconds)
-from creation:
+Create a claimable balance that must be claimed within 1 hour (3600 seconds) from creation:
 
 ```bash
 stellar tx new create-claimable-balance \
@@ -98,8 +94,7 @@ stellar tx new create-claimable-balance \
 
 ### Not Predicate
 
-Create a claimable balance that can be claimed after a certain time (NOT before
-relative time):
+Create a claimable balance that can be claimed after a certain time (NOT before relative time):
 
 ```bash
 stellar tx new create-claimable-balance \
@@ -109,8 +104,7 @@ stellar tx new create-claimable-balance \
   --claimant 'bob:{"not":{"before_relative_time":"7200"}}'
 ```
 
-This means: "Can be claimed, but NOT before 2 hours have passed" (effectively:
-can be claimed after 2 hours).
+This means: "Can be claimed, but NOT before 2 hours have passed" (effectively: can be claimed after 2 hours).
 
 ### And Predicate
 
@@ -144,8 +138,7 @@ This means: "Can be claimed within 1 hour OR after June 1, 2024".
 
 ### Mixed Claimants with Different Predicates
 
-Create a claimable balance with multiple claimants having different claim
-conditions:
+Create a claimable balance with multiple claimants having different claim conditions:
 
 ```bash
 stellar tx new create-claimable-balance \
@@ -163,8 +156,7 @@ This creates a balance where:
 
 ### Escrow-Style Payment
 
-Create an escrow where the recipient has 30 days to claim, otherwise it returns
-to sender:
+Create an escrow where the recipient has 30 days to claim, otherwise it returns to sender:
 
 ```bash
 stellar tx new create-claimable-balance \
@@ -194,19 +186,18 @@ stellar tx new create-claimable-balance \
 
 ## Understanding Predicates
 
-**Note**: Predicates must be valid JSON, so you must use proper quoting and
-escaping.
+**Note**: Predicates must be valid JSON, so you must use proper quoting and escaping.
 
 ### Predicate Types
 
-| Type                   | Description                               | Example                                 |
-| ---------------------- | ----------------------------------------- | --------------------------------------- |
-| `unconditional`        | Can be claimed anytime                    | `"unconditional"`                       |
-| `before_absolute_time` | Must claim before specific timestamp      | `{"before_absolute_time":"1735689599"}` |
-| `before_relative_time` | Must claim within X seconds from creation | `{"before_relative_time":"3600"}`       |
-| `not`                  | Negates another predicate                 | `{"not":{...}}`                         |
-| `and`                  | Both predicates must be true              | `{"and":[{...},{...}]}`                 |
-| `or`                   | Either predicate can be true              | `{"or":[{...},{...}]}`                  |
+| Type | Description | Example |
+| --- | --- | --- |
+| `unconditional` | Can be claimed anytime | `"unconditional"` |
+| `before_absolute_time` | Must claim before specific timestamp | `{"before_absolute_time":"1735689599"}` |
+| `before_relative_time` | Must claim within X seconds from creation | `{"before_relative_time":"3600"}` |
+| `not` | Negates another predicate | `{"not":{...}}` |
+| `and` | Both predicates must be true | `{"and":[{...},{...}]}` |
+| `or` | Either predicate can be true | `{"or":[{...},{...}]}` |
 
 ### Time Format Notes
 
@@ -251,9 +242,7 @@ stellar tx new create-claimable-balance \
 
 - `--amount`: Amount in stroops (1 XLM = 10,000,000 stroops)
 - `--asset`: Use "native" for XLM or "CODE:ISSUER" format for other assets
-- `--claimant`: Account with optional predicate (can be specified multiple
-  times)
-- Predicates are evaluated when the claimable balance is claimed, not when
-  created
+- `--claimant`: Account with optional predicate (can be specified multiple times)
+- Predicates are evaluated when the claimable balance is claimed, not when created
 - `And` and `Or` predicates must have exactly 2 sub-predicates
 - Complex predicates can be nested to create sophisticated claim conditions

--- a/cookbook/tx-new.mdx
+++ b/cookbook/tx-new.mdx
@@ -33,7 +33,7 @@ stellar network use testnet
 
 ### Create Account
 
-Creates and funds a new Stellar account. Above `alice` was funded by [friendbot](https://developers.stellar.org/docs/learn/fundamentals/networks#friendbot). However, `bob` and `charlie` were not. So we can use the `create-account` command to fund them.
+Creates and funds a new Stellar account. Above `alice` was funded by [friendbot](../../../learn/fundamentals/networks.mdx#friendbot). However, `bob` and `charlie` were not. So we can use the `create-account` command to fund them.
 
 `bob` will receive 10 XLM and `charlie` will get 1 XLM.
 
@@ -184,4 +184,3 @@ stellar tx new manage-data \
 Notes:
 - `--data-name`: Name of the data entry (up to 64 bytes)
 - `--data-value`: Hex encoded value to store (up to 64 bytes, omit to delete)
-```

--- a/cookbook/tx-new.mdx
+++ b/cookbook/tx-new.mdx
@@ -5,8 +5,7 @@ description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-new.mdx
 ---
 
-So far the examples of the CLI interacting with the blockchain have been through the `contract` command. Uploading contracts, deploying contracts, and invoking them.
-Each of these are different types of transactions, which must be signed and submitted to the network (and in the case of contract related transactions simulated first).
+So far the examples of the CLI interacting with the blockchain have been through the `contract` command. Uploading contracts, deploying contracts, and invoking them. Each of these are different types of transactions, which must be signed and submitted to the network (and in the case of contract related transactions simulated first).
 
 Technically these three are different operations, of which a transaction can contain up to 100 operations. However, in the case of contract related operations a transaction is limited to just one.
 
@@ -16,7 +15,6 @@ So for all other transactions the CLI provides the `tx` subcommands. These are:
 - `sign`
 - `send`
 - `simulate`
-
 
 ## `tx new`
 
@@ -50,6 +48,7 @@ stellar tx new create-account \
 ```
 
 Notes:
+
 - `--starting-balance`: Initial balance in stroops to fund the account with (1 XLM = 10,000,000 stroops)
 
 ### Payment
@@ -65,8 +64,8 @@ stellar tx new payment \
 ```
 
 Notes:
-- `--asset`: The asset to send - either "native" for XLM or "CODE:ISSUER" format for other assets
 
+- `--asset`: The asset to send - either "native" for XLM or "CODE:ISSUER" format for other assets
 
 ### Bump Sequence
 
@@ -77,7 +76,6 @@ stellar tx new bump-sequence \
   --source alice \
   --bump-to 123450
 ```
-
 
 ### Account Merge
 
@@ -92,6 +90,7 @@ stellar tx new account-merge \
 ```
 
 Notes:
+
 - `--source`: The account to remove from the ledger, thus this is its final tranaction
 
 ### Set Trustline Flags
@@ -109,6 +108,7 @@ stellar tx new set-trustline-flags \
 ```
 
 Arguments:
+
 - `--source`: The issuing account setting the flags (must be the asset issuer)
 - `--asset`: The asset in CODE:ISSUER format
 - `--trustor`: The account whose trustline flags to modify
@@ -139,6 +139,7 @@ stellar tx new set-options \
 ```
 
 Notes:
+
 - `--source`: Account to modify settings for
 - `--inflation-dest`: Set inflation destination account
 - `--home-domain`: Set home domain for federation/compliance
@@ -166,6 +167,7 @@ stellar tx new change-trust \
 ```
 
 Arguments:
+
 - `--source`: Account creating/modifying the trustline
 - `--line`: Asset to create trustline for in CODE:ISSUER format
 - `--limit`: Maximum amount that can be held (0 removes trustline)
@@ -182,5 +184,6 @@ stellar tx new manage-data \
 ```
 
 Notes:
+
 - `--data-name`: Name of the data entry (up to 64 bytes)
 - `--data-value`: Hex encoded value to store (up to 64 bytes, omit to delete)

--- a/cookbook/tx-op-add.mdx
+++ b/cookbook/tx-op-add.mdx
@@ -5,8 +5,7 @@ description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-op-add.mdx
 ---
 
-As seen before you can use pipes to pass a transaction envelope between commands. Before we have only been looking at transactions with one operation,
-however, as mentioned there can be up to 100 operations in a single transaction.
+As seen before you can use pipes to pass a transaction envelope between commands. Before we have only been looking at transactions with one operation, however, as mentioned there can be up to 100 operations in a single transaction.
 
 To add an operation to a transaction you can use the `tx op add` command. This command takes the transaction envolope from the previous command and adds an operation to it.
 
@@ -15,7 +14,7 @@ Let's consider a more complicated example. Consider issuing an asset, here `USDC
 ```sh
 
 stellar keys generate --fund issuer
-stellar keys generate --fund distributor 
+stellar keys generate --fund distributor
 
 ISSUER_PK=$(stellar keys address issuer)
 
@@ -39,7 +38,7 @@ stellar tx new set-options --fee 1000 --source issuer --set-clawback-enabled --s
 | stellar tx sign --sign-with-key distributor \
 | stellar tx send
 
-# Next is an example of sandwiching an operation. That is giving permission in one operation, preforming the operation, and then removing the permission in a third operation. 
+# Next is an example of sandwiching an operation. That is giving permission in one operation, preforming the operation, and then removing the permission in a third operation.
 # Here is an example of minting new assets to the distributor with a sandwich transaction
 # First authorize the distributor to receive the asset
 stellar tx new set-trustline-flags --fee 1000 --build-only --source issuer --asset $ASSET --trustor $distributor_PK --set-authorize \

--- a/cookbook/tx-sign.mdx
+++ b/cookbook/tx-sign.mdx
@@ -5,14 +5,14 @@ description: Create stellar transactions using the Stellar CLI
 custom_edit_url: https://github.com/stellar/stellar-cli/edit/main/cookbook/tx-sign.mdx
 ---
 
-The previous examples of using `tx new` showed how to create transactions. However, these transactions were immediately ready to be signed and submitted to the network. 
+The previous examples of using `tx new` showed how to create transactions. However, these transactions were immediately ready to be signed and submitted to the network.
 
 To avoid this each of the subcommands has the `--build-only` argument, which as the name suggests only builds the transaction and prints the transaction envelope.
 
 ## `tx sign`
 
 Let's return to the first example of creating `bob`s account:
-  
+
   ```sh
 stellar tx new create-account \
     --source alice \
@@ -21,7 +21,7 @@ stellar tx new create-account \
     --build-only
   ```
   would output something like:
-  
+
 ```sh
 AAAAAgAAAADwSUp9CwmVlPN40mKX1I1j39y6DmYc36QS1aK2x6eYVQAAAGQAEcMsAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAACTMkzn1TwPo8SIhnKvnyuv9K2/aWjpX9NTYfyiA7vXaAAAAAAX14QAAAAAAAAAAAA==
 ```
@@ -46,8 +46,10 @@ AAAAAgAAAAAebE8Ewg9uzvHRAl+UmvP0kixsyp238kkz0zOy+91FeQAAAGQAFJk4AAAAAQAAAAAAAAAA
 ```
 You can again [view it in lab and see that there is now a signature attached to the transaction envelope](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAAebE8Ewg9uzvHRAl+UmvP0kixsyp238kkz0zOy+91FeQAAAGQAFJk4AAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAPpiy8qfSw4pLYG//Bav78FfrFWlte7YQfiHX41DQ+nGWAAAAAAX14QAAAAAAAAAAAfvdRXkAAABA4kjz9Yeub//IrzogjMr57U4nYwCmSJAXxIW+7Xyjan//UweIByF7uEhVS4gEl1N138uq07njVxZwRMtugWyMleCg==;;).
 
-::tip
+:::tip
+
 Or sign with lab! Though currently you must send it from lab and cannot return to the CLI (a work in progress!).
+
 ```sh
 stellar tx new create-account \
     --source alice \
@@ -56,6 +58,7 @@ stellar tx new create-account \
     --build-only \
   | stellar tx sign --sign-with-lab
 ```
+
 :::
 
 ## `tx send`

--- a/cookbook/tx-sign.mdx
+++ b/cookbook/tx-sign.mdx
@@ -13,14 +13,15 @@ To avoid this each of the subcommands has the `--build-only` argument, which as 
 
 Let's return to the first example of creating `bob`s account:
 
-  ```sh
+```sh
 stellar tx new create-account \
-    --source alice \
-    --destination bob \
-    --starting-balance 100_000_000 \
-    --build-only
-  ```
-  would output something like:
+  --source alice \
+  --destination bob \
+  --starting-balance 100_000_000 \
+  --build-only
+```
+
+would output something like:
 
 ```sh
 AAAAAgAAAADwSUp9CwmVlPN40mKX1I1j39y6DmYc36QS1aK2x6eYVQAAAGQAEcMsAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAACTMkzn1TwPo8SIhnKvnyuv9K2/aWjpX9NTYfyiA7vXaAAAAAAX14QAAAAAAAAAAAA==
@@ -44,6 +45,7 @@ This should output something like:
 ```sh
 AAAAAgAAAAAebE8Ewg9uzvHRAl+UmvP0kixsyp238kkz0zOy+91FeQAAAGQAFJk4AAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAPpiy8qfSw4pLYG/Bav78FfrFWlte7YQfiHX41DQ+nGWAAAAAAX14QAAAAAAAAAAAfvdRXkAAABA4kjz9Yeub/IrzogjMr57U4nYwCmSJAXxIW+7Xyjan/UweIByF7uEhVS4gEl1N138uq07njVxZwRMtugWyMleCg==
 ```
+
 You can again [view it in lab and see that there is now a signature attached to the transaction envelope](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAgAAAAAebE8Ewg9uzvHRAl+UmvP0kixsyp238kkz0zOy+91FeQAAAGQAFJk4AAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAPpiy8qfSw4pLYG//Bav78FfrFWlte7YQfiHX41DQ+nGWAAAAAAX14QAAAAAAAAAAAfvdRXkAAABA4kjz9Yeub//IrzogjMr57U4nYwCmSJAXxIW+7Xyjan//UweIByF7uEhVS4gEl1N138uq07njVxZwRMtugWyMleCg==;;).
 
 :::tip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "stellar-cli",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@stellar/prettier-config": "^1.2.0",
+        "prettier": "^3.6.2"
+      }
+    },
+    "node_modules/@stellar/prettier-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/prettier-config/-/prettier-config-1.2.0.tgz",
+      "integrity": "sha512-oL9qJ7+7aWnImpbcldroQrvtMCZ9yx4JL/tmDZ860RpBQd2ahkc8bX6/k2ehFK8gpb9ltYu4mtU49wufUuYhGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "prettier": "^3.2.5"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@stellar/prettier-config": "^1.2.0",
+    "prettier": "^3.6.2"
+  }
+}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  ...require("@stellar/prettier-config"),
+  // This is mostly content, and prose wrap has a way of exploding markdown
+  // diffs. Override the default for a better experience.
+  overrides: [
+    {
+      files: "*.md",
+      options: {
+        proseWrap: "never",
+      },
+    },
+  ],
+};


### PR DESCRIPTION
### What

Change some of the documentation links in the cookbook files.

### Why

We're currently in the process of moving the cookbook files in the docs site closer to the CLI manual (stellar/stellar-docs#1834). These links will then be incorrect, and could cause the docs build to fail.

### Known limitations

I've replaced full URLS (`https://developers.stellar.org/docs/path/whatever`) with relative URLs (`../path/whatever`) anywhere i saw it in the cookbook files. (commit 423c46a for reference). I could definitely see some benefit to having them as full URLs here in the CLI repo, though. So, if it'd be better, i can revert that change and change any other relative URLs to full URLs.

I've also run these cookbook files through the same markdown linter/formatter we use in the docs, just to get the styles consistent.

To test this out, I've (manually) copied the cookbook files into the docs working branch and made sure everything builds and links work properly.
