### PR TITLE
Harden file permissions when migrating legacy config.

### DIFF
--- a/cmd/soroban-cli/src/commands/cfg/migrate.rs
+++ b/cmd/soroban-cli/src/commands/cfg/migrate.rs
@@ -127,7 +127,7 @@ impl Cmd {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use crate::test_utils::CwdGuard;
+    use crate::test_utils::with_cwd_guard;
     use serial_test::serial;
     use std::os::unix::fs::PermissionsExt;
 
@@ -135,56 +135,57 @@ mod tests {
     #[serial]
     fn migrate_hardens_permissions() {
         let tmp = tempfile::tempdir().unwrap();
-        let _cwd = CwdGuard::new();
 
-        // Set up legacy local identity: .stellar/identity/alice.toml at 0644 in 0755 dir
-        let local_identity_dir = tmp.path().join(".stellar/identity");
-        std::fs::create_dir_all(&local_identity_dir).unwrap();
-        std::fs::set_permissions(&local_identity_dir, std::fs::Permissions::from_mode(0o755))
+        with_cwd_guard(|| {
+            // Set up legacy local identity: .stellar/identity/alice.toml at 0644 in 0755 dir
+            let local_identity_dir = tmp.path().join(".stellar/identity");
+            std::fs::create_dir_all(&local_identity_dir).unwrap();
+            std::fs::set_permissions(&local_identity_dir, std::fs::Permissions::from_mode(0o755))
+                .unwrap();
+            let legacy_file = local_identity_dir.join("alice.toml");
+            std::fs::write(
+                &legacy_file,
+                "seed_phrase = \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"\n",
+            )
             .unwrap();
-        let legacy_file = local_identity_dir.join("alice.toml");
-        std::fs::write(
-            &legacy_file,
-            "seed_phrase = \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&legacy_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+            std::fs::set_permissions(&legacy_file, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        let global_dir = tmp.path().join("global");
-        std::fs::create_dir_all(&global_dir).unwrap();
+            let global_dir = tmp.path().join("global");
+            std::fs::create_dir_all(&global_dir).unwrap();
 
-        std::env::set_current_dir(tmp.path()).unwrap();
+            std::env::set_current_dir(tmp.path()).unwrap();
 
-        let cmd = Cmd {
-            locator: locator::Args {
-                config_dir: Some(global_dir.clone()),
-            },
-        };
-        cmd.run().unwrap();
+            let cmd = Cmd {
+                locator: locator::Args {
+                    config_dir: Some(global_dir.clone()),
+                },
+            };
+            cmd.run().unwrap();
 
-        let migrated_dir = global_dir.join("identity");
-        let migrated_file = migrated_dir.join("alice.toml");
+            let migrated_dir = global_dir.join("identity");
+            let migrated_file = migrated_dir.join("alice.toml");
 
-        assert!(migrated_file.exists(), "migrated file should exist");
+            assert!(migrated_file.exists(), "migrated file should exist");
 
-        let dir_mode = std::fs::metadata(&migrated_dir)
-            .unwrap()
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(
-            dir_mode, 0o700,
-            "migrated identity directory should be 0700, got {dir_mode:o}",
-        );
+            let dir_mode = std::fs::metadata(&migrated_dir)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                dir_mode, 0o700,
+                "migrated identity directory should be 0700, got {dir_mode:o}",
+            );
 
-        let file_mode = std::fs::metadata(&migrated_file)
-            .unwrap()
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(
-            file_mode, 0o600,
-            "migrated identity file should be 0600, got {file_mode:o}",
-        );
+            let file_mode = std::fs::metadata(&migrated_file)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                file_mode, 0o600,
+                "migrated identity file should be 0600, got {file_mode:o}",
+            );
+        });
     }
 }

--- a/cmd/soroban-cli/src/commands/cfg/migrate.rs
+++ b/cmd/soroban-cli/src/commands/cfg/migrate.rs
@@ -127,22 +127,9 @@ impl Cmd {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use crate::test_utils::CwdGuard;
     use serial_test::serial;
     use std::os::unix::fs::PermissionsExt;
-
-    struct CwdGuard(std::path::PathBuf);
-
-    impl CwdGuard {
-        fn new() -> Self {
-            Self(std::env::current_dir().unwrap())
-        }
-    }
-
-    impl Drop for CwdGuard {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.0);
-        }
-    }
 
     #[test]
     #[serial]

--- a/cmd/soroban-cli/src/commands/cfg/migrate.rs
+++ b/cmd/soroban-cli/src/commands/cfg/migrate.rs
@@ -3,7 +3,6 @@ use crate::commands::cfg::migrate::Error::InvalidFile;
 use crate::config::locator::{KeyType, Location};
 use crate::print::Print;
 use sha2::{Digest, Sha256};
-use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -81,8 +80,9 @@ impl Cmd {
                 print.warnln(format!("Duplicated '{original_name}' {config_type} found: it will be renamed to {name}"));
                 target = target.with_file_name(&name).with_extension(extension);
             }
-            create_dir_all(target.parent().unwrap())?;
+            locator::ensure_directory(target.clone())?;
             fs::copy(path, &target)?;
+            locator::set_hardened_permissions(&target)?;
             fs::remove_file(path)?;
             print.infoln(format!(
                 "Moved {} from {} to {}",
@@ -121,5 +121,83 @@ impl Cmd {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::os::unix::fs::PermissionsExt;
+
+    struct CwdGuard(std::path::PathBuf);
+
+    impl CwdGuard {
+        fn new() -> Self {
+            Self(std::env::current_dir().unwrap())
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn migrate_hardens_permissions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _cwd = CwdGuard::new();
+
+        // Set up legacy local identity: .stellar/identity/alice.toml at 0644 in 0755 dir
+        let local_identity_dir = tmp.path().join(".stellar/identity");
+        std::fs::create_dir_all(&local_identity_dir).unwrap();
+        std::fs::set_permissions(&local_identity_dir, std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+        let legacy_file = local_identity_dir.join("alice.toml");
+        std::fs::write(
+            &legacy_file,
+            "seed_phrase = \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&legacy_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let global_dir = tmp.path().join("global");
+        std::fs::create_dir_all(&global_dir).unwrap();
+
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let cmd = Cmd {
+            locator: locator::Args {
+                config_dir: Some(global_dir.clone()),
+            },
+        };
+        cmd.run().unwrap();
+
+        let migrated_dir = global_dir.join("identity");
+        let migrated_file = migrated_dir.join("alice.toml");
+
+        assert!(migrated_file.exists(), "migrated file should exist");
+
+        let dir_mode = std::fs::metadata(&migrated_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            dir_mode, 0o700,
+            "migrated identity directory should be 0700, got {dir_mode:o}",
+        );
+
+        let file_mode = std::fs::metadata(&migrated_file)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            file_mode, 0o600,
+            "migrated identity file should be 0600, got {file_mode:o}",
+        );
     }
 }

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -415,7 +415,7 @@ impl Args {
         #[cfg(unix)]
         {
             use std::io::Write as _;
-            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+            use std::os::unix::fs::OpenOptionsExt;
             let mut to_file = OpenOptions::new()
                 .create(true)
                 .truncate(true)
@@ -423,7 +423,7 @@ impl Args {
                 .mode(0o600)
                 .open(&path)?;
             to_file.write_all(content.as_bytes())?;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+            set_hardened_permissions(&path)?;
             if let Ok(root) = self.config_dir() {
                 fix_config_permissions(root);
             }
@@ -566,7 +566,7 @@ fn fix_config_permissions(root: std::path::PathBuf) {
         print.warnln("Updated config directories permissions to 0700.");
 
         for dir in bad_dirs {
-            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+            let _ = set_hardened_permissions(&dir);
         }
     }
 
@@ -574,9 +574,19 @@ fn fix_config_permissions(root: std::path::PathBuf) {
         print.warnln("Updated config files permissions to 0600.");
 
         for file in bad_files {
-            let _ = std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600));
+            let _ = set_hardened_permissions(&file);
         }
     }
+}
+
+pub fn set_hardened_permissions(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = if path.is_dir() { 0o700 } else { 0o600 };
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+    }
+    Ok(())
 }
 
 pub fn ensure_directory(dir: PathBuf) -> Result<PathBuf, Error> {
@@ -703,13 +713,10 @@ impl KeyType {
 
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&filepath, std::fs::Permissions::from_mode(0o600)).map_err(
-                |error| Error::IdCreationFailed {
-                    filepath: filepath.clone(),
-                    error,
-                },
-            )?;
+            set_hardened_permissions(&filepath).map_err(|error| Error::IdCreationFailed {
+                filepath: filepath.clone(),
+                error,
+            })?;
             fix_config_permissions(pwd.to_path_buf());
         }
 

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -579,7 +579,7 @@ fn fix_config_permissions(root: std::path::PathBuf) {
     }
 }
 
-pub fn set_hardened_permissions(path: &Path) -> io::Result<()> {
+pub(crate) fn set_hardened_permissions(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -947,21 +947,7 @@ mod tests {
         );
     }
 
-    use crate::test_utils::EnvGuard;
-
-    struct CwdGuard(std::path::PathBuf);
-
-    impl CwdGuard {
-        fn new() -> Self {
-            Self(std::env::current_dir().unwrap())
-        }
-    }
-
-    impl Drop for CwdGuard {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.0);
-        }
-    }
+    use crate::test_utils::{CwdGuard, EnvGuard};
 
     #[test]
     #[serial]

--- a/cmd/soroban-cli/src/test_utils.rs
+++ b/cmd/soroban-cli/src/test_utils.rs
@@ -10,8 +10,19 @@ impl Default for CwdGuard {
 }
 
 impl CwdGuard {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// Runs `f` with the current working directory automatically restored on return or panic.
+pub fn with_cwd_guard<F: FnOnce()>(f: F) {
+    let saved = std::env::current_dir().unwrap();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    let _ = std::env::set_current_dir(saved);
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
     }
 }
 

--- a/cmd/soroban-cli/src/test_utils.rs
+++ b/cmd/soroban-cli/src/test_utils.rs
@@ -1,3 +1,26 @@
+/// Saves and restores the current working directory on drop.
+///
+/// Useful in tests that call `set_current_dir` — guarantees cleanup even on panic.
+pub struct CwdGuard(std::path::PathBuf);
+
+impl Default for CwdGuard {
+    fn default() -> Self {
+        Self(std::env::current_dir().unwrap())
+    }
+}
+
+impl CwdGuard {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.0);
+    }
+}
+
 /// Saves and restores environment variables on drop.
 ///
 /// Useful in tests that mutate env vars — guarantees cleanup even on panic.


### PR DESCRIPTION
### What

Harden file permissions when migrating legacy config.

### Why

Close https://github.com/stellar/stellar-cli-internal/issues/31

### Known limitations

N/A
