### PR TITLE
Properly report when funding accounts fail.

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -96,7 +96,7 @@ impl Cmd {
         let formatted_name = self.name.to_string();
 
         match network.fund_address(&addr).await {
-            Ok(_) => print.checkln(format!(
+            Ok(()) => print.checkln(format!(
                 "Account {} funded on {:?}",
                 formatted_name, network.network_passphrase
             )),


### PR DESCRIPTION
### What

```console
$ stellar keys generate $RANDOM --network local --fund
✅ Key saved with alias 4610 in "/Users/fnando/.config/stellar/identity/4610.toml"
❌ Unable to fund account 4610 on "Standalone Network ; February 2017"

$ stellar keys generate $RANDOM --network local --fund --very-verbose
2025-12-08T18:50:30.255291Z DEBUG soroban_cli::upgrade_check: start upgrade check
2025-12-08T18:50:30.255549Z DEBUG soroban_cli::upgrade_check: finished upgrade check
✅ Key saved with alias 19251 in "/Users/fnando/.config/stellar/identity/19251.toml"
2025-12-08T18:50:30.279591Z DEBUG soroban_cli::config::network: address "GB7HCF67YBKYHV4FNWGHLC4HBADOAD24KNJGEOGSYBC2BRDQXX5XFCS7"
2025-12-08T18:50:30.279687Z DEBUG soroban_cli::config::network: URL Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(8000), path: "/friendbot", query: Some("addr=GB7HCF67YBKYHV4FNWGHLC4HBADOAD24KNJGEOGSYBC2BRDQXX5XFCS7"), fragment: None }
2025-12-08T18:50:30.282583Z TRACE soroban_cli::commands::keys::generate: Account funding error: HttpClient(reqwest::Error { kind: Request, url: "http://localhost:8000/friendbot?addr=GB7HCF67YBKYHV4FNWGHLC4HBADOAD24KNJGEOGSYBC2BRDQXX5XFCS7", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", [::1]:8000, Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) })
❌ Unable to fund account 19251 on "Standalone Network ; February 2017"
```

### Why

Close #2319

### Known limitations

`stellar keys fund` already reports errors.

```console
$ stellar keys fund 4610 --network local
❌ error: error sending request for url (http://localhost:8000/friendbot?addr=GDK7Y5ZE7B6EFVQZBAACT67RP3YDAVYWY7XB4PJZ6PU3EEFRWWVJCV5S)
```
