### PR TITLE
Replace custom data_into_key with to_key method

### DIFF
--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -15,12 +15,9 @@ use std::{
     time::{Duration, Instant},
 };
 use stellar_xdr::curr::{
-    self as xdr, AccountId, Asset, BucketEntry, ConfigSettingEntry, ConfigSettingId,
-    ContractExecutable, Frame, Hash, LedgerEntry, LedgerEntryData, LedgerHeaderHistoryEntry,
-    LedgerKey, LedgerKeyAccount, LedgerKeyClaimableBalance, LedgerKeyConfigSetting,
-    LedgerKeyContractCode, LedgerKeyContractData, LedgerKeyData, LedgerKeyLiquidityPool,
-    LedgerKeyOffer, LedgerKeyTrustLine, LedgerKeyTtl, Limited, Limits, ReadXdr, ScAddress,
-    ScContractInstance, ScVal,
+    self as xdr, AccountId, Asset, BucketEntry, ConfigSettingEntry, ContractExecutable, Frame,
+    Hash, LedgerEntryData, LedgerHeaderHistoryEntry, LedgerKey, Limited, Limits, ReadXdr,
+    ScAddress, ScContractInstance, ScVal,
 };
 use tokio::fs::OpenOptions;
 use tokio::io::BufReader;
@@ -315,7 +312,7 @@ impl Cmd {
                     let Frame(entry) = entry.map_err(Error::ReadXdrFrameBucketEntry)?;
                     let (key, val) = match entry {
                         BucketEntry::Liveentry(l) | BucketEntry::Initentry(l) => {
-                            let k = data_into_key(&l);
+                            let k = l.to_key();
                             (k, Some(l))
                         }
                         BucketEntry::Deadentry(k) => (k, None),
@@ -741,87 +738,4 @@ struct History {
 struct HistoryBucket {
     curr: String,
     snap: String,
-}
-
-fn data_into_key(d: &LedgerEntry) -> LedgerKey {
-    // TODO: Move this function into stellar-xdr.
-    match &d.data {
-        LedgerEntryData::Account(e) => LedgerKey::Account(LedgerKeyAccount {
-            account_id: e.account_id.clone(),
-        }),
-        LedgerEntryData::Trustline(e) => LedgerKey::Trustline(LedgerKeyTrustLine {
-            account_id: e.account_id.clone(),
-            asset: e.asset.clone(),
-        }),
-        LedgerEntryData::Offer(e) => LedgerKey::Offer(LedgerKeyOffer {
-            seller_id: e.seller_id.clone(),
-            offer_id: e.offer_id,
-        }),
-        LedgerEntryData::Data(e) => LedgerKey::Data(LedgerKeyData {
-            account_id: e.account_id.clone(),
-            data_name: e.data_name.clone(),
-        }),
-        LedgerEntryData::ClaimableBalance(e) => {
-            LedgerKey::ClaimableBalance(LedgerKeyClaimableBalance {
-                balance_id: e.balance_id.clone(),
-            })
-        }
-        LedgerEntryData::LiquidityPool(e) => LedgerKey::LiquidityPool(LedgerKeyLiquidityPool {
-            liquidity_pool_id: e.liquidity_pool_id.clone(),
-        }),
-        LedgerEntryData::ContractData(e) => LedgerKey::ContractData(LedgerKeyContractData {
-            contract: e.contract.clone(),
-            key: e.key.clone(),
-            durability: e.durability,
-        }),
-        LedgerEntryData::ContractCode(e) => LedgerKey::ContractCode(LedgerKeyContractCode {
-            hash: e.hash.clone(),
-        }),
-        LedgerEntryData::ConfigSetting(e) => LedgerKey::ConfigSetting(LedgerKeyConfigSetting {
-            config_setting_id: match e {
-                ConfigSettingEntry::ContractMaxSizeBytes(_) => {
-                    ConfigSettingId::ContractMaxSizeBytes
-                }
-                ConfigSettingEntry::ContractComputeV0(_) => ConfigSettingId::ContractComputeV0,
-                ConfigSettingEntry::ContractLedgerCostV0(_) => {
-                    ConfigSettingId::ContractLedgerCostV0
-                }
-                ConfigSettingEntry::ContractHistoricalDataV0(_) => {
-                    ConfigSettingId::ContractHistoricalDataV0
-                }
-                ConfigSettingEntry::ContractEventsV0(_) => ConfigSettingId::ContractEventsV0,
-                ConfigSettingEntry::ContractBandwidthV0(_) => ConfigSettingId::ContractBandwidthV0,
-                ConfigSettingEntry::ContractCostParamsCpuInstructions(_) => {
-                    ConfigSettingId::ContractCostParamsCpuInstructions
-                }
-                ConfigSettingEntry::ContractCostParamsMemoryBytes(_) => {
-                    ConfigSettingId::ContractCostParamsMemoryBytes
-                }
-                ConfigSettingEntry::ContractDataKeySizeBytes(_) => {
-                    ConfigSettingId::ContractDataKeySizeBytes
-                }
-                ConfigSettingEntry::ContractDataEntrySizeBytes(_) => {
-                    ConfigSettingId::ContractDataEntrySizeBytes
-                }
-                ConfigSettingEntry::StateArchival(_) => ConfigSettingId::StateArchival,
-                ConfigSettingEntry::ContractExecutionLanes(_) => {
-                    ConfigSettingId::ContractExecutionLanes
-                }
-                ConfigSettingEntry::EvictionIterator(_) => ConfigSettingId::EvictionIterator,
-                ConfigSettingEntry::LiveSorobanStateSizeWindow(_) => {
-                    ConfigSettingId::LiveSorobanStateSizeWindow
-                }
-                ConfigSettingEntry::ContractParallelComputeV0(_) => {
-                    ConfigSettingId::ContractParallelComputeV0
-                }
-                ConfigSettingEntry::ContractLedgerCostExtV0(_) => {
-                    ConfigSettingId::ContractLedgerCostExtV0
-                }
-                ConfigSettingEntry::ScpTiming(_) => ConfigSettingId::ScpTiming,
-            },
-        }),
-        LedgerEntryData::Ttl(e) => LedgerKey::Ttl(LedgerKeyTtl {
-            key_hash: e.key_hash.clone(),
-        }),
-    }
 }


### PR DESCRIPTION
### What
  Replace the custom data_into_key function with LedgerEntry's built-in to_key method and remove the 86-line helper function along with its associated imports.

  ### Why
  The stellar-xdr library now provides a native to_key method on LedgerEntry, eliminating the need for a custom implementation that manually converts each LedgerEntryData variant to its corresponding LedgerKey.