### PR TITLE
Replace glob with fs::read_dir to avoid path escaping issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ local.sh
 .zed
 node_modules/
 .DS_Store
+logs/
+ai-summary/

--- a/cmd/soroban-cli/src/commands/contract/alias/ls.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/ls.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::Path;
 use std::{fs, process};
@@ -22,12 +23,6 @@ pub enum Error {
 
     #[error(transparent)]
     Network(#[from] network::Error),
-
-    #[error(transparent)]
-    PatternError(#[from] glob::PatternError),
-
-    #[error(transparent)]
-    GlobError(#[from] glob::GlobError),
 
     #[error(transparent)]
     IoError(#[from] std::io::Error),
@@ -58,33 +53,29 @@ impl Cmd {
     }
 
     fn collect_aliases(config_dir: &Path) -> Result<HashMap<String, Vec<AliasEntry>>, Error> {
-        let dir = glob::Pattern::escape(&config_dir.join("contract-ids").to_string_lossy());
-        let pattern = Path::new(&dir)
-            .join("*.json")
-            .to_string_lossy()
-            .into_owned();
-
-        let paths = glob::glob(&pattern)?;
+        let contract_ids_dir = config_dir.join("contract-ids");
         let mut map: HashMap<String, Vec<AliasEntry>> = HashMap::new();
 
-        for path in paths {
-            let path = path?;
+        if !contract_ids_dir.is_dir() {
+            return Ok(map);
+        }
+
+        for entry in fs::read_dir(&contract_ids_dir)? {
+            let path = entry?.path();
+
+            if path.extension() != Some(OsStr::new("json")) {
+                continue;
+            }
 
             if let Some(alias) = path.file_stem() {
                 let alias = alias.to_string_lossy().into_owned();
-                let content = fs::read_to_string(path)?;
+                let content = fs::read_to_string(&path)?;
                 let data: alias::Data = serde_json::from_str(&content).unwrap_or_default();
 
-                for network_passphrase in data.ids.keys() {
-                    let network_passphrase = network_passphrase.clone();
-                    let contract = data
-                        .ids
-                        .get(&network_passphrase)
-                        .map(ToString::to_string)
-                        .unwrap_or_default();
+                for (network_passphrase, contract_id) in &data.ids {
                     let entry = AliasEntry {
                         alias: alias.clone(),
-                        contract,
+                        contract: contract_id.clone(),
                     };
 
                     map.entry(network_passphrase.clone())
@@ -98,22 +89,20 @@ impl Cmd {
     }
 
     fn read_from_config_dir(config_dir: &Path) -> Result<(), Error> {
-        let map = Self::collect_aliases(config_dir)?;
+        let mut map = Self::collect_aliases(config_dir)?;
         let mut found = false;
 
-        for network_passphrase in map.keys() {
-            if let Some(list) = map.clone().get_mut(network_passphrase) {
-                println!("ℹ️ Aliases available for network '{network_passphrase}'");
+        for (network_passphrase, list) in &mut map {
+            println!("ℹ️ Aliases available for network '{network_passphrase}'");
 
-                list.sort_by(|a, b| a.alias.cmp(&b.alias));
+            list.sort_by(|a, b| a.alias.cmp(&b.alias));
 
-                for entry in list {
-                    found = true;
-                    println!("{}: {}", entry.alias, entry.contract);
-                }
-
-                println!();
+            for entry in list.iter() {
+                found = true;
+                println!("{}: {}", entry.alias, entry.contract);
             }
+
+            println!();
         }
 
         if !found {

--- a/cmd/soroban-cli/src/commands/contract/alias/ls.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/ls.rs
@@ -57,15 +57,14 @@ impl Cmd {
         Ok(())
     }
 
-    fn read_from_config_dir(config_dir: &Path) -> Result<(), Error> {
-        let pattern = config_dir
-            .join("contract-ids")
+    fn collect_aliases(config_dir: &Path) -> Result<HashMap<String, Vec<AliasEntry>>, Error> {
+        let dir = glob::Pattern::escape(&config_dir.join("contract-ids").to_string_lossy());
+        let pattern = Path::new(&dir)
             .join("*.json")
             .to_string_lossy()
             .into_owned();
 
         let paths = glob::glob(&pattern)?;
-        let mut found = false;
         let mut map: HashMap<String, Vec<AliasEntry>> = HashMap::new();
 
         for path in paths {
@@ -88,12 +87,19 @@ impl Cmd {
                         contract,
                     };
 
-                    let list = map.entry(network_passphrase.clone()).or_default();
-
-                    list.push(entry.clone());
+                    map.entry(network_passphrase.clone())
+                        .or_default()
+                        .push(entry);
                 }
             }
         }
+
+        Ok(map)
+    }
+
+    fn read_from_config_dir(config_dir: &Path) -> Result<(), Error> {
+        let map = Self::collect_aliases(config_dir)?;
+        let mut found = false;
 
         for network_passphrase in map.keys() {
             if let Some(list) = map.clone().get_mut(network_passphrase) {
@@ -117,5 +123,51 @@ impl Cmd {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_alias(dir: &Path, name: &str, network: &str, contract: &str) {
+        let contract_ids_dir = dir.join("contract-ids");
+        fs::create_dir_all(&contract_ids_dir).unwrap();
+        let content = format!(r#"{{"ids":{{"{network}":"{contract}"}}}}"#);
+        fs::write(contract_ids_dir.join(format!("{name}.json")), content).unwrap();
+    }
+
+    #[test]
+    fn glob_metacharacters_in_config_dir_are_treated_as_literal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        // Sibling directories that would match the glob `[12]` if unescaped.
+        write_alias(&base.join("cfg1"), "alpha", "testnet", "CAAAA");
+        write_alias(&base.join("cfg2"), "beta", "testnet", "CBBBB");
+
+        // The literal directory whose name contains bracket metacharacters.
+        write_alias(&base.join("cfg[12]"), "gamma", "testnet", "CCCCC");
+
+        let map = Cmd::collect_aliases(&base.join("cfg[12]")).unwrap();
+
+        let aliases: Vec<&str> = map
+            .values()
+            .flat_map(|entries| entries.iter().map(|e| e.alias.as_str()))
+            .collect();
+
+        assert!(
+            aliases.contains(&"gamma"),
+            "should read alias from the literal directory"
+        );
+        assert!(
+            !aliases.contains(&"alpha"),
+            "should not read from sibling cfg1"
+        );
+        assert!(
+            !aliases.contains(&"beta"),
+            "should not read from sibling cfg2"
+        );
     }
 }


### PR DESCRIPTION
### What

Escape glob metacharacters in alias ls config dir path.

### Why

Close https://github.com/stellar/stellar-cli-internal/issues/47

### Known limitations

N/A
