### PR TITLE
Sign windows installer.

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -136,8 +136,7 @@ jobs:
 
       - name: Setup Software Trust Manager
         if:
-          github.event_name == 'release' || github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
+          github.event_name == 'release' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
         id: stm-setup
         uses: digicert/code-signing-software-trust-action@v1.0.1
         with:


### PR DESCRIPTION
### What

Sign Windows Installer when making a new release.

<img width="2048" height="1616" alt="CleanShot 2026-01-14 at 17 22 00@2x" src="https://github.com/user-attachments/assets/b573c9b9-aed0-4c0a-a24b-90cdf6dfed3d" />


### Why

So we can get rid of the nasty warning on Windows. See https://github.com/stellar/ops/issues/4170 for reference.

### Known limitations

Given the limited number of signatures we can issue (1000), we're only signing actual releases.
