### PR TITLE
Update RUSTFLAGS warning to suggest CARGO_BUILD_RUSTFLAGS

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -507,7 +507,7 @@ fn make_rustflags_to_remap_absolute_paths(print: &Print) -> Result<Option<String
     }
 
     if env::var("RUSTFLAGS").is_ok() {
-        print.warnln("`RUSTFLAGS` set. Dependency paths will not be remapped; builds may not be reproducible.");
+        print.warnln("`RUSTFLAGS` set. Dependency paths will not be remapped; builds may not be reproducible. Use CARGO_BUILD_RUSTFLAGS instead, which the CLI will merge with remapping.");
         return Ok(None);
     }
 


### PR DESCRIPTION
### What

Update the warning message when RUSTFLAGS is set to suggest using CARGO_BUILD_RUSTFLAGS instead, which the CLI can merge with remapping.

### Why

When users set RUSTFLAGS, dependency path remapping is disabled because the CLI cannot merge remapping with RUSTFLAGS. However, CARGO_BUILD_RUSTFLAGS supports merging, so the warning should guide users to use that instead to maintain reproducible builds.

Came across this myself where I wanted to set RUSTFLAGS but the warning warned me not to. I just happened to remember that we added support for merging with the CARGO_BUILD_RUSTFLAGS, but that's some serioues tribal knowledge. The CLI should help someone move forward with using custom flags.

### Known limitations

N/A