### PR TITLE
Deprecate `stellar contract optimize` in favor of `stellar contract build --optimize`.

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -89,11 +89,11 @@ Tools for smart contract developers
 - `id` — Generate the contract id for a given contract or asset
 - `info` — Access info about contracts
 - `init` — Initialize a Soroban contract project
-- `inspect` — (Deprecated in favor of `contract info` subcommand) Inspect a WASM file listing contract functions, meta, etc
+- `inspect` — (Deprecated, use `contract info`) Inspect a WASM file listing contract functions, meta, etc
 - `upload` — Install a WASM file to the ledger without creating a contract instance
-- `install` — (Deprecated in favor of `contract upload` subcommand) Install a WASM file to the ledger without creating a contract instance
+- `install` — (Deprecated, use `contract upload`) Install a WASM file to the ledger without creating a contract instance
 - `invoke` — Invoke a contract function
-- `optimize` — (Deprecated in favor of `build --optimize` subcommand) Optimize a WASM file
+- `optimize` — (Deprecated, use `build --optimize`) Optimize a WASM file
 - `read` — Print the current value of a contract-data ledger entry
 - `restore` — Restore an evicted value for a contract-data legder entry
 
@@ -662,7 +662,7 @@ This command will create a Cargo workspace project and add a sample Stellar cont
 
 ## `stellar contract inspect`
 
-(Deprecated in favor of `contract info` subcommand) Inspect a WASM file listing contract functions, meta, etc
+(Deprecated, use `contract info`) Inspect a WASM file listing contract functions, meta, etc
 
 **Usage:** `stellar contract inspect [OPTIONS] --wasm <WASM>`
 
@@ -714,7 +714,7 @@ Install a WASM file to the ledger without creating a contract instance
 
 ## `stellar contract install`
 
-(Deprecated in favor of `contract upload` subcommand) Install a WASM file to the ledger without creating a contract instance
+(Deprecated, use `contract upload`) Install a WASM file to the ledger without creating a contract instance
 
 **Usage:** `stellar contract install [OPTIONS] --source-account <SOURCE_ACCOUNT> --wasm <WASM>`
 
@@ -790,7 +790,7 @@ stellar contract invoke ... -- --help
 
 ## `stellar contract optimize`
 
-(Deprecated in favor of `build --optimize` subcommand) Optimize a WASM file
+(Deprecated, use `build --optimize`) Optimize a WASM file
 
 **Usage:** `stellar contract optimize [OPTIONS] --wasm <WASM>...`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -93,7 +93,7 @@ Tools for smart contract developers
 - `upload` — Install a WASM file to the ledger without creating a contract instance
 - `install` — (Deprecated in favor of `contract upload` subcommand) Install a WASM file to the ledger without creating a contract instance
 - `invoke` — Invoke a contract function
-- `optimize` — Optimize a WASM file
+- `optimize` — (Deprecated in favor of `build --optimize` subcommand) Optimize a WASM file
 - `read` — Print the current value of a contract-data ledger entry
 - `restore` — Restore an evicted value for a contract-data legder entry
 
@@ -357,6 +357,7 @@ To view the commands that will be executed, without executing them, use the --pr
 
 - `--print-commands-only` — Print commands to build without executing them
 - `--meta <META>` — Add key-value to contract meta (adds the meta to the `contractmetav0` custom section)
+- `--optimize` — Optimize the generated wasm
 
 ## `stellar contract extend`
 
@@ -789,7 +790,7 @@ stellar contract invoke ... -- --help
 
 ## `stellar contract optimize`
 
-Optimize a WASM file
+(Deprecated in favor of `build --optimize` subcommand) Optimize a WASM file
 
 **Usage:** `stellar contract optimize [OPTIONS] --wasm <WASM>...`
 

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -265,8 +265,8 @@ impl Cmd {
                     optimize::optimize(true, vec![final_path.clone()], Some(path.clone()))?;
                     optimized_wasm_bytes = fs::read(&path).map_err(Error::ReadingWasmFile)?;
 
-                    fs::copy(&path, &final_path).map_err(Error::CopyingWasmFile)?;
-                    fs::remove_file(&path).map_err(Error::DeletingArtifact)?;
+                    fs::remove_file(&final_path).map_err(Error::DeletingArtifact)?;
+                    fs::rename(&path, &final_path).map_err(Error::CopyingWasmFile)?;
                 }
 
                 Self::print_build_summary(&print, &final_path, wasm_bytes, optimized_wasm_bytes);

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -398,7 +398,7 @@ impl Cmd {
         let optimized_size = optimized_wasm_bytes.len();
 
         let size_description = if optimized_size > 0 {
-            format!("{optimized_size} bytes (original size was {size} bytes)")
+            format!("{optimized_size} bytes optimized (original size was {size} bytes)")
         } else {
             format!("{size} bytes")
         };

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -81,7 +81,7 @@ pub enum Cmd {
     ///     stellar contract invoke ... -- --help
     Invoke(invoke::Cmd),
 
-    /// Optimize a WASM file
+    /// (Deprecated in favor of `build --optimize` subcommand) Optimize a WASM file
     Optimize(optimize::Cmd),
 
     /// Print the current value of a contract-data ledger entry
@@ -165,7 +165,7 @@ impl Cmd {
             }
             Cmd::Upload(upload) => upload.run(global_args).await?,
             Cmd::Invoke(invoke) => invoke.run(global_args).await?,
-            Cmd::Optimize(optimize) => optimize.run()?,
+            Cmd::Optimize(optimize) => optimize.run(global_args)?,
             Cmd::Fetch(fetch) => fetch.run().await?,
             Cmd::Read(read) => read.run().await?,
             Cmd::Restore(restore) => restore.run().await?,

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -61,14 +61,14 @@ pub enum Cmd {
     /// be overwritten unless `--overwrite` is passed.
     Init(init::Cmd),
 
-    /// (Deprecated in favor of `contract info` subcommand) Inspect a WASM file listing contract functions, meta, etc
+    /// (Deprecated, use `contract info`) Inspect a WASM file listing contract functions, meta, etc
     #[command(display_order = 100)]
     Inspect(inspect::Cmd),
 
     /// Install a WASM file to the ledger without creating a contract instance
     Upload(upload::Cmd),
 
-    /// (Deprecated in favor of `contract upload` subcommand) Install a WASM file to the ledger without creating a contract instance
+    /// (Deprecated, use `contract upload`) Install a WASM file to the ledger without creating a contract instance
     Install(upload::Cmd),
 
     /// Invoke a contract function
@@ -81,7 +81,7 @@ pub enum Cmd {
     ///     stellar contract invoke ... -- --help
     Invoke(invoke::Cmd),
 
-    /// (Deprecated in favor of `build --optimize` subcommand) Optimize a WASM file
+    /// (Deprecated, use `build --optimize`) Optimize a WASM file
     Optimize(optimize::Cmd),
 
     /// Print the current value of a contract-data ledger entry

--- a/cmd/soroban-cli/src/commands/contract/optimize.rs
+++ b/cmd/soroban-cli/src/commands/contract/optimize.rs
@@ -3,6 +3,8 @@ use std::{fmt::Debug, path::PathBuf};
 #[cfg(feature = "additional-libs")]
 use wasm_opt::{Feature, OptimizationError, OptimizationOptions};
 
+#[cfg(feature = "additional-libs")]
+use crate::commands::global;
 use crate::wasm;
 
 #[derive(Parser, Debug, Clone)]
@@ -36,60 +38,77 @@ pub enum Error {
 
 impl Cmd {
     #[cfg(not(feature = "additional-libs"))]
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run(&self, _global_args: &global::Args) -> Result<(), Error> {
         Err(Error::Install)
     }
 
     #[cfg(feature = "additional-libs")]
-    pub fn run(&self) -> Result<(), Error> {
-        if self.wasm.len() > 1 && self.wasm_out.is_some() {
-            return Err(Error::MultipleFilesOutput);
-        }
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        use crate::print::Print;
 
-        for wasm_path in &self.wasm {
-            let wasm_arg = wasm::Args {
-                wasm: wasm_path.into(),
-            };
-            let wasm_size = wasm_arg.len()?;
+        let print = Print::new(global_args.quiet);
+        print
+            .warnln("`stellar contract optimize` is deprecated and will be removed in the future. Use `stellar contract build --optimize` instead.");
 
-            println!(
-                "Reading: {} ({} bytes)",
-                wasm_arg.wasm.to_string_lossy(),
-                wasm_size
-            );
-
-            let wasm_out = self.wasm_out.clone().unwrap_or_else(|| {
-                let mut wasm_out = wasm_arg.wasm.clone();
-                wasm_out.set_extension("optimized.wasm");
-                wasm_out
-            });
-
-            let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
-            options.converge = true;
-
-            // Explicitly set to MVP + sign-ext + mutable-globals, which happens to
-            // also be the default featureset, but just to be extra clear we set it
-            // explicitly.
-            //
-            // Formerly Soroban supported only the MVP feature set, but Rust 1.70 as
-            // well as Clang generate code with sign-ext + mutable-globals enabled,
-            // so Soroban has taken a change to support them also.
-            options.mvp_features_only();
-            options.enable_feature(Feature::MutableGlobals);
-            options.enable_feature(Feature::SignExt);
-
-            options
-                .run(&wasm_arg.wasm, &wasm_out)
-                .map_err(Error::OptimizationError)?;
-
-            let wasm_out_size = wasm::len(&wasm_out)?;
-            println!(
-                "Optimized: {} ({} bytes)",
-                wasm_out.to_string_lossy(),
-                wasm_out_size
-            );
-        }
-
-        Ok(())
+        optimize(false, self.wasm.clone(), self.wasm_out.clone())
     }
+}
+
+#[cfg(feature = "additional-libs")]
+pub fn optimize(
+    quiet: bool,
+    wasm: Vec<PathBuf>,
+    wasm_out: Option<std::path::PathBuf>,
+) -> Result<(), Error> {
+    if wasm.len() > 1 && wasm_out.is_some() {
+        return Err(Error::MultipleFilesOutput);
+    }
+
+    for wasm_path in &wasm {
+        let wasm_arg = wasm::Args {
+            wasm: wasm_path.into(),
+        };
+
+        if !quiet {
+            println!(
+                "Reading: {path} ({wasm_size} bytes)",
+                path = wasm_arg.wasm.to_string_lossy(),
+                wasm_size = wasm_arg.len()?
+            );
+        }
+
+        let wasm_out = wasm_out.clone().unwrap_or_else(|| {
+            let mut wasm_out = wasm_arg.wasm.clone();
+            wasm_out.set_extension("optimized.wasm");
+            wasm_out
+        });
+
+        let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
+        options.converge = true;
+
+        // Explicitly set to MVP + sign-ext + mutable-globals, which happens to
+        // also be the default featureset, but just to be extra clear we set it
+        // explicitly.
+        //
+        // Formerly Soroban supported only the MVP feature set, but Rust 1.70 as
+        // well as Clang generate code with sign-ext + mutable-globals enabled,
+        // so Soroban has taken a change to support them also.
+        options.mvp_features_only();
+        options.enable_feature(Feature::MutableGlobals);
+        options.enable_feature(Feature::SignExt);
+
+        options
+            .run(&wasm_arg.wasm, &wasm_out)
+            .map_err(Error::OptimizationError)?;
+
+        if !quiet {
+            println!(
+                "Optimized: {path} ({size} bytes)",
+                path = wasm_out.to_string_lossy(),
+                size = wasm::len(&wasm_out)?
+            );
+        }
+    }
+
+    Ok(())
 }

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -116,6 +116,6 @@ create_print_functions!(exclaim, exclaimln, "❗️");
 create_print_functions!(arrow, arrowln, "➡️");
 create_print_functions!(log, logln, "📔");
 create_print_functions!(event, eventln, "📅");
-create_print_functions!(blank, blankln, " ");
+create_print_functions!(blank, blankln, "  ");
 create_print_functions!(gear, gearln, "⚙️");
 create_print_functions!(dir, dirln, "📁");

--- a/licenses.rb
+++ b/licenses.rb
@@ -1,5 +1,0 @@
-require "json"
-
-metadata = JSON.parse(`cargo metadata --format-version 1 --frozen`)
-packages = metadata["packages"]
-puts JSON.pretty_generate(packages)


### PR DESCRIPTION
### What

```console
$ stellar contract build --optimize
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/foo/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.04s
ℹ️ Build Summary:
   Wasm File: target/wasm32v1-none/release/foo.wasm (537 bytes (original size was 574 bytes))
   Wasm Hash: 9276bc278792b46e89b299bb55beffd6ca2fa2d17d723abe1ec615e6d5752485
   Wasm Size: 537 bytes optimized (original size was 574 bytes)
   Exported Functions: 2 found
     • _
     • hello
✅ Build Complete

$ stellar contract build
ℹ️ CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/fnando/.cargo/registry/src= cargo rustc --manifest-path=contracts/foo/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.05s
ℹ️ Build Summary:
   Wasm File: target/wasm32v1-none/release/foo.wasm (574 bytes)
   Wasm Hash: b39694f92f640414ccf28326ecf1d3b1b48981167eb00fc00739f71dac344013
   Wasm Size: 574 bytes
   Exported Functions: 2 found
     • _
     • hello
✅ Build Complete
```

### Why

Supersedes #2045.

### Known limitations

N/A
