### PR TITLE
Move upgrade check check file to data dir.

### DIFF
--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -102,6 +102,8 @@ pub enum Error {
     SecretKeyOnly(String),
     #[error(transparent)]
     Key(#[from] key::Error),
+    #[error("Unable to get project directory")]
+    ProjectDirsError(),
 }
 
 #[derive(Debug, clap::Args, Default, Clone)]

--- a/cmd/soroban-cli/src/config/upgrade_check.rs
+++ b/cmd/soroban-cli/src/config/upgrade_check.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 use serde_json;
 use std::fs;
 
+use super::data::project_dir;
+
 const FILE_NAME: &str = "upgrade_check.json";
 
 /// The `UpgradeCheck` struct represents the state of the upgrade check.
@@ -35,26 +37,28 @@ impl UpgradeCheck {
     /// Loads the state of the upgrade check from the global configuration directory.
     /// If the file doesn't exist, returns a default instance of `UpgradeCheck`.
     pub fn load() -> Result<Self, locator::Error> {
-        let locator = locator::Args {
-            global: false,
-            config_dir: None,
-        };
-        let path = locator.global_config_path()?.join(FILE_NAME);
+        let path = project_dir()
+            .map_err(|_| locator::Error::ProjectDirsError())?
+            .data_dir()
+            .join(FILE_NAME);
+
         if !path.exists() {
             return Ok(Self::default());
         }
+
         let data = fs::read(&path)
             .map_err(|error| locator::Error::UpgradeCheckReadFailed { path, error })?;
+
         Ok(serde_json::from_slice(data.as_slice())?)
     }
 
-    /// Saves the state of the upgrade check to the `upgrade_check.json` file in the global configuration directory.
+    /// Saves the state of the upgrade check to the `upgrade_check.json` file in the global data directory.
     pub fn save(&self) -> Result<(), locator::Error> {
-        let locator = locator::Args {
-            global: false,
-            config_dir: None,
-        };
-        let path = locator.global_config_path()?.join(FILE_NAME);
+        let path = project_dir()
+            .map_err(|_| locator::Error::ProjectDirsError())?
+            .data_dir()
+            .join(FILE_NAME);
+
         let path = locator::ensure_directory(path)?;
         let data = serde_json::to_string(self).map_err(|_| locator::Error::ConfigSerialization)?;
         fs::write(&path, data)
@@ -69,9 +73,9 @@ mod tests {
 
     #[test]
     fn test_upgrade_check_load_save() {
-        // Set the `XDG_CONFIG_HOME` environment variable to a temporary directory
+        // Set the `XDG_DATA_HOME` environment variable to a temporary directory
         let temp_dir = tempfile::tempdir().unwrap();
-        env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        env::set_var("XDG_DATA_HOME", temp_dir.path());
         // Test default loading
         let default_check = UpgradeCheck::load().unwrap();
         assert_eq!(default_check, UpgradeCheck::default());

--- a/cmd/soroban-cli/src/env_vars.rs
+++ b/cmd/soroban-cli/src/env_vars.rs
@@ -12,6 +12,7 @@ pub fn unprefixed() -> Vec<&'static str> {
         "NETWORK",
         "NETWORK_PASSPHRASE",
         "NO_CACHE",
+        "NO_UPDATE_CHECK",
         "OPERATION_SOURCE_ACCOUNT",
         "RPC_HEADERS",
         "RPC_URL",


### PR DESCRIPTION
### What

Move upgrade check check file to data dir.

### Why

It makes sense to have cache data at the data directory.

### Known limitations

N/A
