### PR TITLE
Set soroban-sdk version to major only in new contracts

### DIFF
--- a/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
+++ b/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "23.0.2"
+soroban-sdk = "23"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What
  Change soroban-sdk dependency version from "23.0.2" to "23" in the contract workspace template Cargo.toml.

  ### Why
  When creating new projects a developer probably wants to use the latest available soroban-sdk for the supported major version. Specifying 23.0.2 means only the latest 23.0.x version will be used. Specifying 23 will mean the latest 23 version will be used.