### PR TITLE
Stop reading from local config directory.

### DIFF
--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -105,9 +105,9 @@ fn multiple_networks() {
 #[test]
 fn read_key() {
     let sandbox = TestEnv::default();
-    let dir = sandbox.dir().as_ref();
-    add_test_id(dir);
-    let ident_dir = dir.join(".soroban/identity");
+    let config_dir = sandbox.config_dir();
+    add_test_id(&config_dir);
+    let ident_dir = config_dir.join("identity");
     assert!(ident_dir.exists());
     sandbox
         .new_assert_cmd("keys")
@@ -179,9 +179,9 @@ fn generate_key_on_testnet() {
 #[test]
 fn seed_phrase() {
     let sandbox = TestEnv::default();
-    let dir = sandbox.dir();
+    let config_dir = sandbox.config_dir();
     add_key(
-        dir,
+        &config_dir,
         "test_seed",
         SecretKind::Seed,
         "one two three four five six seven eight nine ten eleven twelve",
@@ -189,7 +189,6 @@ fn seed_phrase() {
 
     sandbox
         .new_assert_cmd("keys")
-        .current_dir(dir)
         .arg("ls")
         .assert()
         .stdout(predicates::str::contains("test_seed\n"));

--- a/cmd/crates/soroban-test/tests/it/util.rs
+++ b/cmd/crates/soroban-test/tests/it/util.rs
@@ -24,9 +24,7 @@ pub fn add_key(dir: &Path, name: &str, kind: SecretKind, data: &str) {
         },
     };
 
-    KeyType::Identity
-        .write(name, &secret, &dir.join(".soroban"))
-        .unwrap();
+    KeyType::Identity.write(name, &secret, dir).unwrap();
 }
 
 pub fn add_test_id(dir: &Path) -> String {

--- a/cmd/soroban-cli/src/commands/contract/alias/ls.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/ls.rs
@@ -45,15 +45,19 @@ impl Cmd {
 
         for cfg in config_dirs {
             match cfg {
-                Location::Local(config_dir) => Self::read_from_config_dir(&config_dir, true)?,
-                Location::Global(config_dir) => Self::read_from_config_dir(&config_dir, false)?,
+                Location::Local(config_dir) => {
+                    if config_dir.exists() {
+                        print_deprecation_warning(&config_dir);
+                    }
+                }
+                Location::Global(config_dir) => Self::read_from_config_dir(&config_dir)?,
             }
         }
 
         Ok(())
     }
 
-    fn read_from_config_dir(config_dir: &Path, deprecation_mode: bool) -> Result<(), Error> {
+    fn read_from_config_dir(config_dir: &Path) -> Result<(), Error> {
         let pattern = config_dir
             .join("contract-ids")
             .join("*.json")
@@ -98,9 +102,6 @@ impl Cmd {
                 list.sort_by(|a, b| a.alias.cmp(&b.alias));
 
                 for entry in list {
-                    if !found && deprecation_mode {
-                        print_deprecation_warning(config_dir);
-                    }
                     found = true;
                     println!("{}: {}", entry.alias, entry.contract);
                 }
@@ -109,7 +110,7 @@ impl Cmd {
             }
         }
 
-        if !found && !deprecation_mode {
+        if !found {
             eprintln!("⚠️ No aliases defined for network");
 
             process::exit(1);

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -167,7 +167,11 @@ impl Args {
     }
 
     pub fn local_config(&self) -> Result<PathBuf, Error> {
-        let pwd = self.current_dir()?;
+        // When --config-dir is explicitly set, do not walk ancestors of that
+        // path — doing so would let callers read identities from outside the
+        // selected profile (security finding 004).  Use the real process cwd
+        // for local-config discovery regardless.
+        let pwd = std::env::current_dir().map_err(|_| Error::CurrentDirNotFound)?;
         Ok(find_config_dir(pwd.clone()).unwrap_or_else(|_| pwd.join(".stellar")))
     }
 
@@ -889,6 +893,50 @@ mod tests {
     }
 
     use crate::test_utils::EnvGuard;
+
+    #[test]
+    #[serial]
+    fn config_dir_does_not_search_ancestors_for_identity() {
+        // Regression test for: --config-dir ancestor search discloses secrets
+        // outside the selected profile (security finding 004).
+        //
+        // Place alice.toml in an ancestor of the explicit --config-dir.
+        // The command should fail to find alice, not read the ancestor file.
+        use crate::config::key::Key;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+
+        // Ancestor .stellar with alice.toml
+        let ancestor_identity_dir = tmp.path().join(".stellar/identity");
+        std::fs::create_dir_all(&ancestor_identity_dir).unwrap();
+        std::fs::write(
+            ancestor_identity_dir.join("alice.toml"),
+            "seed_phrase = \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"\n",
+        )
+        .unwrap();
+
+        // Explicit --config-dir is a descendant of the ancestor, and is empty.
+        let isolated = tmp.path().join("sub/deep");
+        std::fs::create_dir_all(&isolated).unwrap();
+
+        // Global config is also separate and empty.
+        let global_cfg = tmp.path().join("global-cfg");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        let locator = Args {
+            config_dir: Some(isolated),
+        };
+
+        let result = locator.read_identity("alice");
+        assert!(
+            result.is_err(),
+            "expected error when alice is absent from --config-dir and global, \
+             but got: {:?}",
+            result.map(|k: Key| format!("{k:?}"))
+        );
+    }
 
     #[test]
     #[serial]

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -1008,6 +1008,95 @@ mod tests {
 
     #[test]
     #[serial]
+    fn local_config_network_is_not_read() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+        let _cwd = CwdGuard::new();
+
+        let local_network_dir = tmp.path().join(".stellar/network");
+        std::fs::create_dir_all(&local_network_dir).unwrap();
+        std::fs::write(
+            local_network_dir.join("mynet.toml"),
+            "rpc_url = \"https://127.0.0.1\"\nnetwork_passphrase = \"Local\"\n",
+        )
+        .unwrap();
+
+        let global_cfg = tmp.path().join("global");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let locator = Args { config_dir: None };
+        let result = locator.read_network("mynet");
+        assert!(result.is_err(), "local config network should not be read");
+    }
+
+    #[test]
+    #[serial]
+    fn local_config_network_not_listed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+        let _cwd = CwdGuard::new();
+
+        let local_network_dir = tmp.path().join(".stellar/network");
+        std::fs::create_dir_all(&local_network_dir).unwrap();
+        std::fs::write(
+            local_network_dir.join("mynet.toml"),
+            "rpc_url = \"https://127.0.0.1\"\nnetwork_passphrase = \"Local\"\n",
+        )
+        .unwrap();
+
+        let global_cfg = tmp.path().join("global");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let locator = Args { config_dir: None };
+        let networks = locator.list_networks().unwrap();
+        assert!(
+            !networks.contains(&"mynet".to_string()),
+            "local config networks should not appear in list, got: {networks:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn local_config_contract_alias_not_listed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+        let _cwd = CwdGuard::new();
+
+        let local_alias_dir = tmp.path().join(".stellar/contract-ids");
+        std::fs::create_dir_all(&local_alias_dir).unwrap();
+        std::fs::write(
+            local_alias_dir.join("mycontract.json"),
+            r#"{"ids":{"testnet":"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"}}"#,
+        )
+        .unwrap();
+
+        let global_cfg = tmp.path().join("global");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let locator = Args { config_dir: None };
+        let [local, global] = locator.local_and_global().unwrap();
+
+        // Verify the alias ls logic: local must be skipped, global has no aliases.
+        assert!(matches!(local, Location::Local(_)));
+        assert!(matches!(global, Location::Global(_)));
+        let global_alias_dir = global.as_ref().join("contract-ids");
+        assert!(
+            !global_alias_dir.exists(),
+            "global alias dir should be empty — local alias must not bleed through"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn config_dir_does_not_search_ancestors_for_identity() {
         // Regression test for: --config-dir ancestor search discloses secrets
         // outside the selected profile (security finding 004).

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -167,10 +167,9 @@ impl Args {
     }
 
     pub fn local_config(&self) -> Result<PathBuf, Error> {
-        // When --config-dir is explicitly set, do not walk ancestors of that
-        // path — doing so would let callers read identities from outside the
-        // selected profile (security finding 004).  Use the real process cwd
-        // for local-config discovery regardless.
+        // Always use the real process cwd for local-config discovery, regardless
+        // of whether --config-dir is set.  This prevents ancestor-walking outside
+        // the selected profile.
         let pwd = std::env::current_dir().map_err(|_| Error::CurrentDirNotFound)?;
         Ok(find_config_dir(pwd.clone()).unwrap_or_else(|_| pwd.join(".stellar")))
     }
@@ -512,7 +511,9 @@ pub fn print_deprecation_warning(dir: &Path) {
         return;
     }
 
-    print.warnln(format!("A local config was found at {dir:?}."));
+    print.warnln(format!(
+        "A local config was found at {dir:?} but is no longer read."
+    ));
     print.blankln(format!(
         " Run `stellar config migrate` to move the local config into the global config ({global_dir:?})."
     ));
@@ -724,7 +725,6 @@ impl KeyType {
     pub fn list_paths(&self, paths: &[Location]) -> Result<Vec<(String, Location)>, Error> {
         Ok(paths
             .iter()
-            .unique_by(|p| location_to_string(p))
             .filter(|p| {
                 if let Location::Local(dir) = p {
                     if dir.exists() {
@@ -734,6 +734,7 @@ impl KeyType {
                 }
                 true
             })
+            .unique_by(|p| location_to_string(p))
             .flat_map(|p| self.list(p, false).unwrap_or_default())
             .collect())
     }

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -348,14 +348,8 @@ impl Args {
 
         match local {
             Location::Local(config_dir) => {
-                let path = config_dir.join("contract-ids").join(&file_name);
-                if path.exists() {
+                if config_dir.exists() {
                     print_deprecation_warning(config_dir);
-
-                    let content = fs::read_to_string(path)?;
-                    let data: alias::Data = serde_json::from_str(&content).unwrap_or_default();
-
-                    return Ok(Some(data));
                 }
             }
             Location::Global(_) => unreachable!(),
@@ -656,13 +650,18 @@ impl KeyType {
         locator: &Args,
     ) -> Result<(T, Location), Error> {
         for location in locator.local_and_global()? {
-            let path = self.path(location.as_ref(), key);
-
-            if let Ok(t) = Self::read_from_path(&path) {
-                if let Location::Local(config_dir) = location.clone() {
-                    print_deprecation_warning(&config_dir);
+            match &location {
+                Location::Local(config_dir) => {
+                    if config_dir.exists() {
+                        print_deprecation_warning(config_dir);
+                    }
+                    continue;
                 }
+                Location::Global(_) => {}
+            }
 
+            let path = self.path(location.as_ref(), key);
+            if let Ok(t) = Self::read_from_path(&path) {
                 return Ok((t, location));
             }
         }
@@ -727,7 +726,16 @@ impl KeyType {
         Ok(paths
             .iter()
             .unique_by(|p| location_to_string(p))
-            .flat_map(|p| self.list(p, true).unwrap_or_default())
+            .filter(|p| {
+                if let Location::Local(dir) = p {
+                    if dir.exists() {
+                        print_deprecation_warning(dir);
+                    }
+                    return false;
+                }
+                true
+            })
+            .flat_map(|p| self.list(p, false).unwrap_or_default())
             .collect())
     }
 
@@ -893,6 +901,110 @@ mod tests {
     }
 
     use crate::test_utils::EnvGuard;
+
+    struct CwdGuard(std::path::PathBuf);
+
+    impl CwdGuard {
+        fn new() -> Self {
+            Self(std::env::current_dir().unwrap())
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn local_config_identity_is_not_read() {
+        use crate::config::key::Key;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+        let _cwd = CwdGuard::new();
+
+        let local_identity_dir = tmp.path().join(".stellar/identity");
+        std::fs::create_dir_all(&local_identity_dir).unwrap();
+        std::fs::write(
+            local_identity_dir.join("alice.toml"),
+            "seed_phrase = \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"\n",
+        )
+        .unwrap();
+
+        let global_cfg = tmp.path().join("global");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let locator = Args { config_dir: None };
+        let result = locator.read_identity("alice");
+        assert!(
+            result.is_err(),
+            "local config identity should not be read, but got: {:?}",
+            result.map(|k: Key| format!("{k:?}"))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn local_config_contract_alias_is_not_read() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+        let _cwd = CwdGuard::new();
+
+        let local_alias_dir = tmp.path().join(".stellar/contract-ids");
+        std::fs::create_dir_all(&local_alias_dir).unwrap();
+        std::fs::write(
+            local_alias_dir.join("mycontract.json"),
+            r#"{"ids":{"testnet":"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"}}"#,
+        )
+        .unwrap();
+
+        let global_cfg = tmp.path().join("global");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let locator = Args { config_dir: None };
+        let result = locator.load_contract_from_alias("mycontract").unwrap();
+        assert!(
+            result.is_none(),
+            "local config contract alias should not be read"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn local_config_identity_not_listed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::new(&["STELLAR_CONFIG_HOME", "XDG_CONFIG_HOME"]);
+        let _cwd = CwdGuard::new();
+
+        let local_identity_dir = tmp.path().join(".stellar/identity");
+        std::fs::create_dir_all(&local_identity_dir).unwrap();
+        std::fs::write(
+            local_identity_dir.join("alice.toml"),
+            "seed_phrase = \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"\n",
+        )
+        .unwrap();
+
+        let global_cfg = tmp.path().join("global");
+        std::fs::create_dir_all(&global_cfg).unwrap();
+        std::env::set_var("STELLAR_CONFIG_HOME", &global_cfg);
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let locator = Args { config_dir: None };
+        let identities = locator.list_identities().unwrap();
+        assert!(
+            !identities.contains(&"alice".to_string()),
+            "local config identities should not appear in list, got: {identities:?}"
+        );
+    }
 
     #[test]
     #[serial]

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -513,7 +513,6 @@ pub fn print_deprecation_warning(dir: &Path) {
     }
 
     print.warnln(format!("A local config was found at {dir:?}."));
-    print.blankln(" Local config is deprecated and will be removed in the future.".to_string());
     print.blankln(format!(
         " Run `stellar config migrate` to move the local config into the global config ({global_dir:?})."
     ));


### PR DESCRIPTION
### What

Stop reading from local config directory. We're still checking for .stellar directories and warning about the required migration.

### Why

To complete the removal from v26. Close https://github.com/stellar/stellar-cli/issues/2493

### Known limitations

N/A
