### PR TITLE
Update deny.toml to ignore rustls-pemfile error for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,8 @@ ignore = [
     "RUSTSEC-2024-0388", # derivative is no longer maintained, but that has no known material impact on the this repo
     "RUSTSEC-2024-0436", # paste is no longer maintained
     "RUSTSEC-2025-0052", # async-std has been discontinued - used only in test dependencies
+    "RUSTSEC-2025-0134", # rustls-pemfile is archived; used indirectly via bollard which should be updated in the future
+
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
### What
Add RUSTSEC-2025-0134 to list of advisories to ignore. This advisory is regarding the rustls-pemfile crate, which has been archived. We are using rustls-pemfile indirectly via bollard.


### Why

So that cargo deny check will no longer fail.

### Known limitations

I am working on trying to upgrade bollard in another PR, which will hopefully allow for removing this ID from the list of ignores.
