### PR TITLE
Hide secret env var values from help output.

### DIFF
--- a/cmd/soroban-cli/src/commands/message/sign.rs
+++ b/cmd/soroban-cli/src/commands/message/sign.rs
@@ -58,7 +58,7 @@ pub struct Cmd {
 
     // @dev: Ledger and Lab don't support signing arbitrary messages yet. Once they do, use `sign_with::Args` here.
     /// Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path.
-    #[arg(long, env = "STELLAR_SIGN_WITH_KEY")]
+    #[arg(long, env = "STELLAR_SIGN_WITH_KEY", hide_env_values = true)]
     pub sign_with_key: String,
 
     #[arg(long)]
@@ -232,5 +232,19 @@ mod tests {
         let signature_base64 = sep_53_sign(&message_bytes, signer).unwrap();
 
         assert_eq!(signature_base64, expected_signature);
+    }
+
+    #[test]
+    fn test_help_does_not_expose_sign_with_key() {
+        use clap::CommandFactory;
+        let secret = "SDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCQYFD";
+        std::env::set_var("STELLAR_SIGN_WITH_KEY", secret);
+        let mut cmd = Cmd::command();
+        let help_text = cmd.render_long_help().to_string();
+        std::env::remove_var("STELLAR_SIGN_WITH_KEY");
+        assert!(
+            !help_text.contains(secret),
+            "help text must not expose STELLAR_SIGN_WITH_KEY value"
+        );
     }
 }

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -77,6 +77,7 @@ pub struct Args {
         action = clap::ArgAction::Append,
         value_delimiter = '\n',
         value_parser = parse_http_header,
+        hide_env_values = true,
     )]
     pub rpc_headers: Vec<(String, String)>,
     /// Network passphrase to sign the transaction sent to the rpc server
@@ -138,6 +139,7 @@ pub struct Network {
         action = clap::ArgAction::Append,
         value_delimiter = '\n',
         value_parser = parse_http_header,
+        hide_env_values = true,
     )]
     pub rpc_headers: Vec<(String, String)>,
     /// Network passphrase to sign the transaction sent to the rpc server

--- a/cmd/soroban-cli/src/config/sign_with.rs
+++ b/cmd/soroban-cli/src/config/sign_with.rs
@@ -37,7 +37,7 @@ pub enum Error {
 #[group(skip)]
 pub struct Args {
     /// Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path.
-    #[arg(long, env = "STELLAR_SIGN_WITH_KEY")]
+    #[arg(long, env = "STELLAR_SIGN_WITH_KEY", hide_env_values = true)]
     pub sign_with_key: Option<String>,
 
     #[arg(long, conflicts_with = "sign_with_lab")]


### PR DESCRIPTION
### What

Hide secret env var values from help output.

### Why

Close https://github.com/stellar/stellar-cli-internal/issues/71

### Known limitations

N/A
