### PR TITLE
Add soroban-test integration testing instructions to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,7 @@ Stellar CLI is a Rust-based command-line tool for interacting with the Stellar n
 
 - Test main soroban-cli library: `cargo test --package soroban-cli --lib` -- takes 52 seconds. NEVER CANCEL.
 - Test individual crates: `cargo test --package <crate-name>` -- typically takes 40 seconds per crate.
+- Test soroban-test integration tests: `cargo test --features it --test it -- integration` -- tests the commands of the cli and is where the bulk of the tests live for this repository. All new commands and changes to commands should include updates or additions to tests in soroban-test.
 - **WARNING**: Full test suite via `make test` requires building WebAssembly test fixtures and consumes significant memory and disk space. It may fail with "No space left on device" in constrained environments.
 
 ### CLI Usage and Validation


### PR DESCRIPTION
### What
  Add documentation for running soroban-test integration tests using cargo test with the it feature flag. Include guidance that all new commands and command changes require corresponding test updates in soroban-test.

  ### Why
  The soroban-test integration tests contain the bulk of CLI command tests, but instructions for running them were missing from the copilot instructions.