### PR TITLE
Fix `snapshot create` unconditionally adding entries when match result was unused.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,7 +5021,6 @@ dependencies = [
  "soroban-ledger-snapshot",
  "soroban-sdk",
  "soroban-spec",
- "soroban-spec-json",
  "soroban-spec-rust",
  "soroban-spec-tools",
  "soroban-spec-typescript",
@@ -5208,20 +5207,6 @@ dependencies = [
  "stellar-xdr",
  "thiserror 1.0.69",
  "wasmparser",
-]
-
-[[package]]
-name = "soroban-spec-json"
-version = "25.1.0"
-dependencies = [
- "pretty_assertions",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.9.9",
- "soroban-spec",
- "stellar-xdr",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -274,7 +274,6 @@ Generate code client bindings for a contract
 
 ###### **Subcommands:**
 
-- `json` — Generate Json Bindings
 - `rust` — Generate Rust bindings
 - `typescript` — Generate a TypeScript / JavaScript package
 - `python` — Generate Python bindings
@@ -282,16 +281,6 @@ Generate code client bindings for a contract
 - `flutter` — Generate Flutter bindings
 - `swift` — Generate Swift bindings
 - `php` — Generate PHP bindings
-
-## `stellar contract bindings json`
-
-Generate Json Bindings
-
-**Usage:** `stellar contract bindings json --wasm <WASM>`
-
-###### **Options:**
-
-- `--wasm <WASM>` — Path to wasm binary
 
 ## `stellar contract bindings rust`
 

--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -350,7 +350,7 @@ impl Cmd {
                         continue;
                     };
 
-                    match &val.data {
+                    let include = match &val.data {
                         LedgerEntryData::ConfigSetting(ConfigSettingEntry::StateArchival(
                             state_archival,
                         )) => {
@@ -409,10 +409,12 @@ impl Cmd {
                         }
                         _ => false,
                     };
-                    snapshot
-                        .ledger_entries
-                        .push((Box::new(key), (Box::new(val), Some(u32::MAX))));
-                    count_saved += 1;
+                    if include {
+                        snapshot
+                            .ledger_entries
+                            .push((Box::new(key), (Box::new(val), Some(u32::MAX))));
+                        count_saved += 1;
+                    }
                 }
                 if count_saved > 0 {
                     print.infoln(format!("Found {count_saved} entries"));


### PR DESCRIPTION
### What

Fix `snapshot create` unconditionally adding entries when match result was unused.

```console
$ grep -c config_setting /tmp/before.json
17

$ grep -c config_setting /tmp/after.json
0
```

### Why

A previous refactor broke filtering. Close #2397.

### Known limitations

N/A
