### PR TITLE
Remove deprecated `--with-example` and `--frontend-template` switches.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -9,13 +9,7 @@ use std::{
 use clap::Parser;
 use rust_embed::RustEmbed;
 
-use crate::{commands::global, error_on_use_of_removed_arg, print, utils};
-
-const EXAMPLE_REMOVAL_NOTICE: &str = "Adding examples via cli is no longer supported. \
-You can still clone examples from the repo https://github.com/stellar/soroban-examples";
-const FRONTEND_EXAMPLE_REMOVAL_NOTICE: &str = "Using frontend template via cli is no longer \
-supported. You can search for frontend templates using github tags, \
-such as `soroban-template` or `soroban-frontend-template`";
+use crate::{commands::global, print};
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -28,25 +22,6 @@ pub struct Cmd {
         long_help = "An optional flag to specify a new contract's name."
     )]
     pub name: String,
-
-    // TODO: remove in future version (23+) https://github.com/stellar/stellar-cli/issues/1586
-    #[arg(
-        short,
-        long,
-        hide = true,
-        display_order = 100,
-        value_parser = error_on_use_of_removed_arg!(String, EXAMPLE_REMOVAL_NOTICE)
-    )]
-    pub with_example: Option<String>,
-
-    // TODO: remove in future version (23+) https://github.com/stellar/stellar-cli/issues/1586
-    #[arg(
-        long,
-        hide = true,
-        display_order = 100,
-        value_parser = error_on_use_of_removed_arg!(String, FRONTEND_EXAMPLE_REMOVAL_NOTICE),
-    )]
-    pub frontend_template: Option<String>,
 
     #[arg(long, long_help = "Overwrite all existing files.")]
     pub overwrite: bool,
@@ -217,8 +192,6 @@ mod tests {
             args: Cmd {
                 project_path: project_dir.to_string_lossy().to_string(),
                 name: "hello_world".to_string(),
-                with_example: None,
-                frontend_template: None,
                 overwrite: false,
             },
             print: print::Print::new(false),
@@ -237,8 +210,6 @@ mod tests {
             args: Cmd {
                 project_path: project_dir.to_string_lossy().to_string(),
                 name: "contract2".to_string(),
-                with_example: None,
-                frontend_template: None,
                 overwrite: false,
             },
             print: print::Print::new(false),


### PR DESCRIPTION
### Why

These switches were disabled on P22 and needed to be removed on P23.

### Known limitations

N/A
