### PR TITLE
Reject non-ULID IDs in cache actionlog read command.

### DIFF
--- a/cmd/soroban-cli/src/commands/cache/actionlog/read.rs
+++ b/cmd/soroban-cli/src/commands/cache/actionlog/read.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::PathBuf};
+use std::io;
 
 use crate::config::{data, locator};
 
@@ -12,6 +12,10 @@ pub enum Error {
     NotFound(String),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
+    #[error("invalid cache entry ID \"{0}\": expected a ULID")]
+    InvalidId(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -24,15 +28,65 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let file = self.file()?;
+        let id: ulid::Ulid = self
+            .id
+            .parse()
+            .map_err(|_| Error::InvalidId(self.id.clone()))?;
+        let file = data::actions_dir()?
+            .join(id.to_string())
+            .with_extension("json");
         tracing::debug!("reading file {}", file.display());
-        let mut file = fs::File::open(file).map_err(|_| Error::NotFound(self.id.clone()))?;
+        let contents =
+            std::fs::read_to_string(&file).map_err(|_| Error::NotFound(self.id.clone()))?;
         let mut stdout = io::stdout();
-        let _ = io::copy(&mut file, &mut stdout);
+        io::Write::write_all(&mut stdout, contents.as_bytes())?;
         Ok(())
     }
+}
 
-    pub fn file(&self) -> Result<PathBuf, Error> {
-        Ok(data::actions_dir()?.join(&self.id).with_extension("json"))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn path_traversal_via_dotdot_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("STELLAR_DATA_HOME", tmp.path());
+
+        let outside = tmp.path().join("outside.json");
+        std::fs::write(&outside, r#"{"leaked":true}"#).unwrap();
+
+        let cmd = Cmd {
+            id: "../outside".to_string(),
+        };
+
+        assert!(
+            cmd.run().is_err(),
+            "expected an error for a path-traversal ID, but run() succeeded"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn absolute_path_id_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("STELLAR_DATA_HOME", tmp.path());
+
+        let outside = tmp.path().join("outside.json");
+        std::fs::write(&outside, r#"{"leaked":true}"#).unwrap();
+
+        let abs_id = outside
+            .to_str()
+            .unwrap()
+            .trim_end_matches(".json")
+            .to_string();
+        let cmd = Cmd { id: abs_id };
+
+        assert!(
+            cmd.run().is_err(),
+            "expected an error for an absolute-path ID, but run() succeeded"
+        );
     }
 }

--- a/cmd/soroban-cli/src/commands/cache/actionlog/read.rs
+++ b/cmd/soroban-cli/src/commands/cache/actionlog/read.rs
@@ -36,10 +36,14 @@ impl Cmd {
             .join(id.to_string())
             .with_extension("json");
         tracing::debug!("reading file {}", file.display());
-        let contents =
-            std::fs::read_to_string(&file).map_err(|_| Error::NotFound(self.id.clone()))?;
-        let mut stdout = io::stdout();
-        io::Write::write_all(&mut stdout, contents.as_bytes())?;
+        let mut f = std::fs::File::open(&file).map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                Error::NotFound(self.id.clone())
+            } else {
+                Error::Io(e)
+            }
+        })?;
+        io::copy(&mut f, &mut io::stdout())?;
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/cache/actionlog/read.rs
+++ b/cmd/soroban-cli/src/commands/cache/actionlog/read.rs
@@ -10,8 +10,6 @@ pub enum Error {
     Data(#[from] data::Error),
     #[error("failed to find cache entry {0}")]
     NotFound(String),
-    #[error(transparent)]
-    SerdeJson(#[from] serde_json::Error),
     #[error("invalid cache entry ID \"{0}\": expected a ULID")]
     InvalidId(String),
     #[error(transparent)]
@@ -51,13 +49,14 @@ impl Cmd {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::EnvGuard;
     use serial_test::serial;
 
     #[test]
     #[serial]
     fn path_traversal_via_dotdot_is_rejected() {
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("STELLAR_DATA_HOME", tmp.path());
+        let _guard = EnvGuard::set("STELLAR_DATA_HOME", tmp.path());
 
         let outside = tmp.path().join("outside.json");
         std::fs::write(&outside, r#"{"leaked":true}"#).unwrap();
@@ -66,9 +65,10 @@ mod tests {
             id: "../outside".to_string(),
         };
 
+        let err = cmd.run().expect_err("expected error for path-traversal ID");
         assert!(
-            cmd.run().is_err(),
-            "expected an error for a path-traversal ID, but run() succeeded"
+            matches!(err, Error::InvalidId(_)),
+            "expected InvalidId, got {err:?}"
         );
     }
 
@@ -76,7 +76,7 @@ mod tests {
     #[serial]
     fn absolute_path_id_is_rejected() {
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("STELLAR_DATA_HOME", tmp.path());
+        let _guard = EnvGuard::set("STELLAR_DATA_HOME", tmp.path());
 
         let outside = tmp.path().join("outside.json");
         std::fs::write(&outside, r#"{"leaked":true}"#).unwrap();
@@ -88,9 +88,10 @@ mod tests {
             .to_string();
         let cmd = Cmd { id: abs_id };
 
+        let err = cmd.run().expect_err("expected error for absolute-path ID");
         assert!(
-            cmd.run().is_err(),
-            "expected an error for an absolute-path ID, but run() succeeded"
+            matches!(err, Error::InvalidId(_)),
+            "expected InvalidId, got {err:?}"
         );
     }
 }

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -888,28 +888,7 @@ mod tests {
         );
     }
 
-    struct EnvGuard(Vec<(String, Option<String>)>);
-
-    impl EnvGuard {
-        fn new(vars: &[&str]) -> Self {
-            let saved = vars
-                .iter()
-                .map(|k| (k.to_string(), std::env::var(k).ok()))
-                .collect();
-            Self(saved)
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.0 {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-    }
+    use crate::test_utils::EnvGuard;
 
     #[test]
     #[serial]

--- a/cmd/soroban-cli/src/lib.rs
+++ b/cmd/soroban-cli/src/lib.rs
@@ -27,6 +27,9 @@ pub mod upgrade_check;
 pub mod utils;
 pub mod wasm;
 
+#[cfg(test)]
+pub mod test_utils;
+
 pub use commands::Root;
 
 pub fn parse_cmd<T>(s: &str) -> Result<T, clap::Error>

--- a/cmd/soroban-cli/src/test_utils.rs
+++ b/cmd/soroban-cli/src/test_utils.rs
@@ -1,0 +1,34 @@
+/// Saves and restores environment variables on drop.
+///
+/// Useful in tests that mutate env vars — guarantees cleanup even on panic.
+pub struct EnvGuard(Vec<(String, Option<String>)>);
+
+impl EnvGuard {
+    pub fn new(vars: &[&str]) -> Self {
+        let saved = vars
+            .iter()
+            .map(|k| (k.to_string(), std::env::var(k).ok()))
+            .collect();
+        for k in vars {
+            std::env::remove_var(k);
+        }
+        Self(saved)
+    }
+
+    pub fn set(key: &'static str, val: &std::path::Path) -> Self {
+        let prev = std::env::var(key).ok();
+        std::env::set_var(key, val);
+        Self(vec![(key.to_string(), prev)])
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.0 {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What

Reject non-ULID IDs in cache actionlog read command.

### Why

So we only accept valid ULIDs.

### Known limitations

N/A
