### PR TITLE
correct a link to the "networks" page in the docs

### DIFF
--- a/cookbook/tx-new.mdx
+++ b/cookbook/tx-new.mdx
@@ -31,7 +31,7 @@ stellar network use testnet
 
 ### Create Account
 
-Creates and funds a new Stellar account. Above `alice` was funded by [friendbot](../../../learn/fundamentals/networks.mdx#friendbot). However, `bob` and `charlie` were not. So we can use the `create-account` command to fund them.
+Creates and funds a new Stellar account. Above `alice` was funded by [friendbot](../../../networks/README.mdx#friendbot). However, `bob` and `charlie` were not. So we can use the `create-account` command to fund them.
 
 `bob` will receive 10 XLM and `charlie` will get 1 XLM.
 


### PR DESCRIPTION


### What

Change a link in one of the cookbook documents.

### Why

We're consolidating a couple "Networks" pages

Refs: stellar/stellar-docs#1901, stellar/stellar-docs#1916