### PR TITLE
Switch publish workflow to rust-publish-v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   publish:
-    uses: stellar/actions/.github/workflows/rust-publish.yml@main
+    uses: stellar/actions/.github/workflows/rust-publish-v2.yml@main
     with:
       additional-deb-packages: libudev-dev libdbus-1-dev
     secrets:


### PR DESCRIPTION
### What
Replace the `rust-publish` reusable workflow with `rust-publish-v2` in `.github/workflows/publish.yml`.

### Why
`rust-publish-v2` uses `cargo publish --workspace` instead of `cargo-workspaces`, removing a supply chain dependency now that cargo natively supports ordered workspace publishing.

This will be the first repo that uses the new publish approach. If it goes well, we might just update the original rust-publish instead of continuing to update more repos with the v2 workflow.

Related https://github.com/stellar/actions/pull/102