### PR TITLE
Update cargo-deny.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
     continue-on-error: ${{ matrix.check == 'advisories' }}
     steps:
       - uses: actions/checkout@v5
-      - uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979
         with:
           command: check ${{ matrix.check }}
 


### PR DESCRIPTION
### What

Update cargo-deny action.

### Why

So it fixes the error 

```
2026-01-19 20:01:27 [ERROR] failed to load advisory database: parse error: error parsing /github/home/.cargo/advisory-db/advisory-db-3157b0e258782691/crates/cmov/RUSTSEC-2026-0003.md: parse error: TOML parse error at line 7, column 8
  |
7 | cvss = "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N"
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unsupported CVSS version: 4.0
```

### Known limitations

N/A
