### PR TITLE
Fix CI wasm discovery picking dependency files

### DIFF
--- a/.github/workflows/test-with-openzeppelin-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-contracts.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Find wasm
         id: find-wasm
         run: |
-          wasm=$(find . -name '*.wasm' -path '*/wasm32v1-none/*' | head -1)
+          wasm=$(find . -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
           echo "wasm=$wasm" | tee -a $GITHUB_OUTPUT
       - name: Verify interface
         run: |

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Find wasm
         id: find-wasm
         run: |
-          wasm=$(find ${{ matrix.dir }}/target -name '*.wasm' -path '*/wasm32v1-none/*' | head -1)
+          wasm=$(find ${{ matrix.dir }}/target -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
           echo "wasm=$wasm" | tee -a $GITHUB_OUTPUT
       - name: Verify interface
         run: |


### PR DESCRIPTION
### What
Exclude `deps/` from the `find` command that locates built WASM files in the OpenZeppelin contracts and soroban-examples CI workflows. Add `-not -path '*/deps/*'` and narrow the search to `*/wasm32v1-none/release/*`.

### Why
The `find | head -1` command was picking up dependency library WASMs from `target/wasm32v1-none/release/deps/` (e.g., `stellar_tokens.wasm`) instead of the actual contract WASM (e.g., `fungible_pausable_example.wasm`). This caused `spec-verify` and other verification steps to run against library WASMs that contain duplicate spec entries from aggregating multiple token standards, failing the CI for many crates.

This is also impacting https://github.com/stellar/stellar-cli/pull/2353.