### PR TITLE
chore: update sdk to published version, update sep5, and remove slipped10 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -659,12 +683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,12 +712,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -719,9 +764,30 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -797,7 +863,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -835,6 +901,16 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "time",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2 0.10.9",
+ "tinyvec",
 ]
 
 [[package]]
@@ -1059,6 +1135,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "coins-bip32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c43ff7fd9ff522219058808a259e61423335767b1071d5b346de60d9219657"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4587c0b4064da887ed39a6522f577267d57e58bdd583178cd877d721b56a2e"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3aeeec621f4daec552e9d28befd58020a78cfc364827d06a753e8bc13c6c4b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32 0.9.1",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2 0.10.9",
+ "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -1161,6 +1300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,17 +1364,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -1268,6 +1404,15 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "curve25519-dalek"
@@ -1449,6 +1594,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1770,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1671,10 +1828,46 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
+
+[[package]]
+name = "embassy-sync"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-sink",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
+dependencies = [
+ "embedded-io",
 ]
 
 [[package]]
@@ -1961,6 +2154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,9 +2308,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2233,7 +2441,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -2306,17 +2516,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -3021,7 +3221,9 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.9",
+ "signature",
 ]
 
 [[package]]
@@ -3589,6 +3791,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ows-core"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f45a4d7f9502c7edf8841ab7a13ee4a4782830262139d9863a9b390ea93ec1"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "ows-signer"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dbe55662b82df0c62f21331d55be7c0ef9f03c7f55be7b3cc1f40b61cc107d"
+dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
+ "bech32 0.11.1",
+ "blake2",
+ "bs58",
+ "coins-bip32",
+ "coins-bip39",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "hex",
+ "hkdf",
+ "hmac",
+ "k256",
+ "libc",
+ "ows-core",
+ "rand 0.8.5",
+ "ripemd",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "signal-hook",
+ "thiserror 2.0.18",
+ "xrpl-rust",
+ "zeroize",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,6 +3904,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,11 +3928,12 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -3813,6 +4074,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,6 +4208,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3980,7 +4268,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
  "socket2 0.6.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4001,7 +4289,7 @@ dependencies = [
  "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4043,6 +4331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,16 +4355,6 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "getrandom 0.4.2",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -4112,10 +4396,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.0"
+name = "rand_hc"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4240,7 +4536,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -4256,6 +4552,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4311,6 +4616,18 @@ checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4470,6 +4787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4557,6 +4883,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4581,8 +4919,27 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4651,13 +5008,14 @@ dependencies = [
 
 [[package]]
 name = "sep5"
-version = "0.0.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec6914e06f503f83e431e1762c82003c5233b1dffb6185e51e4c40dd1c26eaa"
+checksum = "35a5a225b0cc092f0c818c7e51faf9d63d07da8c3157d6250096ca4b8708cfe3"
 dependencies = [
- "slipped10",
- "stellar-strkey 0.0.8",
- "thiserror 1.0.69",
+ "ed25519-dalek",
+ "ows-signer",
+ "stellar-strkey 0.0.16",
+ "thiserror 2.0.18",
  "tiny-bip39",
 ]
 
@@ -4910,6 +5268,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4945,18 +5313,6 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
-name = "slipped10"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0467009f63d9ec6920100ddb026ccdb8b661ba37aaa86664c5e9ac3a4e3e316b"
-dependencies = [
- "ed25519-dalek",
- "hmac 0.9.0",
- "rand 0.10.0",
- "sha2 0.9.9",
-]
 
 [[package]]
 name = "smallvec"
@@ -5008,9 +5364,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.0.1"
+version = "26.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38f0269c20b3c4c3aa2198b5460c72837e0361295a46b914adbcad67fa83d48"
+checksum = "df78c69d87834af6a53e47323a8fa02d68d92ab233476c860db643f8d1801cfe"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5112,9 +5468,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.0.1"
+version = "26.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b15a125a4ec51eeee94cfa58ac3e4f29e7f5426e7f4692a1b119ee60d83a06"
+checksum = "08582c2c21bd3f7b737bcb76db9d4ca473f8349d65f8952a50eeed8823f44aef"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -5131,9 +5487,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.0.1"
+version = "26.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85f2b5be7654eca65aa17333cb3fe6b0e6685bc7a40792e28e247e4fef6372e"
+checksum = "aad436ff91576ce4c231b474aecd521ccf890df62042fc0234ffc2006b72fa1b"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -5141,9 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.0.1"
+version = "26.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9c9c66b62af1179dc6265000bb4356caf0b67225568f64f39bd4194925917a"
+checksum = "2662cd060f6a3be269e23d0611bd2ea9eb6a0e7db77e11427e09de0efe547f8b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5157,7 +5513,7 @@ dependencies = [
  "generic-array",
  "getrandom 0.2.16",
  "hex-literal",
- "hmac 0.12.1",
+ "hmac",
  "k256",
  "num-derive",
  "num-integer",
@@ -5178,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.0.1"
+version = "26.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d075b3654119b6dac81abd0f8c2f29cdba36edbda102b3c8c3d5f029f099790"
+checksum = "9d5489ee232e1fa56c817ac57e2cba8b788685c48902928fecbae05cba97f065"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5197,8 +5553,9 @@ version = "25.2.0"
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8330f1ba47d85183b96f6a5f1f774d76100cd40baa79cada77147e11fb4c7b5"
 dependencies = [
  "serde",
  "serde_json",
@@ -5210,8 +5567,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc156a0183eb584e57d45f63f3bd7023165980131d6eecc939fe5cda2490c63"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5233,8 +5591,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422af96b2e135390beb043480eb376b27943bd79e6857e5c950e307da057d0ad"
 dependencies = [
  "darling",
  "heck 0.5.0",
@@ -5252,8 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5077ba171ede4dd69428095a2760b01196291b9bd467a4f4ba27bdfec206ade5"
 dependencies = [
  "base64 0.22.1",
  "sha2 0.10.9",
@@ -5264,8 +5624,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ddc78f9da68c1d20fd25194e43113fdd0bf40ad51d891c20c90268379af4390"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5362,16 +5723,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1898e882f2af93b2bda2c11543b9f189b8778110a66387df7e135f64f7f694e3"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfbce7705b66fc8adddf3170154a021f069584d9a541d9059ca748698c1cd5"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5420,8 +5783,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "25.3.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview#d5b6d67cdab661795943163669f1fae07669b2f3"
+version = "26.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca300556416dcb206b69a973612b8ae6adb6563942265d16c1f0b6ef69294343"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5463,7 +5827,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
- "slipped10",
  "stellar-strkey 0.0.15",
  "stellar-xdr",
  "test-case",
@@ -5496,17 +5859,6 @@ dependencies = [
  "termcolor_output",
  "thiserror 1.0.69",
  "tokio",
-]
-
-[[package]]
-name = "stellar-strkey"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
-dependencies = [
- "base32",
- "crate-git-revision",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5623,6 +5975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
 name = "strum_macros"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5645,6 +6003,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5715,6 +6086,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "temp-dir"
@@ -5891,7 +6268,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5909,11 +6286,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5929,13 +6306,33 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]
@@ -5980,12 +6377,10 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
+checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
- "anyhow",
- "hmac 0.12.1",
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
@@ -6371,6 +6766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6408,6 +6809,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -6472,6 +6883,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -6584,6 +7006,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -7303,6 +7726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7320,6 +7752,55 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xrpl-rust"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f1baf87fce6470794dd95d125864dc08b1aeef4c7dc3931cad039deae7b544"
+dependencies = [
+ "bigdecimal",
+ "bs58",
+ "chrono",
+ "crypto-bigint",
+ "derive-new",
+ "ed25519-dalek",
+ "embassy-futures",
+ "embassy-sync",
+ "fnv",
+ "hashbrown 0.15.5",
+ "hex",
+ "indexmap 2.11.0",
+ "lazy_static",
+ "rand 0.8.5",
+ "rand_hc",
+ "regex",
+ "ripemd",
+ "rust_decimal",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "sha2 0.10.9",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror-no-std",
+ "url",
+ "xrpl-rust-macros",
+ "zeroize",
+]
+
+[[package]]
+name = "xrpl-rust-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c5a56d688dd492c201011c19933a9d0e64452d3763bc88624dde91fff37164"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,39 +48,25 @@ version = "26.0.0"
 
 # Dependencies from the rs-soroban-sdk repo:
 [workspace.dependencies.soroban-spec]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 [workspace.dependencies.soroban-env-host]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 [workspace.dependencies.soroban-token-sdk]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 [workspace.dependencies.stellar-asset-spec]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "25.3.1"
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "release/v26-preview"
+version = "26.0.0-rc.1"
 
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
@@ -90,7 +76,7 @@ version = "26.0.0-rc.1"
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]
 stellar-strkey = "0.0.15"
-sep5 = "0.0.4"
+sep5 = "0.1.0"
 base64 = "0.21.2"
 thiserror = "1.0.46"
 sha2 = "0.10.7"

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -100,7 +100,6 @@ async fn invoke_contract() {
     invoke_hello_world_with_lib(sandbox, id).await;
 
     let config_locator = locator::Args {
-        global: false,
         config_dir: Some(dir.to_path_buf()),
     };
 

--- a/cmd/crates/stellar-ledger/Cargo.toml
+++ b/cmd/crates/stellar-ledger/Cargo.toml
@@ -20,7 +20,6 @@ ed25519-dalek = { workspace = true }
 stellar-strkey = { workspace = true }
 ledger-transport-hid = "0.10.0"
 ledger-transport = "0.10.0"
-slip10 = { package = "slipped10", version = "0.4.7" }
 tracing = { workspace = true }
 hex.workspace = true
 byteorder = "1.5.0"

--- a/cmd/crates/stellar-ledger/src/hd_path.rs
+++ b/cmd/crates/stellar-ledger/src/hd_path.rs
@@ -1,7 +1,6 @@
-use crate::Error;
+use crate::{Error, HD_PATH_ELEMENTS_COUNT};
 
 const HARDENED_OFFSET: u32 = 1 << 31;
-const STELLAR_PATH_DEPTH: u8 = 3;
 const PURPOSE: u32 = 44;
 const COIN_TYPE: u32 = 148;
 
@@ -11,7 +10,7 @@ pub struct HdPath(pub u32);
 impl HdPath {
     #[must_use]
     pub fn depth(&self) -> u8 {
-        STELLAR_PATH_DEPTH
+        HD_PATH_ELEMENTS_COUNT
     }
 }
 
@@ -62,7 +61,7 @@ mod test {
 
     #[test]
     fn test_depth() {
-        assert_eq!(HdPath(7).depth(), STELLAR_PATH_DEPTH);
+        assert_eq!(HdPath(7).depth(), HD_PATH_ELEMENTS_COUNT);
     }
 
     #[test]

--- a/cmd/crates/stellar-ledger/src/hd_path.rs
+++ b/cmd/crates/stellar-ledger/src/hd_path.rs
@@ -1,13 +1,17 @@
 use crate::Error;
 
+const HARDENED_OFFSET: u32 = 1 << 31;
+const STELLAR_PATH_DEPTH: u8 = 3;
+const PURPOSE: u32 = 44;
+const COIN_TYPE: u32 = 148;
+
 #[derive(Clone, Copy)]
 pub struct HdPath(pub u32);
 
 impl HdPath {
     #[must_use]
     pub fn depth(&self) -> u8 {
-        let path: slip10::BIP32Path = self.into();
-        path.depth()
+        STELLAR_PATH_DEPTH
     }
 }
 
@@ -28,27 +32,57 @@ impl HdPath {
     ///
     /// Could fail to convert the path to bytes
     pub fn to_vec(&self) -> Result<Vec<u8>, Error> {
-        hd_path_to_bytes(&self.into())
+        hd_path_to_bytes(*self)
     }
 }
 
-impl From<&HdPath> for slip10::BIP32Path {
-    fn from(value: &HdPath) -> Self {
-        let index = value.0;
-        format!("m/44'/148'/{index}'").parse().unwrap()
-    }
+fn hd_path_to_bytes(hd_path: HdPath) -> Result<Vec<u8>, Error> {
+    let index = hardened(hd_path.0, hd_path)?;
+    let result = [
+        hardened(PURPOSE, hd_path)?,
+        hardened(COIN_TYPE, hd_path)?,
+        index,
+    ];
+    Ok(result.into_iter().flat_map(u32::to_be_bytes).collect())
 }
 
-fn hd_path_to_bytes(hd_path: &slip10::BIP32Path) -> Result<Vec<u8>, Error> {
-    let hd_path_indices = 0..hd_path.depth();
-    let result = hd_path_indices
-        .into_iter()
-        .map(|index| {
-            Ok(hd_path
-                .index(index)
-                .ok_or_else(|| Error::Bip32PathError(format!("{hd_path}")))?
-                .to_be_bytes())
-        })
-        .collect::<Result<Vec<_>, Error>>()?;
-    Ok(result.into_iter().flatten().collect())
+fn hardened(value: u32, hd_path: HdPath) -> Result<u32, Error> {
+    value
+        .checked_add(HARDENED_OFFSET)
+        .ok_or_else(|| Error::Bip32PathError(path_string(hd_path)))
+}
+
+fn path_string(hd_path: HdPath) -> String {
+    format!("m/{PURPOSE}'/{COIN_TYPE}'/{}'", hd_path.0)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_depth() {
+        assert_eq!(HdPath(7).depth(), STELLAR_PATH_DEPTH);
+    }
+
+    #[test]
+    fn test_to_vec() {
+        assert_eq!(
+            HdPath(7).to_vec().unwrap(),
+            vec![0x80, 0x00, 0x00, 0x2c, 0x80, 0x00, 0x00, 0x94, 0x80, 0x00, 0x00, 0x07,]
+        );
+    }
+
+    #[test]
+    fn test_to_vec_rejects_out_of_range_index() {
+        let err = HdPath(HARDENED_OFFSET).to_vec().unwrap_err();
+        assert!(matches!(err, Error::Bip32PathError(_)));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "Error occurred while parsing BIP32 path: {}",
+                path_string(HdPath(HARDENED_OFFSET))
+            )
+        );
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -66,6 +66,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "ISC",
     "BSD-2-Clause",
+    "CC0-1.0",
     "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
@@ -188,14 +189,6 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-
-    # Requires updating slipped10 to newest sha2 others are dependents that will be updated
-    { crate = "sha2", reason = "temporary duplicate until upstream updates" },
-    { crate = "digest", reason = "temporary duplicate until upstream updates" },
-    { crate = "block-buffer", reason = "temporary duplicate until upstream updates" },
-    # slipped again 0.12.1
-    { crate = "hmac", reason = "temp" },
-
     # syn is too large of a surface to check
     { crate = "syn", reason = "Too many crates haven't updated to v2" },
 
@@ -238,8 +231,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
   # Only used by the unpublished doc-gen crate, temporarily until PR is merged: https://github.com/ConnorGray/clap-markdown/pull/48
-  "https://github.com/ConnorGray/clap-markdown?rev=42956b342cef3325d9060fc43995d595e7c8aa66",
-  "https://github.com/stellar/rs-soroban-sdk?branch=release%2Fv26-preview"
+  "https://github.com/ConnorGray/clap-markdown?rev=42956b342cef3325d9060fc43995d595e7c8aa66"
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
### What

Update the `sep5` crate that also removed the `slipped10` dependency in favor of `ows_signer` to `0.1.0`. Also, manually implement the HD Path logic in `stellar-ledger` instead of relying on `slipped10`.

### Why

The `slipped10` dependency has a security advisory, and old, valid versions were yanked.

### Known limitations

None
