### PR TITLE
Ensure snapshot's bucket cache is not corrupted.

### DIFF
--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -671,7 +671,7 @@ async fn cache_bucket(
 
     // Validate cached bucket if it exists
     if cache_path.exists() {
-        if let Err(_) = validate_bucket_hash(&cache_path, bucket) {
+        if validate_bucket_hash(&cache_path, bucket).is_err() {
             print.warnln(format!(
                 "Cached bucket {bucket} is corrupted, re-downloading"
             ));


### PR DESCRIPTION
### What

```console
# while running the command below
$ truncate -s 0 /Users/fnando/.local/share/stellar-cli/bucket/bucket-f10cc0c81fcea299e9fe0806d0921d086362a1b11c8757b236468deb1abc97fe.xdr

$ stellar snapshot create --network pubnet --address CATRNPHYKNXAPNLHEYH55REB6YSAJLGCPA4YM6L3WUKSZOPI77M2UMKI --output json --out /tmp/sorobandomains.json
🌎 Downloading history https://history.stellar.org/prd/core-live/core_live_001/.well-known
🌎 Downloaded history https://history.stellar.org/prd/core-live/core_live_001/.well-known/stellar-history.json
ℹ️ Ledger: 59262079
ℹ️ Network Passphrase: Public Global Stellar Network ; September 2015
ℹ️ Network id: 7ac33997544e3175d266bd022439b22cdb16508c01163f26e5cb2a3e1045a979
🌎 Downloading ledger headers https://history.stellar.org/prd/core-live/core_live_001/ledg
🌎 Downloaded ledger headers for ledger 59262079
ℹ️ Ledger Close Time: 1759779768
ℹ️ Base Reserve: 5000000
🌎 Downloaded bucket 0 9d849e54ebdc0542478959d2ad0af7fb6116c255a9d7543bb4cf66cd5b5dc7b4 (108.1 KB)
🌎 Downloaded bucket 1 dadf5673d018ac7582cc8418eef0a17c666ef1d1f9710eaf1fd7597a94197b5e (107.1 KB)
🌎 Downloaded bucket 2 985661017c5510b5d02093e0eeb520f7c72f636752d3318aacaec6d9749be5e1 (315.2 KB)
🌎 Downloaded bucket 3 a46f30676e434dd364ae789fb4bb00808a0873ba14e3b5234a06c4cb1b6cd2b3 (334.7 KB)
🌎 Downloaded bucket 4 070fd13a70c7539957842a01b5202bf699b5a274936971e661aa5005ced02977 (1.5 MB)
🌎 Downloaded bucket 5 ac32d301a2112f1ff11c60725778fe7bb6248a625f8c1ee907a725fd89e22de0 (1.2 MB)
🌎 Downloaded bucket 6 cc90317e669790d3577dcf9085699608c626b622e58f1a163edd026e196a0e25 (2.8 MB)
🌎 Downloaded bucket 7 d4b66f0fa326779ad3a4aa3418e0be9e3251fb17d5ab49615220cadc7dde4eef (1.7 MB)
🌎 Downloaded bucket 8 c0fa30ce1397c11b1cf5aa60717c5a08cf8ac85597e0307cca349fb1a53342be (1.8 MB)
🌎 Downloaded bucket 9 ce09e7d69fe57fae7080f37ae03f8dab09418cd50906645e320f686b2c9765ea (4.8 MB)
🌎 Downloaded bucket 10 a867e479dfb74105008df8f9c07964b7cbbd4a4f0c5cfbb01afef32d07e2f45c (32.1 MB)
🌎 Downloaded bucket 14 f10cc0c81fcea299e9fe0806d0921d086362a1b11c8757b236468deb1abc97fe (214.4 MB)
ℹ️ Searching for 0 accounts, 1 contracts, 0 wasms
🔎 Searching bucket 0 9d849e54ebdc0542478959d2ad0af7fb6116c255a9d7543bb4cf66cd5b5dc7b4 (349.1 KB)
ℹ️ Protocol version: 23
ℹ️ Found 1 entries
🔎 Searching bucket 1 dadf5673d018ac7582cc8418eef0a17c666ef1d1f9710eaf1fd7597a94197b5e (346.1 KB)
🔎 Searching bucket 2 985661017c5510b5d02093e0eeb520f7c72f636752d3318aacaec6d9749be5e1 (910.3 KB)
🔎 Searching bucket 3 a46f30676e434dd364ae789fb4bb00808a0873ba14e3b5234a06c4cb1b6cd2b3 (1005.1 KB)
🔎 Searching bucket 4 070fd13a70c7539957842a01b5202bf699b5a274936971e661aa5005ced02977 (4.2 MB)
🔎 Searching bucket 5 ac32d301a2112f1ff11c60725778fe7bb6248a625f8c1ee907a725fd89e22de0 (3.8 MB)
ℹ️ Found 1 entries
🔎 Searching bucket 6 cc90317e669790d3577dcf9085699608c626b622e58f1a163edd026e196a0e25 (9.6 MB)
🔎 Searching bucket 7 d4b66f0fa326779ad3a4aa3418e0be9e3251fb17d5ab49615220cadc7dde4eef (7.2 MB)
🔎 Searching bucket 8 c0fa30ce1397c11b1cf5aa60717c5a08cf8ac85597e0307cca349fb1a53342be (7.6 MB)
🔎 Searching bucket 9 ce09e7d69fe57fae7080f37ae03f8dab09418cd50906645e320f686b2c9765ea (21.1 MB)
🔎 Searching bucket 10 a867e479dfb74105008df8f9c07964b7cbbd4a4f0c5cfbb01afef32d07e2f45c (128.4 MB)
🔎 Searching bucket 11 572e91a72d600fa0a2ed211e0c41343a888e9273c4faeaf573d57c59b8b220ed (120.5 MB)
🔎 Searching bucket 12 cab6060199f28ccb2dff394c3797f108ee00938ee9cfdeeb8c318f7cdaa1e621 (86.9 MB)
ℹ️ Found 1 entries
🔎 Searching bucket 13 3fd61ec9d0a4b2f76f265167b49f64db0979b4ebc3c78580a3e7feb3e791637d (325.9 MB)
ℹ️ Found 11 entries
⚠️ Cached bucket f10cc0c81fcea299e9fe0806d0921d086362a1b11c8757b236468deb1abc97fe is corrupted, re-downloading
🌎 Downloaded bucket 14 f10cc0c81fcea299e9fe0806d0921d086362a1b11c8757b236468deb1abc97fe (214.4 MB)
🔎 Searching bucket 14 f10cc0c81fcea299e9fe0806d0921d086362a1b11c8757b236468deb1abc97fe (656.2 MB)
ℹ️ Found 2 entries
^C
```

### Why

Fix #2208

### Known limitations

N/A
