### PR TITLE
Allowlist cargo deny rand advisory.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,7 @@ ignore = [
     "RUSTSEC-2024-0436", # paste is no longer maintained
     "RUSTSEC-2025-0052", # async-std has been discontinued - used only in test dependencies
     "RUSTSEC-2025-0134", # rustls-pemfile has been discontinued - need to update stellar-rpc-client with compatible jsonrpsee (possible other deps too)
-    "RUSTSEC-2026-0097", # rand 0.8.5 unsound advisory - pinned by transitive deps (ark-std, soroban-env-host); no patch in 0.8.x line
+    "RUSTSEC-2026-0097", # rand 0.8.5 unsound advisory - currently present in Cargo.lock via transitive dependencies such as ark-std and soroban-env-host
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,7 @@ ignore = [
     "RUSTSEC-2024-0436", # paste is no longer maintained
     "RUSTSEC-2025-0052", # async-std has been discontinued - used only in test dependencies
     "RUSTSEC-2025-0134", # rustls-pemfile has been discontinued - need to update stellar-rpc-client with compatible jsonrpsee (possible other deps too)
+    "RUSTSEC-2026-0097", # rand 0.8.5 unsound advisory - pinned by transitive deps (ark-std, soroban-env-host); no patch in 0.8.x line
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
### What

Allowlist cargo deny rand advisory.

### Why

Because transient deps don't allow upgrading rand to the recommended version.

### Known limitations

N/A
