### PR TITLE
ci: remove stale logging jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,13 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  github_context:
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "github.sha => ${{ github.sha }}"
-          echo "github.ref => ${{ github.ref }}"
-
   docs-validation:
     uses: stellar/stellar-docs/.github/workflows/build.yml@main
     with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,17 +16,6 @@ defaults:
     shell: bash
 
 jobs:
-  debug-context:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug GitHub context
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Head ref: ${{ github.head_ref }}"
-          echo "Base ref: ${{ github.base_ref }}"
-          echo "Condition result: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/') }}"
-
   complete:
     if: always()
     needs:


### PR DESCRIPTION
### What

Removes github context logging jobs

### Why

Prevents use of user supplied inputs in bash scripts for `pull_request` jobs

### Known limitations

None
