### PR TITLE
fix(ts-bindings): `options` is `MethodOptions`

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/src/index.ts
@@ -17,7 +17,6 @@ import type {
   i128,
   u256,
   i256,
-  AssembledTransactionOptions,
   Option,
   Typepoint,
   Duration,
@@ -40,7 +39,7 @@ export interface Client {
    * Construct and simulate a counter transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    * Counter value
    */
-  counter: (options?: AssembledTransactionOptions<u32>) => Promise<AssembledTransaction<u32>>
+  counter: (options?: MethodOptions) => Promise<AssembledTransaction<u32>>
 
 }
 export class Client extends ContractClient {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/index.ts
@@ -17,7 +17,6 @@ import type {
   i128,
   u256,
   i256,
-  AssembledTransactionOptions,
   Option,
   Typepoint,
   Duration,
@@ -56,6 +55,8 @@ export type TupleStruct = readonly [Test,  SimpleEnum];
 
 export type ComplexEnum = {tag: "Struct", values: readonly [Test]} | {tag: "Tuple", values: readonly [TupleStruct]} | {tag: "Enum", values: readonly [SimpleEnum]} | {tag: "Asset", values: readonly [string, i128]} | {tag: "Void", values: void};
 
+export type RecursiveEnum = {tag: "List", values: readonly [Array<RecursiveEnum>]} | {tag: "Void", values: void};
+
 export const Errors = {
   /**
    * Please provide an odd number
@@ -75,145 +76,150 @@ export interface Client {
   /**
    * Construct and simulate a hello transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  hello: ({hello}: {hello: string}, options?: AssembledTransactionOptions<string>) => Promise<AssembledTransaction<string>>
+  hello: ({hello}: {hello: string}, options?: MethodOptions) => Promise<AssembledTransaction<string>>
 
   /**
    * Construct and simulate a woid transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  woid: (options?: AssembledTransactionOptions<null>) => Promise<AssembledTransaction<null>>
+  woid: (options?: MethodOptions) => Promise<AssembledTransaction<null>>
 
   /**
    * Construct and simulate a val transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  val: (options?: AssembledTransactionOptions<any>) => Promise<AssembledTransaction<any>>
+  val: (options?: MethodOptions) => Promise<AssembledTransaction<any>>
 
   /**
    * Construct and simulate a u32_fail_on_even transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  u32_fail_on_even: ({u32_}: {u32_: u32}, options?: AssembledTransactionOptions<Result<u32>>) => Promise<AssembledTransaction<Result<u32>>>
+  u32_fail_on_even: ({u32_}: {u32_: u32}, options?: MethodOptions) => Promise<AssembledTransaction<Result<u32>>>
 
   /**
    * Construct and simulate a u32_ transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  u32_: ({u32_}: {u32_: u32}, options?: AssembledTransactionOptions<u32>) => Promise<AssembledTransaction<u32>>
+  u32_: ({u32_}: {u32_: u32}, options?: MethodOptions) => Promise<AssembledTransaction<u32>>
 
   /**
    * Construct and simulate a i32_ transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  i32_: ({i32_}: {i32_: i32}, options?: AssembledTransactionOptions<i32>) => Promise<AssembledTransaction<i32>>
+  i32_: ({i32_}: {i32_: i32}, options?: MethodOptions) => Promise<AssembledTransaction<i32>>
 
   /**
    * Construct and simulate a i64_ transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  i64_: ({i64_}: {i64_: i64}, options?: AssembledTransactionOptions<i64>) => Promise<AssembledTransaction<i64>>
+  i64_: ({i64_}: {i64_: i64}, options?: MethodOptions) => Promise<AssembledTransaction<i64>>
 
   /**
    * Construct and simulate a strukt_hel transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    * Example contract method which takes a struct
    */
-  strukt_hel: ({strukt}: {strukt: Test}, options?: AssembledTransactionOptions<Array<string>>) => Promise<AssembledTransaction<Array<string>>>
+  strukt_hel: ({strukt}: {strukt: Test}, options?: MethodOptions) => Promise<AssembledTransaction<Array<string>>>
 
   /**
    * Construct and simulate a strukt transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  strukt: ({strukt}: {strukt: Test}, options?: AssembledTransactionOptions<Test>) => Promise<AssembledTransaction<Test>>
+  strukt: ({strukt}: {strukt: Test}, options?: MethodOptions) => Promise<AssembledTransaction<Test>>
 
   /**
    * Construct and simulate a simple transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  simple: ({simple}: {simple: SimpleEnum}, options?: AssembledTransactionOptions<SimpleEnum>) => Promise<AssembledTransaction<SimpleEnum>>
+  simple: ({simple}: {simple: SimpleEnum}, options?: MethodOptions) => Promise<AssembledTransaction<SimpleEnum>>
 
   /**
    * Construct and simulate a complex transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  complex: ({complex}: {complex: ComplexEnum}, options?: AssembledTransactionOptions<ComplexEnum>) => Promise<AssembledTransaction<ComplexEnum>>
+  complex: ({complex}: {complex: ComplexEnum}, options?: MethodOptions) => Promise<AssembledTransaction<ComplexEnum>>
+
+  /**
+   * Construct and simulate a recursive_enum transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
+   */
+  recursive_enum: ({recursive}: {recursive: RecursiveEnum}, options?: MethodOptions) => Promise<AssembledTransaction<RecursiveEnum>>
 
   /**
    * Construct and simulate a addresse transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  addresse: ({addresse}: {addresse: string}, options?: AssembledTransactionOptions<string>) => Promise<AssembledTransaction<string>>
+  addresse: ({addresse}: {addresse: string}, options?: MethodOptions) => Promise<AssembledTransaction<string>>
 
   /**
    * Construct and simulate a bytes transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  bytes: ({bytes}: {bytes: Buffer}, options?: AssembledTransactionOptions<Buffer>) => Promise<AssembledTransaction<Buffer>>
+  bytes: ({bytes}: {bytes: Buffer}, options?: MethodOptions) => Promise<AssembledTransaction<Buffer>>
 
   /**
    * Construct and simulate a bytes_n transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  bytes_n: ({bytes_n}: {bytes_n: Buffer}, options?: AssembledTransactionOptions<Buffer>) => Promise<AssembledTransaction<Buffer>>
+  bytes_n: ({bytes_n}: {bytes_n: Buffer}, options?: MethodOptions) => Promise<AssembledTransaction<Buffer>>
 
   /**
    * Construct and simulate a card transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  card: ({card}: {card: RoyalCard}, options?: AssembledTransactionOptions<RoyalCard>) => Promise<AssembledTransaction<RoyalCard>>
+  card: ({card}: {card: RoyalCard}, options?: MethodOptions) => Promise<AssembledTransaction<RoyalCard>>
 
   /**
    * Construct and simulate a boolean transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  boolean: ({boolean}: {boolean: boolean}, options?: AssembledTransactionOptions<boolean>) => Promise<AssembledTransaction<boolean>>
+  boolean: ({boolean}: {boolean: boolean}, options?: MethodOptions) => Promise<AssembledTransaction<boolean>>
 
   /**
    * Construct and simulate a not transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    * Negates a boolean value
    */
-  not: ({boolean}: {boolean: boolean}, options?: AssembledTransactionOptions<boolean>) => Promise<AssembledTransaction<boolean>>
+  not: ({boolean}: {boolean: boolean}, options?: MethodOptions) => Promise<AssembledTransaction<boolean>>
 
   /**
    * Construct and simulate a i128 transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  i128: ({i128}: {i128: i128}, options?: AssembledTransactionOptions<i128>) => Promise<AssembledTransaction<i128>>
+  i128: ({i128}: {i128: i128}, options?: MethodOptions) => Promise<AssembledTransaction<i128>>
 
   /**
    * Construct and simulate a u128 transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  u128: ({u128}: {u128: u128}, options?: AssembledTransactionOptions<u128>) => Promise<AssembledTransaction<u128>>
+  u128: ({u128}: {u128: u128}, options?: MethodOptions) => Promise<AssembledTransaction<u128>>
 
   /**
    * Construct and simulate a multi_args transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  multi_args: ({a, b}: {a: u32, b: boolean}, options?: AssembledTransactionOptions<u32>) => Promise<AssembledTransaction<u32>>
+  multi_args: ({a, b}: {a: u32, b: boolean}, options?: MethodOptions) => Promise<AssembledTransaction<u32>>
 
   /**
    * Construct and simulate a map transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  map: ({map}: {map: Map<u32, boolean>}, options?: AssembledTransactionOptions<Map<u32, boolean>>) => Promise<AssembledTransaction<Map<u32, boolean>>>
+  map: ({map}: {map: Map<u32, boolean>}, options?: MethodOptions) => Promise<AssembledTransaction<Map<u32, boolean>>>
 
   /**
    * Construct and simulate a vec transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  vec: ({vec}: {vec: Array<u32>}, options?: AssembledTransactionOptions<Array<u32>>) => Promise<AssembledTransaction<Array<u32>>>
+  vec: ({vec}: {vec: Array<u32>}, options?: MethodOptions) => Promise<AssembledTransaction<Array<u32>>>
 
   /**
    * Construct and simulate a tuple transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  tuple: ({tuple}: {tuple: readonly [string, u32]}, options?: AssembledTransactionOptions<readonly [string, u32]>) => Promise<AssembledTransaction<readonly [string, u32]>>
+  tuple: ({tuple}: {tuple: readonly [string, u32]}, options?: MethodOptions) => Promise<AssembledTransaction<readonly [string, u32]>>
 
   /**
    * Construct and simulate a option transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    * Example of an optional argument
    */
-  option: ({option}: {option: Option<u32>}, options?: AssembledTransactionOptions<Option<u32>>) => Promise<AssembledTransaction<Option<u32>>>
+  option: ({option}: {option: Option<u32>}, options?: MethodOptions) => Promise<AssembledTransaction<Option<u32>>>
 
   /**
    * Construct and simulate a u256 transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  u256: ({u256}: {u256: u256}, options?: AssembledTransactionOptions<u256>) => Promise<AssembledTransaction<u256>>
+  u256: ({u256}: {u256: u256}, options?: MethodOptions) => Promise<AssembledTransaction<u256>>
 
   /**
    * Construct and simulate a i256 transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  i256: ({i256}: {i256: i256}, options?: AssembledTransactionOptions<i256>) => Promise<AssembledTransaction<i256>>
+  i256: ({i256}: {i256: i256}, options?: MethodOptions) => Promise<AssembledTransaction<i256>>
 
   /**
    * Construct and simulate a string transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  string: ({string}: {string: string}, options?: AssembledTransactionOptions<string>) => Promise<AssembledTransaction<string>>
+  string: ({string}: {string: string}, options?: MethodOptions) => Promise<AssembledTransaction<string>>
 
   /**
    * Construct and simulate a tuple_strukt transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.
    */
-  tuple_strukt: ({tuple_strukt}: {tuple_strukt: TupleStruct}, options?: AssembledTransactionOptions<TupleStruct>) => Promise<AssembledTransaction<TupleStruct>>
+  tuple_strukt: ({tuple_strukt}: {tuple_strukt: TupleStruct}, options?: MethodOptions) => Promise<AssembledTransaction<TupleStruct>>
 
 }
 export class Client extends ContractClient {
@@ -238,6 +244,7 @@ export class Client extends ContractClient {
         "AAAAAwAAAAAAAAAAAAAACVJveWFsQ2FyZAAAAAAAAAMAAAAAAAAABEphY2sAAAALAAAAAAAAAAVRdWVlbgAAAAAAAAwAAAAAAAAABEtpbmcAAAAN",
         "AAAAAQAAAAAAAAAAAAAAC1R1cGxlU3RydWN0AAAAAAIAAAAAAAAAATAAAAAAAAfQAAAABFRlc3QAAAAAAAAAATEAAAAAAAfQAAAAClNpbXBsZUVudW0AAA==",
         "AAAAAgAAAAAAAAAAAAAAC0NvbXBsZXhFbnVtAAAAAAUAAAABAAAAAAAAAAZTdHJ1Y3QAAAAAAAEAAAfQAAAABFRlc3QAAAABAAAAAAAAAAVUdXBsZQAAAAAAAAEAAAfQAAAAC1R1cGxlU3RydWN0AAAAAAEAAAAAAAAABEVudW0AAAABAAAH0AAAAApTaW1wbGVFbnVtAAAAAAABAAAAAAAAAAVBc3NldAAAAAAAAAIAAAATAAAACwAAAAAAAAAAAAAABFZvaWQ=",
+        "AAAAAgAAAAAAAAAAAAAADVJlY3Vyc2l2ZUVudW0AAAAAAAACAAAAAQAAAAAAAAAETGlzdAAAAAEAAAPqAAAH0AAAAA1SZWN1cnNpdmVFbnVtAAAAAAAAAAAAAAAAAAAEVm9pZA==",
         "AAAABAAAAAAAAAAAAAAABUVycm9yAAAAAAAAAQAAABxQbGVhc2UgcHJvdmlkZSBhbiBvZGQgbnVtYmVyAAAAD051bWJlck11c3RCZU9kZAAAAAAB",
         "AAAABAAAAAAAAAAAAAAACUVycm9uZW91cwAAAAAAAAEAAACsU29tZSBjb250cmFjdCBsaWJyYXJpZXMgY29udGFpbiBleHRyYSAjW2NvbnRyYWN0ZXJyb3JdIGRlZmluaXRpb25zIHRoYXQgZW5kIHVwIGNvbXBpbGVkCmludG8gdGhlIG1haW4gY29udHJhY3QgdHlwZXMuIFdlIG5lZWQgdG8gbWFrZSBzdXJlIHRvb2xpbmcgZGVhbHMgd2l0aCB0aGlzIHByb3Blcmx5LgAAAAtIb3dDb3VsZFlvdQAAAABk",
         "AAAAAAAAAAAAAAAFaGVsbG8AAAAAAAABAAAAAAAAAAVoZWxsbwAAAAAAABEAAAABAAAAEQ==",
@@ -251,6 +258,7 @@ export class Client extends ContractClient {
         "AAAAAAAAAAAAAAAGc3RydWt0AAAAAAABAAAAAAAAAAZzdHJ1a3QAAAAAB9AAAAAEVGVzdAAAAAEAAAfQAAAABFRlc3Q=",
         "AAAAAAAAAAAAAAAGc2ltcGxlAAAAAAABAAAAAAAAAAZzaW1wbGUAAAAAB9AAAAAKU2ltcGxlRW51bQAAAAAAAQAAB9AAAAAKU2ltcGxlRW51bQAA",
         "AAAAAAAAAAAAAAAHY29tcGxleAAAAAABAAAAAAAAAAdjb21wbGV4AAAAB9AAAAALQ29tcGxleEVudW0AAAAAAQAAB9AAAAALQ29tcGxleEVudW0A",
+        "AAAAAAAAAAAAAAAOcmVjdXJzaXZlX2VudW0AAAAAAAEAAAAAAAAACXJlY3Vyc2l2ZQAAAAAAB9AAAAANUmVjdXJzaXZlRW51bQAAAAAAAAEAAAfQAAAADVJlY3Vyc2l2ZUVudW0AAAA=",
         "AAAAAAAAAAAAAAAIYWRkcmVzc2UAAAABAAAAAAAAAAhhZGRyZXNzZQAAABMAAAABAAAAEw==",
         "AAAAAAAAAAAAAAAFYnl0ZXMAAAAAAAABAAAAAAAAAAVieXRlcwAAAAAAAA4AAAABAAAADg==",
         "AAAAAAAAAAAAAAAHYnl0ZXNfbgAAAAABAAAAAAAAAAdieXRlc19uAAAAA+4AAAAJAAAAAQAAA+4AAAAJ",
@@ -283,6 +291,7 @@ export class Client extends ContractClient {
         strukt: this.txFromJSON<Test>,
         simple: this.txFromJSON<SimpleEnum>,
         complex: this.txFromJSON<ComplexEnum>,
+        recursive_enum: this.txFromJSON<RecursiveEnum>,
         addresse: this.txFromJSON<string>,
         bytes: this.txFromJSON<Buffer>,
         bytes_n: this.txFromJSON<Buffer>,

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -222,7 +222,7 @@ pub fn entry_to_method_type(entry: &Entry) -> String {
             format!(
                 r"
   {doc}
-  {name}: ({input}options?: AssembledTransactionOptions<{return_type}>) => Promise<AssembledTransaction<{return_type}>>
+  {name}: ({input}options?: MethodOptions) => Promise<AssembledTransaction<{return_type}>>
 "
             )
         }

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/index.ts
@@ -17,7 +17,6 @@ import type {
   i128,
   u256,
   i256,
-  AssembledTransactionOptions,
   Option,
   Typepoint,
   Duration,


### PR DESCRIPTION
### What

This is an update to #2283, which changed hard-coded `options` to
`AssembledTransactionOptions`. This was not quite correct, it should be
a `MethodOptions`.

### Why

This works together with
https://github.com/stellar/js-stellar-sdk/pull/1293 to finally remove
the need for `@ts-expect-error` lines in our canonical write-method
invocation examples.


### Known limitations

Same as #2283