### PR TITLE
Run Horizon during RPC CI tests

### DIFF
--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: stellar/quickstart@main
         with:
           tag: future
-          enable: core,rpc
       - uses: actions/checkout@v5
       - uses: stellar/actions/rust-cache@main
       - run: rustup update


### PR DESCRIPTION
### What

Run quickstart with horizon.

### Why

This was removed during optimization efforts, but appeared not to have an effect, as it seems like horizon was still getting started. Now that horizon is not running, a few tests require horizon are failing.

### Known limitations

None
