### PR TITLE
Add bulk memory feature for wasm optimization.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/optimize.rs
+++ b/cmd/soroban-cli/src/commands/contract/optimize.rs
@@ -78,16 +78,18 @@ pub fn optimize(
         let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
         options.converge = true;
 
-        // Explicitly set to MVP + sign-ext + mutable-globals, which happens to
+        // Explicitly set to MVP + sign-ext + mutable-globals + bulk-memory, which happens to
         // also be the default featureset, but just to be extra clear we set it
         // explicitly.
         //
         // Formerly Soroban supported only the MVP feature set, but Rust 1.70 as
         // well as Clang generate code with sign-ext + mutable-globals enabled,
         // so Soroban has taken a change to support them also.
+        // Modern Rust toolchains also generate bulk memory operations (memory.fill, memory.copy).
         options.mvp_features_only();
         options.enable_feature(Feature::MutableGlobals);
         options.enable_feature(Feature::SignExt);
+        options.enable_feature(Feature::BulkMemory);
 
         options
             .run(&wasm_arg.wasm, &wasm_out)


### PR DESCRIPTION
### What

Add wasm-opt's Feature::BulkMemory feature, so it can handle more contracts.

```console
$ stellar contract optimize --wasm /Users/fnando/Downloads/02e9f32323236b7288dc2b3d4652db678dcd876301fb3852d9cfb7cfaf54e0d2.wasm --wasm-out ~/Downloads/optimized.wasm
⚠️ `stellar contract optimize` is deprecated and will be removed in future versions of the CLI. Use `stellar contract build --optimize` instead.
Reading: /Users/fnando/Downloads/02e9f32323236b7288dc2b3d4652db678dcd876301fb3852d9cfb7cfaf54e0d2.wasm (14026 bytes)
Optimized: /Users/fnando/Downloads/optimized.wasm (11453 bytes)
```

I optimized ALL contracts on the repo mentioned on #2290 successfully with this feature.

```console
$ ls *.wasm | wc -l
    1799

$ ls optimized/*.wasm | wc -l
    1799
```

### Why

Close #2290.

### Known limitations

N/A
