### PR TITLE
Update error messaging when a container is already running

### DIFF
--- a/cmd/soroban-cli/src/commands/container/start.rs
+++ b/cmd/soroban-cli/src/commands/container/start.rs
@@ -28,6 +28,9 @@ pub enum Error {
 
     #[error("⛔ ️Failed to create container: {0}")]
     CreateContainerFailed(#[from] bollard::errors::Error),
+
+    #[error("⛔ ️ a container named {0:?} already running")]
+    ContainerAlreadyRunning(String),
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -139,7 +142,17 @@ impl Runner {
                 }),
                 config,
             )
-            .await?;
+            .await.map_err(|e| {
+                match &e {
+                    bollard::errors::Error::DockerResponseServerError { status_code, .. } => {
+                        if *status_code == 409 {
+                            return Error::ContainerAlreadyRunning(self.container_name().get_internal_container_name());
+                        }
+                        return Error::CreateContainerFailed(e)
+                    },
+                    _ => return Error::CreateContainerFailed(e)
+                }
+            })?;
 
         docker
             .start_container(


### PR DESCRIPTION
### What

Return a custom error if a user calls `stellar container start` before docker has finished cleaning up the container.


### Why

We previously were just returning the internal bollard error message which isn't super easy to read.

```
❌ error: ⛔ ️Failed to create container: Docker responded with status code 409: Conflict. The container name "/stellar-local" is already in use by container "269170efd31f922fcdc2ea4c237ecf6b104f33f6f2bd4833d0e6f4d28d2ba279". You have to remove (or rename) that container to be able to reuse that name.
```

### Known limitations

We still may have an issue where doing this results in the bollard error mentioned above, and maybe it should be handled more gracefully than that. But hopefully this PR will at least make it clearer what is going on.

```
stellar container stop local && stellar container start local
```