### PR TITLE
Fix Windows build warnings in set_hardened_permissions.

### DIFF
--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -585,6 +585,7 @@ fn fix_config_permissions(root: std::path::PathBuf) {
     }
 }
 
+#[allow(unused_variables, clippy::unnecessary_wraps)]
 pub(crate) fn set_hardened_permissions(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {


### PR DESCRIPTION
### What

Fix Windows build warnings in set_hardened_permissions.

### Why

So Windows builds can run cleanly.

### Known limitations

N/A
