### PR TITLE
Add better emoji support for unknown terminals.

### DIFF
--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -7,8 +7,6 @@ use crate::{
     config::network::Network, utils::explorer_url_for_transaction, utils::transaction_hash,
 };
 
-const TERMS: &[&str] = &["Apple_Terminal", "vscode", "unknown"];
-
 #[derive(Clone)]
 pub struct Print {
     pub quiet: bool,
@@ -43,22 +41,12 @@ impl Print {
         }
     }
 
-    fn should_add_additional_space(&self) -> bool {
-        let term_program = env::var("TERM_PROGRAM").unwrap_or("unknown".to_string());
-
-        if TERMS.contains(&term_program.as_str()) {
-            return true;
-        }
-
-        false
-    }
-
     // Some terminals like vscode's and macOS' default terminal will not render
     // the subsequent space if the emoji codepoints size is 2; in this case,
     // we need an additional space. We also need an additional space if `TERM_PROGRAM` is not
     // defined (e.g. vhs running in a docker container).
     pub fn compute_emoji<T: Display + Sized>(&self, emoji: T) -> String {
-        if self.should_add_additional_space()
+        if should_add_additional_space()
             && (emoji.to_string().chars().count() == 2 || format!("{emoji}") == " ")
         {
             return format!("{emoji} ");
@@ -109,6 +97,17 @@ macro_rules! create_print_functions {
             }
         }
     };
+}
+
+fn should_add_additional_space() -> bool {
+    const TERMS: &[&str] = &["Apple_Terminal", "vscode", "unknown"];
+    let term_program = env::var("TERM_PROGRAM").unwrap_or("unknown".to_string());
+
+    if TERMS.contains(&term_program.as_str()) {
+        return true;
+    }
+
+    false
 }
 
 create_print_functions!(bucket, bucketln, "🪣");


### PR DESCRIPTION
### What

Running VHS in a docker container prints the wrong emoji spacing. `$TERM_PROGRAM` is not set at all when running with ttyd (the thing vhs uses), so we can default to `unknown`. Worse case scenario, people will see an additional space (but I believe all real terminals set that).

Before fix:


https://github.com/user-attachments/assets/1ecca099-4f35-4172-9796-31335fddb902

After fix:


https://github.com/user-attachments/assets/65dc2e47-1146-4308-a152-2ac84f57b1c5



### Why

So we can have better emoji support.

### Known limitations

N/A
