### PR TITLE
Remove dead local-storage code from keys rm command.

### DIFF
--- a/cmd/soroban-cli/src/commands/keys/rm.rs
+++ b/cmd/soroban-cli/src/commands/keys/rm.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead, IsTerminal};
 
 use crate::commands::global;
 use crate::config::address::KeyName;
-use crate::config::locator::{self, KeyType, Location};
+use crate::config::locator::{self, KeyType};
 use crate::print::Print;
 
 #[derive(thiserror::Error, Debug)]
@@ -13,10 +13,6 @@ pub enum Error {
     Cancelled,
     #[error(transparent)]
     Io(#[from] io::Error),
-    #[error(
-        "please migrate from local storage using `stellar config migrate` before removing keys"
-    )]
-    LocalStorage(),
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -40,15 +36,11 @@ impl Cmd {
             let stdin = io::stdin();
 
             // Check that the key exists before asking for confirmation
-            let (_, location) = self.config.read_identity_with_location(&self.name)?;
-            // TODO: Remove check for local storage once it's no longer supported
-            if let Location::Local(_) = location {
-                return Err(Error::LocalStorage());
-            }
+            self.config.read_identity(&self.name)?;
 
             // Show the prompt only when the user can see it
             if stdin.is_terminal() {
-                let config_path = KeyType::Identity.path(location.as_ref(), &self.name);
+                let config_path = KeyType::Identity.path(&self.config.config_dir()?, &self.name);
                 print.warnln(format!(
                     "Are you sure you want to remove the key '{}' at '{}'? This action cannot be undone. (y/N)",
                     self.name,

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -283,12 +283,6 @@ impl Args {
         KeyType::Identity.read_with_global(name, self)
     }
 
-    // TODO: Remove once local storage is no longer supported
-    pub fn read_identity_with_location(&self, name: &str) -> Result<(Key, Location), Error> {
-        utils::validate_name(name)?;
-        KeyType::Identity.read_with_global_with_location(name, self)
-    }
-
     pub fn read_key(&self, key_or_name: &str) -> Result<Key, Error> {
         key_or_name
             .parse()


### PR DESCRIPTION
### What

Remove dead local-storage code from keys rm command.

### Why

Now that we don't read from local config dirs anymore, we can get rid of dead code related to that.

### Known limitations

N/A
