### PR TITLE
Handle contract build info when multiple attestations are available.

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/info/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/build.rs
@@ -96,11 +96,8 @@ impl Cmd {
                     .decode(&attestation.bundle.dsse_envelope.payload)
                     .ok()?;
                 let payload: gh_payload::Root = serde_json::from_slice(&payload).ok()?;
-                if payload.predicate_type == "https://slsa.dev/provenance/v1" {
-                    Some(payload)
-                } else {
-                    None
-                }
+
+                (payload.predicate_type == "https://slsa.dev/provenance/v1").then_some(payload)
             })
             .ok_or(Error::AttestationNotFound)?;
 


### PR DESCRIPTION
### What

Handle contract build info when multiple attestations are available.

```console
$ stellar contract info build --contract-id CDV6FVU76E2UPXMXLZEBIF2PSKVXC7GGTNE6CBWNATTBYMID2FQPNO56
⚠️ This command displays information about the GitHub Actions run that attested to have built the wasm, and does not verify the source code. Please review the run, its workflow, and source code.
ℹ️ Network: Test SDF Network ; September 2015
🌎 Downloading contract spec: CDV6FVU76E2UPXMXLZEBIF2PSKVXC7GGTNE6CBWNATTBYMID2FQPNO56
ℹ️ Wasm Hash: 3c8d0b8b347752e57abe0b50380401ca8f5793bc971b685fd072571bbf5d54cc
ℹ️ Source Repo: github:stellar/sep45-reference
ℹ️ Collecting GitHub attestation from https://api.github.com/repos/stellar/sep45-reference/attestations/sha256:3c8d0b8b347752e57abe0b50380401ca8f5793bc971b685fd072571bbf5d54cc
✅ Attestation found linked to GitHub Actions Workflow Run:
    Repository: https://github.com/stellar/sep45-reference
    Ref:        refs/tags/v0.1.3
    Path:       .github/workflows/release.yml
    Git Commit: 3dcabc965f01512a631d2c0c6999786f5f6a01cd
    Runner:     github-hosted
    Run:        https://github.com/stellar/sep45-reference/actions/runs/21009985939/attempts/1
🌎 View the workflow at https://github.com/stellar/sep45-reference/blob/3dcabc965f01512a631d2c0c6999786f5f6a01cd/.github/workflows/release.yml
🌎 View the repo at https://github.com/stellar/sep45-reference/tree/3dcabc965f01512a631d2c0c6999786f5f6a01cd
```

### Why

Close #2358

### Known limitations

N/A
