### PR TITLE
Add network id to `stellar network info`.

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/network.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/network.rs
@@ -1,5 +1,5 @@
 use predicates::prelude::{predicate, PredicateBooleanExt};
-use soroban_test::TestEnv;
+use soroban_test::{AssertExt, TestEnv};
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
@@ -51,4 +51,35 @@ async fn unset_default_network() {
         .assert()
         .stdout(predicate::str::contains("STELLAR_NETWORK=").not())
         .success();
+}
+
+#[tokio::test]
+async fn network_info_includes_id_in_text_output() {
+    let sandbox = &TestEnv::new();
+    sandbox
+        .new_assert_cmd("network")
+        .arg("info")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Network Id: baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a",
+        ));
+}
+
+#[tokio::test]
+async fn network_info_includes_id_in_json_output() {
+    let sandbox = &TestEnv::new();
+    let output = sandbox
+        .new_assert_cmd("network")
+        .arg("info")
+        .arg("--output")
+        .arg("json")
+        .assert()
+        .success()
+        .stdout_as_str();
+    let info: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(
+        info["id"],
+        "baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a"
+    );
 }


### PR DESCRIPTION
### What

```console
$ stellar network info --output json
{"id":"baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a","version":"25.0.0","commit_hash":"9fc81d81a4680932f2a94a641613ef1546be206c","build_timestamp":"2026-01-08T23:18:11","captive_core_version":"v25.1.1","protocol_version":25,"passphrase":"Standalone Network ; February 2017","friendbot_url":"http://localhost:8000/friendbot"}

$ stellar network info --output json-formatted
{
  "id": "baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a",
  "version": "25.0.0",
  "commit_hash": "9fc81d81a4680932f2a94a641613ef1546be206c",
  "build_timestamp": "2026-01-08T23:18:11",
  "captive_core_version": "v25.1.1",
  "protocol_version": 25,
  "passphrase": "Standalone Network ; February 2017",
  "friendbot_url": "http://localhost:8000/friendbot"
}

$ stellar network info
ℹ️ Network Id: baefd734b8d3e48472cff83912375fedbc7573701912fe308af730180f97d74a
ℹ️ Version: 25.0.0
ℹ️ Commit Hash: 9fc81d81a4680932f2a94a641613ef1546be206c
ℹ️ Build Timestamp: 2026-01-08T23:18:11
ℹ️ Captive Core Version: v25.1.1
ℹ️ Protocol Version: 25
ℹ️ Passphrase: Standalone Network ; February 2017
ℹ️ Friendbot Url: http://localhost:8000/friendbot
```

### Why

Close #2390.

### Known limitations

N/A
