### PR TITLE
Add data dir to `stellar doctor`.

### DIFF
--- a/cmd/soroban-cli/src/commands/doctor.rs
+++ b/cmd/soroban-cli/src/commands/doctor.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use crate::{
     commands::global,
     config::{
-        self,
+        self, data,
         locator::{self, KeyType},
         network::{Network, DEFAULTS as DEFAULT_NETWORKS},
     },
@@ -36,6 +36,9 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Data(#[from] data::Error),
 }
 
 impl Cmd {
@@ -46,6 +49,7 @@ impl Cmd {
         check_rust_version(&print);
         check_wasm_target(&print);
         show_config_path(&print, &self.config_locator)?;
+        show_data_path(&print)?;
         show_xdr_version(&print);
         inspect_networks(&print, &self.config_locator).await?;
 
@@ -60,6 +64,14 @@ fn show_config_path(print: &Print, config_locator: &locator::Args) -> Result<(),
         "Config directory: {}",
         global_path.to_string_lossy()
     ));
+
+    Ok(())
+}
+
+fn show_data_path(print: &Print) -> Result<(), Error> {
+    let path = data::data_local_dir()?;
+
+    print.dirln(format!("Data directory: {}", path.to_string_lossy()));
 
     Ok(())
 }

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -118,3 +118,4 @@ create_print_functions!(log, logln, "📔");
 create_print_functions!(event, eventln, "📅");
 create_print_functions!(blank, blankln, " ");
 create_print_functions!(gear, gearln, "⚙️");
+create_print_functions!(dir, dirln, "📁");


### PR DESCRIPTION
### What

```console
$ stellar doctor
✅ You are using the latest version of Stellar CLI: 23.1.4
ℹ️ Rust version: 1.89.0
✅ Rust target `wasm32v1-none` is installed
⚙️ Config directory: /Users/fnando/.config/stellar
📁 Data directory: /Users/fnando/.local/share/stellar-cli
ℹ️ XDR version: 4b7a2ef7931ab2ca2499be68d849f38190b443ca
🌎 Default network "local" (http://localhost:8000/rpc)
   protocol 23
   rpc f225766c37ffa46b7e456054280f973ecb19b07
🌎 Default network "futurenet" (https://rpc-futurenet.stellar.org:443)
   protocol 23
   rpc 23.0.4-7c2b6f34c6b5f953d574e1b4f0ca0cf4ee78cf97
🌎 Default network "testnet" (https://soroban-testnet.stellar.org)
   protocol 23
   rpc 23.0.4-7c2b6f34c6b5f953d574e1b4f0ca0cf4ee78cf97
🌎 Network "dev" (http://localhost:8000/rpc)
   protocol 23
   rpc f225766c37ffa46b7e456054280f973ecb19b07
🌎 Network "pubnet" (https://mainnet.sorobanrpc.com)
   protocol 23
   rpc 23.0.4-7c2b6f34c6b5f953d574e1b4f0ca0cf4ee78cf97
🌎 Network "standalone" (http://localhost:8000/rpc)
   protocol 23
   rpc f225766c37ffa46b7e456054280f973ecb19b07
```

### Why

Snapshots are stored there, so it's helpful to know where the files are actually being stored.

### Known limitations

N/A