### PR TITLE
Add CI for soroban-examples and OZ contracts

### DIFF
--- a/.github/workflows/test-with-openzeppelin-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-contracts.yml
@@ -16,14 +16,6 @@ defaults:
     shell: bash
 
 jobs:
-  complete:
-    if: always()
-    needs: [build-cli, collect-crates, build-crate]
-    runs-on: ubuntu-slim
-    steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1
-
   build-cli:
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -16,14 +16,6 @@ defaults:
     shell: bash
 
 jobs:
-  complete:
-    if: always()
-    needs: [build-cli, collect-examples, build-example]
-    runs-on: ubuntu-slim
-    steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1
-
   build-cli:
     runs-on: ubuntu-latest-8-cores
     steps:


### PR DESCRIPTION
### What
Add two GitHub Actions workflows that build real-world contracts from `stellar/soroban-examples` and `OpenZeppelin/stellar-contracts` using the CLI built from source. Each workflow builds all cdylib contracts with `stellar contract build`, verifies each Wasm exposes at least one contract function via `stellar contract info interface`.

### Why
The CLI has little coverage for `stellar contract build` or `stellar contract upload` against real-world contracts, leaving regressions in those paths undetected until after release.

This test is limited in that it doesn't check much about the contract, but does check that the build process works, doesn't error, and that the resulting contracts still have expected custom sections which are components that the stellar-cli does touch.

This testing approach of testing against soroban-examples and openzeppelin/stellar-contracts is used today in the stellar/rs-soroban-sdk.

Close #2423