### PR TITLE
Cache secure-store public key in identity files.

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/secure_store.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/secure_store.rs
@@ -35,6 +35,21 @@ async fn secure_store_key_management() {
         .stdout_as_str();
     assert!(secure_store_address.starts_with('G'));
 
+    // validate that the public key is cached on disk (so `keys address` and
+    // tx-signing hint derivation can skip the keychain on subsequent calls).
+    let identity_path = sandbox
+        .config_dir()
+        .join("identity")
+        .join(format!("{secure_key_name}.toml"));
+    let identity_toml = std::fs::read_to_string(&identity_path).unwrap_or_else(|err| {
+        panic!("expected identity file at {identity_path:?}: {err}");
+    });
+    assert!(
+        identity_toml.contains(&format!("public_key = \"{secure_store_address}\"")),
+        "expected public_key to be cached on disk after `keys generate --secure-store`, \
+         but identity file was:\n{identity_toml}"
+    );
+
     // use the secure store key to fund a new account
     let new_key_name = "new";
     sandbox

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -109,9 +109,13 @@ impl Cmd {
 
             let seed_phrase: SeedPhrase = secret_key.parse()?;
 
-            let secret =
-                secure_store::save_secret(print, &self.name, &seed_phrase, self.overwrite)?;
-            Ok(secret.parse()?)
+            Ok(secure_store::save_secret(
+                print,
+                &self.name,
+                &seed_phrase,
+                None,
+                self.overwrite,
+            )?)
         } else {
             let prompt = "Type a secret key or 12/24 word seed phrase:";
             let secret_key = read_password(print, prompt)?;

--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -116,9 +116,13 @@ impl Cmd {
     fn secret(&self, print: &Print) -> Result<Secret, Error> {
         let seed_phrase = self.seed_phrase()?;
         if self.secure_store {
-            let secret =
-                secure_store::save_secret(print, &self.name, &seed_phrase, self.overwrite)?;
-            Ok(secret.parse()?)
+            Ok(secure_store::save_secret(
+                print,
+                &self.name,
+                &seed_phrase,
+                self.hd_path,
+                self.overwrite,
+            )?)
         } else if self.as_secret {
             let secret: Secret = seed_phrase.into();
             Ok(secret.private_key(self.hd_path)?.into())
@@ -200,6 +204,34 @@ mod tests {
         assert!(result.is_ok());
         let identity = test_locator.read_identity("test_name").unwrap();
         assert!(matches!(identity, Key::Secret(Secret::SecureStore { .. })));
+    }
+
+    #[cfg(feature = "additional-libs")]
+    #[tokio::test]
+    async fn test_generate_secure_store_caches_public_key_on_disk() {
+        use keyring::{mock, set_default_credential_builder};
+        set_default_credential_builder(mock::default_credential_builder());
+        let (test_locator, mut cmd) = set_up_test();
+        cmd.secure_store = true;
+        let global_args = global_args();
+
+        cmd.run(&global_args).await.unwrap();
+
+        let identity = test_locator.read_identity("test_name").unwrap();
+        match identity {
+            Key::Secret(Secret::SecureStore {
+                public_key,
+                hd_path,
+                ..
+            }) => {
+                assert!(
+                    public_key.is_some(),
+                    "public_key should be cached on disk after `keys generate --secure-store`"
+                );
+                assert_eq!(hd_path, None);
+            }
+            other => panic!("expected SecureStore variant, got {other:?}"),
+        }
     }
 
     #[cfg(not(feature = "additional-libs"))]

--- a/cmd/soroban-cli/src/commands/message/sign.rs
+++ b/cmd/soroban-cli/src/commands/message/sign.rs
@@ -77,7 +77,9 @@ impl Cmd {
 
         // Get the signer
         let key_or_name = &self.sign_with_key;
-        let secret = self.locator.get_secret_key(key_or_name)?;
+        let secret = self
+            .locator
+            .get_secret_key_with_hd_path(key_or_name, self.hd_path)?;
         let signer = secret.signer(self.hd_path, print.clone()).await?;
         let public_key = signer.get_public_key()?;
 

--- a/cmd/soroban-cli/src/config/address.rs
+++ b/cmd/soroban-cli/src/config/address.rs
@@ -116,9 +116,9 @@ impl UnresolvedMuxedAccount {
     ) -> Result<xdr::MuxedAccount, Error> {
         match self {
             UnresolvedMuxedAccount::Resolved(muxed_account) => Ok(muxed_account.clone()),
-            UnresolvedMuxedAccount::AliasOrSecret(alias_or_secret) => {
-                Ok(locator.read_key(alias_or_secret)?.muxed_account(hd_path)?)
-            }
+            UnresolvedMuxedAccount::AliasOrSecret(alias_or_secret) => Ok(locator
+                .read_key_with_secure_store_cache(alias_or_secret, hd_path)?
+                .muxed_account(hd_path)?),
             UnresolvedMuxedAccount::Ledger(_) => Err(Error::LedgerNotSupported),
         }
     }

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -299,11 +299,64 @@ impl Args {
             .or_else(|_| self.read_identity(key_or_name))
     }
 
+    /// Like [`Args::read_key`], but for a `SecureStore` identity loaded from disk
+    /// that lacks a cached public key, derive one via the keychain (one prompt)
+    /// and persist it back so subsequent reads avoid the keychain.
+    pub fn read_key_with_secure_store_cache(
+        &self,
+        key_or_name: &str,
+        hd_path: Option<usize>,
+    ) -> Result<Key, Error> {
+        if let Ok(literal) = key_or_name.parse::<Key>() {
+            return Ok(literal);
+        }
+        let key = self.read_identity(key_or_name)?;
+        if let Key::Secret(Secret::SecureStore {
+            entry_name,
+            public_key: None,
+            ..
+        }) = &key
+        {
+            let pk = secure_store::get_public_key(entry_name, hd_path)?;
+            let migrated = Key::Secret(Secret::SecureStore {
+                entry_name: entry_name.clone(),
+                public_key: Some(pk.to_string()),
+                hd_path,
+            });
+            // Best-effort write-back: if persistence fails we still return the
+            // freshly-derived value so the current call succeeds.
+            let _ = self.write_key(key_or_name, &migrated);
+            return Ok(migrated);
+        }
+        Ok(key)
+    }
+
     pub fn get_secret_key(&self, key_or_name: &str) -> Result<Secret, Error> {
         let key = self.read_key(key_or_name).map_err(|e| match e {
             Error::InvalidName(_) | Error::ConfigMissing(_, _) => Error::InvalidSigningKey,
             other => other,
         })?;
+        match key {
+            Key::Secret(s) => Ok(s),
+            _ => Err(Error::InvalidSigningKey),
+        }
+    }
+
+    /// Like [`Args::get_secret_key`], but if the secret is a `SecureStore`
+    /// identity loaded from disk without a cached public key, derive it for the
+    /// given `hd_path` and persist the cache. Use from signing paths so the
+    /// returned `Secret` already carries the data signing needs for the hint.
+    pub fn get_secret_key_with_hd_path(
+        &self,
+        key_or_name: &str,
+        hd_path: Option<usize>,
+    ) -> Result<Secret, Error> {
+        let key = self
+            .read_key_with_secure_store_cache(key_or_name, hd_path)
+            .map_err(|e| match e {
+                Error::InvalidName(_) | Error::ConfigMissing(_, _) => Error::InvalidSigningKey,
+                other => other,
+            })?;
         match key {
             Key::Secret(s) => Ok(s),
             _ => Err(Error::InvalidSigningKey),
@@ -334,7 +387,7 @@ impl Args {
         let print = Print::new(global_args.quiet);
         let identity = self.read_identity(name)?;
 
-        if let Key::Secret(Secret::SecureStore { entry_name }) = identity {
+        if let Key::Secret(Secret::SecureStore { entry_name, .. }) = identity {
             secure_store::delete_secret(&print, &entry_name)?;
         }
 
@@ -1208,5 +1261,80 @@ mod tests {
             // Must not panic even though ~/.config/stellar does not exist
             print_deprecation_warning(&local_dir);
         });
+    }
+
+    mod secure_store_cache {
+        use super::super::*;
+
+        const TEST_PUBLIC_KEY: &str = "GAREAZZQWHOCBJS236KIE3AWYBVFLSBK7E5UW3ICI3TCRWQKT5LNLCEZ";
+        const TEST_SECRET_KEY: &str = "SBF5HLRREHMS36XZNTUSKZ6FTXDZGNXOHF4EXKUL5UCWZLPBX3NGJ4BH";
+
+        fn locator_with_tempdir() -> (tempfile::TempDir, Args) {
+            let dir = tempfile::tempdir().unwrap();
+            let args = Args {
+                config_dir: Some(dir.path().to_path_buf()),
+            };
+            (dir, args)
+        }
+
+        // The legacy-file -> derive-via-keychain -> write-back path is
+        // exercised end-to-end by the soroban-test integration test
+        // `secure_store_key_management`. The keyring crate's mock builder
+        // assigns each `Entry` instance its own in-memory credential
+        // (CredentialPersistence::EntryOnly), which makes the read-after-write
+        // round trip impossible to simulate in pure unit tests.
+
+        #[test]
+        fn passes_through_already_cached_identity_without_keychain_access() {
+            let (_dir, locator) = locator_with_tempdir();
+
+            // Entry name points to a non-existent keychain entry, so any
+            // keychain access would fail the test.
+            let already = Secret::SecureStore {
+                entry_name: "secure_store:org.stellar.cli-no-such-entry".to_string(),
+                public_key: Some(TEST_PUBLIC_KEY.to_string()),
+                hd_path: None,
+            };
+            locator.write_identity("already", &already).unwrap();
+
+            let key = locator
+                .read_key_with_secure_store_cache("already", None)
+                .unwrap();
+            match key {
+                Key::Secret(Secret::SecureStore {
+                    public_key: Some(pk),
+                    ..
+                }) => assert_eq!(pk, TEST_PUBLIC_KEY),
+                other => panic!("expected SecureStore, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn passes_through_non_secure_store_identity() {
+            let (_dir, locator) = locator_with_tempdir();
+
+            let secret = Secret::SecretKey {
+                secret_key: TEST_SECRET_KEY.to_string(),
+            };
+            locator.write_identity("plain", &secret).unwrap();
+
+            let key = locator
+                .read_key_with_secure_store_cache("plain", None)
+                .unwrap();
+            assert!(matches!(
+                key,
+                Key::Secret(Secret::SecretKey { ref secret_key }) if secret_key == TEST_SECRET_KEY
+            ));
+        }
+
+        #[test]
+        fn returns_literal_public_key_without_disk_lookup() {
+            let (_dir, locator) = locator_with_tempdir();
+
+            let key = locator
+                .read_key_with_secure_store_cache(TEST_PUBLIC_KEY, None)
+                .unwrap();
+            assert!(matches!(key, Key::PublicKey(_)));
+        }
     }
 }

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -57,10 +57,23 @@ pub struct Args {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Secret {
-    SecretKey { secret_key: String },
-    SeedPhrase { seed_phrase: String },
+    SecretKey {
+        secret_key: String,
+    },
+    SeedPhrase {
+        seed_phrase: String,
+    },
     Ledger,
-    SecureStore { entry_name: String },
+    SecureStore {
+        entry_name: String,
+        // Cached public key derived from the secure-store entry. Lets us answer
+        // address/hint queries without unlocking the keychain. Optional for
+        // backwards compatibility with files written before this field existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        public_key: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hd_path: Option<usize>,
+    },
 }
 
 impl FromStr for Secret {
@@ -80,6 +93,8 @@ impl FromStr for Secret {
         } else if s.starts_with(secure_store::ENTRY_PREFIX) {
             Ok(Secret::SecureStore {
                 entry_name: s.to_string(),
+                public_key: None,
+                hd_path: None,
             })
         } else {
             Err(Error::InvalidSecretOrSeedPhrase)
@@ -127,7 +142,17 @@ impl Secret {
     }
 
     pub fn public_key(&self, index: Option<usize>) -> Result<PublicKey, Error> {
-        if let Secret::SecureStore { entry_name } = self {
+        if let Secret::SecureStore {
+            entry_name,
+            public_key,
+            hd_path,
+        } = self
+        {
+            if let Some(cached) = public_key {
+                if hd_path == &index {
+                    return Ok(PublicKey::from_string(cached)?);
+                }
+            }
             Ok(secure_store::get_public_key(entry_name, index)?)
         } else {
             let key = self.key_pair(index)?;
@@ -150,10 +175,22 @@ impl Secret {
                     .expect("uszie bigger than u32");
                 SignerKind::Ledger(ledger::new(hd_path).await?)
             }
-            Secret::SecureStore { entry_name } => SignerKind::SecureStore(SecureStoreEntry {
-                name: entry_name.clone(),
-                hd_path,
-            }),
+            Secret::SecureStore {
+                entry_name,
+                public_key,
+                hd_path: cached_hd_path,
+            } => {
+                let cached_public_key = public_key
+                    .as_deref()
+                    .filter(|_| cached_hd_path == &hd_path)
+                    .map(PublicKey::from_string)
+                    .transpose()?;
+                SignerKind::SecureStore(SecureStoreEntry {
+                    name: entry_name.clone(),
+                    hd_path,
+                    public_key: cached_public_key,
+                })
+            }
         };
         Ok(Signer { kind, print })
     }
@@ -224,5 +261,58 @@ mod tests {
     fn test_secret_from_invalid_string() {
         let secret = Secret::from_str("invalid");
         assert!(secret.is_err());
+    }
+
+    #[test]
+    fn test_secure_store_toml_round_trip_with_cache() {
+        let secret = Secret::SecureStore {
+            entry_name: "secure_store:org.stellar.cli-alice".to_string(),
+            public_key: Some(TEST_PUBLIC_KEY.to_string()),
+            hd_path: None,
+        };
+        let serialized = toml::to_string(&secret).unwrap();
+        assert!(
+            serialized.contains("entry_name"),
+            "expected entry_name field in TOML, got: {serialized}"
+        );
+        assert!(
+            serialized.contains("public_key"),
+            "expected public_key field in TOML, got: {serialized}"
+        );
+        let parsed: Secret = toml::from_str(&serialized).unwrap();
+        assert_eq!(secret, parsed);
+    }
+
+    #[test]
+    fn test_secure_store_legacy_toml_parses_with_none_cache() {
+        // Identity files written before this feature only contain entry_name.
+        // They must still parse, with public_key/hd_path defaulting to None.
+        let toml_str = "entry_name = \"secure_store:org.stellar.cli-alice\"\n";
+        let secret: Secret = toml::from_str(toml_str).unwrap();
+        match secret {
+            Secret::SecureStore {
+                entry_name,
+                public_key,
+                hd_path,
+            } => {
+                assert_eq!(entry_name, "secure_store:org.stellar.cli-alice");
+                assert_eq!(public_key, None);
+                assert_eq!(hd_path, None);
+            }
+            other => panic!("expected SecureStore variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_secure_store_public_key_uses_cache_without_keychain_access() {
+        // A non-existent entry_name guarantees a keychain lookup would fail.
+        // The cached public_key should be returned without touching the keychain.
+        let secret = Secret::SecureStore {
+            entry_name: "secure_store:org.stellar.cli-no-such-entry".to_string(),
+            public_key: Some(TEST_PUBLIC_KEY.to_string()),
+            hd_path: None,
+        };
+        let pk = secret.public_key(None).unwrap();
+        assert_eq!(pk.to_string(), TEST_PUBLIC_KEY);
     }
 }

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -148,10 +148,8 @@ impl Secret {
             hd_path,
         } = self
         {
-            if let Some(cached) = public_key {
-                if hd_path == &index {
-                    return Ok(PublicKey::from_string(cached)?);
-                }
+            if let Some(cached) = cached_public_key(public_key.as_deref(), *hd_path, index) {
+                return Ok(cached);
             }
             Ok(secure_store::get_public_key(entry_name, index)?)
         } else {
@@ -180,11 +178,8 @@ impl Secret {
                 public_key,
                 hd_path: cached_hd_path,
             } => {
-                let cached_public_key = public_key
-                    .as_deref()
-                    .filter(|_| cached_hd_path == &hd_path)
-                    .map(PublicKey::from_string)
-                    .transpose()?;
+                let cached_public_key =
+                    cached_public_key(public_key.as_deref(), *cached_hd_path, hd_path);
                 SignerKind::SecureStore(SecureStoreEntry {
                     name: entry_name.clone(),
                     hd_path,
@@ -202,6 +197,21 @@ impl Secret {
     pub fn from_seed(seed: Option<&str>) -> Result<Self, Error> {
         Ok(seed_phrase_from_seed(seed)?.into())
     }
+}
+
+// Returns the cached public key when it can be used, or `None` to signal a
+// cache miss. The cache is best-effort: a malformed cached value is ignored
+// rather than propagated, and `None`/`Some(0)` are treated as the same path
+// since the rest of the codebase uses `unwrap_or_default()` for hd_path.
+fn cached_public_key(
+    cached: Option<&str>,
+    cached_hd_path: Option<usize>,
+    requested_hd_path: Option<usize>,
+) -> Option<PublicKey> {
+    if cached_hd_path.unwrap_or_default() != requested_hd_path.unwrap_or_default() {
+        return None;
+    }
+    PublicKey::from_string(cached?).ok()
 }
 
 pub fn seed_phrase_from_seed(seed: Option<&str>) -> Result<SeedPhrase, Error> {
@@ -314,5 +324,27 @@ mod tests {
         };
         let pk = secret.public_key(None).unwrap();
         assert_eq!(pk.to_string(), TEST_PUBLIC_KEY);
+    }
+
+    #[test]
+    fn test_cached_public_key_treats_none_and_zero_as_equal() {
+        // `unwrap_or_default()` is used everywhere else for hd_path, so the
+        // cache must treat None and Some(0) as the same path.
+        assert!(cached_public_key(Some(TEST_PUBLIC_KEY), None, Some(0)).is_some());
+        assert!(cached_public_key(Some(TEST_PUBLIC_KEY), Some(0), None).is_some());
+        assert!(cached_public_key(Some(TEST_PUBLIC_KEY), None, None).is_some());
+        assert!(cached_public_key(Some(TEST_PUBLIC_KEY), Some(0), Some(0)).is_some());
+
+        // Different paths must still miss.
+        assert!(cached_public_key(Some(TEST_PUBLIC_KEY), None, Some(1)).is_none());
+        assert!(cached_public_key(Some(TEST_PUBLIC_KEY), Some(1), None).is_none());
+    }
+
+    #[test]
+    fn test_cached_public_key_treats_corrupt_value_as_miss() {
+        // A malformed cached value must be ignored so callers fall through to
+        // the keychain instead of erroring out.
+        assert!(cached_public_key(Some("not-a-public-key"), None, None).is_none());
+        assert!(cached_public_key(Some(""), None, None).is_none());
     }
 }

--- a/cmd/soroban-cli/src/config/sign_with.rs
+++ b/cmd/soroban-cli/src/config/sign_with.rs
@@ -97,7 +97,7 @@ impl Args {
                 },
             };
 
-            let secret = locator.get_secret_key(key_or_name)?;
+            let secret = locator.get_secret_key_with_hd_path(key_or_name, self.hd_path)?;
             secret.signer(self.hd_path, print).await?
         };
         Ok(signer.sign_tx_env(tx, network).await?)

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -353,17 +353,19 @@ impl Lab {
 pub struct SecureStoreEntry {
     pub name: String,
     pub hd_path: Option<usize>,
+    pub public_key: Option<stellar_strkey::ed25519::PublicKey>,
 }
 
 impl SecureStoreEntry {
     pub fn get_public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
+        if let Some(pk) = &self.public_key {
+            return Ok(*pk);
+        }
         Ok(secure_store::get_public_key(&self.name, self.hd_path)?)
     }
 
     pub fn sign_tx_hash(&self, tx_hash: [u8; 32]) -> Result<DecoratedSignature, Error> {
-        let hint = SignatureHint(
-            secure_store::get_public_key(&self.name, self.hd_path)?.0[28..].try_into()?,
-        );
+        let hint = SignatureHint(self.get_public_key()?.0[28..].try_into()?);
 
         let signed_tx_hash = secure_store::sign_tx_data(&self.name, self.hd_path, &tx_hash)?;
 

--- a/cmd/soroban-cli/src/signer/secure_store.rs
+++ b/cmd/soroban-cli/src/signer/secure_store.rs
@@ -49,7 +49,7 @@ mod secure_store_impl {
         hd_path: Option<usize>,
         overwrite: bool,
     ) -> Result<Secret, Error> {
-        // secure_store:org.stellar.cli:<key name>
+        // secure_store:org.stellar.cli-<key name>
         let entry_name = format!("{ENTRY_PREFIX}{ENTRY_SERVICE}-{name}");
 
         let entry = StellarEntry::new(&entry_name)?;

--- a/cmd/soroban-cli/src/signer/secure_store.rs
+++ b/cmd/soroban-cli/src/signer/secure_store.rs
@@ -1,6 +1,7 @@
 use sep5::SeedPhrase;
 use stellar_strkey::ed25519::PublicKey;
 
+use crate::config::secret::Secret;
 use crate::print::Print;
 
 #[cfg(feature = "additional-libs")]
@@ -28,7 +29,7 @@ pub enum Error {
 
 #[cfg(feature = "additional-libs")]
 mod secure_store_impl {
-    use super::{Error, Print, PublicKey, SeedPhrase, StellarEntry, ENTRY_PREFIX};
+    use super::{Error, Print, PublicKey, Secret, SeedPhrase, StellarEntry, ENTRY_PREFIX};
     const ENTRY_SERVICE: &str = "org.stellar.cli";
 
     pub fn get_public_key(entry_name: &str, index: Option<usize>) -> Result<PublicKey, Error> {
@@ -43,17 +44,29 @@ mod secure_store_impl {
 
     pub fn save_secret(
         print: &Print,
-        entry_name: &str,
+        name: &str,
         seed_phrase: &SeedPhrase,
+        hd_path: Option<usize>,
         overwrite: bool,
-    ) -> Result<String, Error> {
+    ) -> Result<Secret, Error> {
         // secure_store:org.stellar.cli:<key name>
-        let entry_name_with_prefix = format!("{ENTRY_PREFIX}{ENTRY_SERVICE}-{entry_name}");
+        let entry_name = format!("{ENTRY_PREFIX}{ENTRY_SERVICE}-{name}");
 
-        let entry = StellarEntry::new(&entry_name_with_prefix)?;
+        let entry = StellarEntry::new(&entry_name)?;
         entry.write(seed_phrase.clone(), print, overwrite)?;
 
-        Ok(entry_name_with_prefix)
+        let public_key_bytes = seed_phrase
+            .clone()
+            .from_path_index(hd_path.unwrap_or_default(), None)?
+            .public()
+            .0;
+        let public_key = PublicKey(public_key_bytes).to_string();
+
+        Ok(Secret::SecureStore {
+            entry_name,
+            public_key: Some(public_key),
+            hd_path,
+        })
     }
 
     pub fn sign_tx_data(
@@ -68,7 +81,7 @@ mod secure_store_impl {
 
 #[cfg(not(feature = "additional-libs"))]
 mod secure_store_impl {
-    use super::{Error, Print, PublicKey, SeedPhrase};
+    use super::{Error, Print, PublicKey, Secret, SeedPhrase};
 
     pub fn get_public_key(_entry_name: &str, _index: Option<usize>) -> Result<PublicKey, Error> {
         Err(Error::FeatureNotEnabled)
@@ -80,10 +93,11 @@ mod secure_store_impl {
 
     pub fn save_secret(
         _print: &Print,
-        _entry_name: &str,
+        _name: &str,
         _seed_phrase: &SeedPhrase,
+        _hd_path: Option<usize>,
         _overwrite: bool,
-    ) -> Result<String, Error> {
+    ) -> Result<Secret, Error> {
         Err(Error::FeatureNotEnabled)
     }
 


### PR DESCRIPTION
### What

- Add optional `public_key` and `hd_path` fields to the `SecureStore` variant of `Secret`, serialized into the identity TOML so address/hint lookups don't need to unlock the OS keychain.
- Lazily migrate legacy identity files on first read: derive the public key once via the keychain and persist it back to disk. The migration is best-effort — if the write-back fails the current call still succeeds, and the next invocation will retry.
- Add `read_key_with_secure_store_cache` and `get_secret_key_with_hd_path` on `locator::Args` so callers in `message sign`, `sign_with`, and `address` resolution can pass through the requested `hd_path` and use the cached public key when it matches.
- Update `Secret::public_key` and `Secret::signer` to return the cached public key when present (and the requested `hd_path` matches the cached one), so `SecureStoreEntry` can compute the signature hint without re-opening the keychain.

### Why

On macOS (and other keyring backends), every secure-store operation prompts the user to unlock the keychain. Today even read-only flows trigger prompts:

- `stellar keys address <name>` prompts, even though the public key never changes.
- `stellar tx sign` prompts to compute the signature hint before prompting again to actually sign.
- Any command that resolves a `MuxedAccount` from a secure-store alias prompts.

Caching the public key on disk eliminates prompts for read-only address/hint queries entirely.

Close https://github.com/stellar/stellar-cli/issues/2446

### Known limitations

- Legacy identity files written before this change are migrated on first read (one keychain prompt, then persisted). Users on read-only filesystems will keep seeing the prompt on every invocation.
- The on-disk cache is keyed by `hd_path`. A read at a different `hd_path` than the cached one falls through to the keychain (one prompt) but does not overwrite the cached entry. This keeps the common single-path case fast without invalidating data on multi-path users. To also cache `hd_path`, add a separate entry with `stellar keys add name --hd-path=PATH`.
- The `keyring` crate's mock builder isolates each `Entry` to its own in-memory credential, so the legacy-file → derive → write-back round trip is covered by the `secure_store_key_management` soroban-test integration test rather than a pure unit test.
