### PR TITLE
Link to lab after deploying contract, so users can interact with it.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -327,7 +327,7 @@ impl NetworkRunnable for Cmd {
             data::write(get_txn_resp.clone().try_into()?, &network.rpc_uri()?)?;
         }
 
-        if let Some(url) = utils::explorer_url_for_contract(&network, &contract_id) {
+        if let Some(url) = utils::lab_url_for_contract(&network, &contract_id) {
             print.linkln(url);
         }
 

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -41,19 +41,24 @@ static EXPLORERS: phf::Map<&'static str, &'static str> = phf_map! {
     "Public Global Stellar Network ; September 2015" => "https://stellar.expert/explorer/public",
 };
 
+static LAB_CONTRACT_URLS: phf::Map<&'static str, &'static str> = phf_map! {
+    "Test SDF Network ; September 2015" => "https://lab.stellar.org/r/testnet/contract/{contract_id}",
+    "Public Global Stellar Network ; September 2015" => "https://lab.stellar.org/r/mainnet/contract/{contract_id}",
+};
+
 pub fn explorer_url_for_transaction(network: &Network, tx_hash: &str) -> Option<String> {
     EXPLORERS
         .get(&network.network_passphrase)
         .map(|base_url| format!("{base_url}/tx/{tx_hash}"))
 }
 
-pub fn explorer_url_for_contract(
+pub fn lab_url_for_contract(
     network: &Network,
     contract_id: &stellar_strkey::Contract,
 ) -> Option<String> {
-    EXPLORERS
+    LAB_CONTRACT_URLS
         .get(&network.network_passphrase)
-        .map(|base_url| format!("{base_url}/contract/{contract_id}"))
+        .map(|base_url| base_url.replace("{contract_id}", &contract_id.to_string()))
 }
 
 /// # Errors


### PR DESCRIPTION
### What

Link to lab after deploying contract, so users can interact with it.

Requires https://github.com/stellar/laboratory/pull/1738 to be deployed first!

```console
$ stellar contract deploy --wasm target/wasm32v1-none/release/hello_world.wasm --alias hello

ℹ️ Skipping install because wasm already installed
ℹ️ Using wasm hash 92b56dc759810788ad79c246243694eb81d03b7bb977a07b655bafd1ee055ed0
ℹ️ Simulating deploy transaction…
ℹ️ Transaction hash is 00755dea37d9116cfe037eb8304d8ee4a977f78c9fafbf703df305968c1f5072
🔗 https://stellar.expert/explorer/testnet/tx/00755dea37d9116cfe037eb8304d8ee4a977f78c9fafbf703df305968c1f5072
ℹ️ Signing transaction: 00755dea37d9116cfe037eb8304d8ee4a977f78c9fafbf703df305968c1f5072
🌎 Submitting deploy transaction…
🔗 https://lab.stellar.org/r/testnet/contract/CCLLPPD45ETPX2NHZXNBYBQA7IZY7W3HJ4IJPXVBH6VU7QIBLWTYVMTY
✅ Deployed!
CCLLPPD45ETPX2NHZXNBYBQA7IZY7W3HJ4IJPXVBH6VU7QIBLWTYVMTY
```

### Why

Close #2068.

### Known limitations

- We can only link to testnet and mainnet because lab depends on Stellar.expert, which doesn't support other networks.
