### PR TITLE
Persist --hd-path on plain seed-phrase keys

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1138,7 +1138,7 @@ Add a new identity (keypair, ledger, OS specific secure store)
 
 - `--public-key <PUBLIC_KEY>` — Add a public key, ed25519, or muxed account, e.g. G1.., M2..
 - `--overwrite` — Overwrite existing identity if it already exists. When combined with --secure-store, also replaces the existing Secure Store entry
-- `--hd-path <HD_PATH>` — When importing a seed phrase into the Secure Store, which `hd_path` to derive the key at
+- `--hd-path <HD_PATH>` — When importing a seed phrase, which `hd_path` to derive the key at. Persisted on the identity (or its Secure Store entry) so later commands derive the same account without re-passing the flag. Not valid with `--public-key` or a raw secret key
 
 ###### **Options (Global):**
 
@@ -1207,7 +1207,7 @@ Generate a new identity using a 24-word seed phrase The seed phrase can be store
 
   On Mac this uses Keychain, on Windows it is Secure Store Service, and on \*nix platforms it uses a combination of the kernel keyutils and DBus-based Secret Service.
 
-- `--hd-path <HD_PATH>` — With `--as-secret` or `--secure-store`, which `hd_path` to derive the key at from the seed phrase
+- `--hd-path <HD_PATH>` — Which `hd_path` to derive the key at from the seed phrase. Honored across all storage modes: with `--as-secret` it picks which derived key is stored, with `--secure-store` or plain seed-phrase storage it is persisted on the identity so later commands derive the same account without re-passing the flag
 - `--fund` — Fund generated key pair
 
   Default value: `false`

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1138,7 +1138,7 @@ Add a new identity (keypair, ledger, OS specific secure store)
 
 - `--public-key <PUBLIC_KEY>` — Add a public key, ed25519, or muxed account, e.g. G1.., M2..
 - `--overwrite` — Overwrite existing identity if it already exists. When combined with --secure-store, also replaces the existing Secure Store entry
-- `--hd-path <HD_PATH>` — When importing a seed phrase, which `hd_path` to derive the key at. Persisted on the identity (or its Secure Store entry) so later commands derive the same account without re-passing the flag. Not valid with `--public-key` or a raw secret key
+- `--hd-path <HD_PATH>` — When importing a seed phrase, which `hd_path` to derive the key at. Persisted on the identity so later commands derive the same account without re-passing the flag. Not valid with `--public-key` or a raw secret key
 
 ###### **Options (Global):**
 

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -71,7 +71,7 @@ async fn invoke_contract() {
     let dir = sandbox.config_dir();
     let seed_phrase = std::fs::read_to_string(dir.join("identity/test.toml")).unwrap();
     let s = toml::from_str::<secret::Secret>(&seed_phrase).unwrap();
-    let secret::Secret::SeedPhrase { seed_phrase } = s else {
+    let secret::Secret::SeedPhrase { seed_phrase, .. } = s else {
         panic!("Expected seed phrase")
     };
 

--- a/cmd/crates/soroban-test/tests/it/integration/keys.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/keys.rs
@@ -351,6 +351,79 @@ async fn rm_with_force_skips_confirmation() {
         .failure();
 }
 
+// `keys generate --hd-path N` (plain seed-phrase storage) must persist N so
+// that later `keys address` calls without `--hd-path` derive at index N rather
+// than the default. Guards the user-visible contract from #2538 across CLI
+// parsing, identity-file I/O, and key derivation.
+#[tokio::test]
+async fn hd_path_persists_for_keys_generate() {
+    let sandbox = &TestEnv::new();
+    sandbox
+        .new_assert_cmd("keys")
+        .args(["generate", "hd-gen", "--hd-path", "5"])
+        .assert()
+        .success();
+
+    let address_default = pubkey_for_identity(sandbox, "hd-gen");
+    let address_explicit = sandbox
+        .new_assert_cmd("keys")
+        .args(["address", "hd-gen", "--hd-path", "5"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let address_zero = sandbox
+        .new_assert_cmd("keys")
+        .args(["address", "hd-gen", "--hd-path", "0"])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    assert_eq!(
+        address_default, address_explicit,
+        "expected `keys address hd-gen` (no flag) to derive at the persisted hd_path 5"
+    );
+    assert_ne!(
+        address_default, address_zero,
+        "expected hd_path 5 derivation to differ from hd_path 0"
+    );
+}
+
+#[tokio::test]
+async fn hd_path_persists_for_keys_add_seed_phrase() {
+    let sandbox = &TestEnv::new();
+    let seed_phrase = "aisle reflect depart add safe fury dress artist bronze abuse warrior clap inquiry ask mandate deputy view trade debate flip priority boy depart recipe";
+
+    sandbox
+        .new_assert_cmd("keys")
+        .write_stdin(format!("{seed_phrase}\n"))
+        .args(["add", "hd-add", "--hd-path", "5"])
+        .assert()
+        .success();
+
+    let address_default = pubkey_for_identity(sandbox, "hd-add");
+    let address_explicit = sandbox
+        .new_assert_cmd("keys")
+        .args(["address", "hd-add", "--hd-path", "5"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let address_zero = sandbox
+        .new_assert_cmd("keys")
+        .args(["address", "hd-add", "--hd-path", "0"])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    assert_eq!(
+        address_default, address_explicit,
+        "expected `keys address hd-add` (no flag) to derive at the persisted hd_path 5"
+    );
+    assert_ne!(
+        address_default, address_zero,
+        "expected hd_path 5 derivation to differ from hd_path 0"
+    );
+}
+
 #[tokio::test]
 async fn rm_nonexistent_key() {
     let sandbox = &TestEnv::new();

--- a/cmd/crates/soroban-test/tests/it/integration/secure_store.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/secure_store.rs
@@ -169,4 +169,35 @@ async fn secure_store_key_management() {
         "expected cached public_key to match the address derived at hd_path 5, \
          but identity file was:\n{identity_toml}"
     );
+
+    // Strip the cached public_key but keep hd_path = 5: simulates a legacy
+    // identity that persisted hd_path but never cached the derived pubkey.
+    // `keys address` without --hd-path must rederive at the persisted index 5
+    // and write the index-5 pubkey back to the cache — not silently overwrite
+    // it with the index-0 pubkey.
+    let stripped: String = identity_toml
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("public_key"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&identity_path, stripped).unwrap();
+
+    let address_after_rederive = sandbox
+        .new_assert_cmd("keys")
+        .args(["address", add_hd_path])
+        .assert()
+        .success()
+        .stdout_as_str();
+    assert_eq!(
+        address_after_rederive.trim(),
+        address_hd_path.trim(),
+        "expected `keys address {add_hd_path}` (no --hd-path) to derive at the persisted hd_path 5"
+    );
+
+    let identity_toml = std::fs::read_to_string(&identity_path).unwrap();
+    assert!(
+        identity_toml.contains(&format!("public_key = \"{}\"", address_hd_path.trim())),
+        "expected cache write-back to use the persisted hd_path, \
+         but identity file was:\n{identity_toml}"
+    );
 }

--- a/cmd/crates/soroban-test/tests/it/util.rs
+++ b/cmd/crates/soroban-test/tests/it/util.rs
@@ -18,6 +18,7 @@ pub fn add_key(dir: &Path, name: &str, kind: SecretKind, data: &str) {
     let secret = match kind {
         SecretKind::Seed => Secret::SeedPhrase {
             seed_phrase: data.to_string(),
+            hd_path: None,
         },
         SecretKind::Key => Secret::SecretKey {
             secret_key: data.to_string(),

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -39,6 +39,12 @@ pub enum Error {
          unset STELLAR_SECRET_KEY or provide a seed phrase instead"
     )]
     SecureStoreRequiresSeedPhrase,
+
+    #[error("--hd-path is not valid with a secret key; secret keys cannot be derived")]
+    HdPathNotSupportedForSecretKey,
+
+    #[error("--hd-path is not valid with --public-key; public keys cannot be derived")]
+    HdPathNotSupportedForPublicKey,
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -62,7 +68,9 @@ pub struct Cmd {
     #[arg(long)]
     pub overwrite: bool,
 
-    /// When importing a seed phrase into the Secure Store, which `hd_path` to derive the key at.
+    /// When importing a seed phrase, which `hd_path` to derive the key at. Persisted on
+    /// the identity (or its Secure Store entry) so later commands derive the same account
+    /// without re-passing the flag. Not valid with `--public-key` or a raw secret key.
     #[arg(long)]
     pub hd_path: Option<usize>,
 }
@@ -70,6 +78,10 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = Print::new(global_args.quiet);
+
+        if self.public_key.is_some() && self.hd_path.is_some() {
+            return Err(Error::HdPathNotSupportedForPublicKey);
+        }
 
         if self.config_locator.read_identity(&self.name).is_ok() {
             if !self.overwrite {
@@ -98,7 +110,7 @@ impl Cmd {
                 return Err(Error::SecureStoreRequiresSeedPhrase);
             }
         } else if let Ok(secret_key) = std::env::var("STELLAR_SECRET_KEY") {
-            return Ok(secret_key.parse()?);
+            return build_secret(&secret_key, self.hd_path);
         }
 
         if self.secrets.secure_store {
@@ -123,8 +135,8 @@ impl Cmd {
         } else {
             let prompt = "Type a secret key or 12/24 word seed phrase:";
             let secret_key = read_password(print, prompt)?;
-            let secret = secret_key.parse()?;
-            if let Secret::SeedPhrase { seed_phrase } = &secret {
+            let secret = build_secret(&secret_key, self.hd_path)?;
+            if let Secret::SeedPhrase { seed_phrase, .. } = &secret {
                 if seed_phrase.split_whitespace().count() < 24 {
                     print.warnln("The provided seed phrase lacks sufficient entropy and should be avoided. Using a 24-word seed phrase is a safer option.".to_string());
                     print.warnln(
@@ -135,6 +147,18 @@ impl Cmd {
             }
             Ok(secret)
         }
+    }
+}
+
+fn build_secret(input: &str, hd_path: Option<usize>) -> Result<Secret, Error> {
+    let secret: Secret = input.parse()?;
+    match (secret, hd_path) {
+        (Secret::SecretKey { .. }, Some(_)) => Err(Error::HdPathNotSupportedForSecretKey),
+        (Secret::SeedPhrase { seed_phrase, .. }, hd_path) => Ok(Secret::SeedPhrase {
+            seed_phrase,
+            hd_path,
+        }),
+        (secret, _) => Ok(secret),
     }
 }
 
@@ -190,11 +214,70 @@ mod tests {
         (temp_dir, locator, cmd)
     }
 
+    fn cmd_with_public_key(
+        public_key: &str,
+        hd_path: Option<usize>,
+    ) -> (tempfile::TempDir, locator::Args, Cmd) {
+        let (temp_dir, locator, mut cmd) = set_up_test();
+        cmd.public_key = Some(public_key.to_string());
+        cmd.hd_path = hd_path;
+        (temp_dir, locator, cmd)
+    }
+
     fn global_args() -> global::Args {
         global::Args {
             quiet: true,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_build_secret_persists_hd_path_on_seed_phrase() {
+        let secret = build_secret(SEED_PHRASE, Some(5)).unwrap();
+        match secret {
+            Secret::SeedPhrase {
+                seed_phrase,
+                hd_path,
+            } => {
+                assert_eq!(seed_phrase, SEED_PHRASE);
+                assert_eq!(hd_path, Some(5));
+            }
+            other => panic!("expected SeedPhrase variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_secret_seed_phrase_without_hd_path() {
+        let secret = build_secret(SEED_PHRASE, None).unwrap();
+        match secret {
+            Secret::SeedPhrase { hd_path, .. } => assert_eq!(hd_path, None),
+            other => panic!("expected SeedPhrase variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_secret_rejects_hd_path_with_secret_key() {
+        let result = build_secret(SECRET_KEY, Some(5));
+        assert!(matches!(result, Err(Error::HdPathNotSupportedForSecretKey)));
+    }
+
+    #[test]
+    fn test_build_secret_secret_key_without_hd_path() {
+        let secret = build_secret(SECRET_KEY, None).unwrap();
+        assert!(matches!(secret, Secret::SecretKey { .. }));
+    }
+
+    #[test]
+    fn test_run_rejects_hd_path_with_public_key() {
+        let (_tmp, _locator, cmd) = cmd_with_public_key(PUBLIC_KEY, Some(3));
+        let result = cmd.run(&global_args());
+        assert!(matches!(result, Err(Error::HdPathNotSupportedForPublicKey)));
+    }
+
+    #[test]
+    fn test_run_accepts_public_key_without_hd_path() {
+        let (_tmp, _locator, cmd) = cmd_with_public_key(PUBLIC_KEY, None);
+        assert!(cmd.run(&global_args()).is_ok());
     }
 
     #[test]

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -42,9 +42,6 @@ pub enum Error {
 
     #[error("--hd-path is not valid with a secret key; secret keys cannot be derived")]
     HdPathNotSupportedForSecretKey,
-
-    #[error("--hd-path is not valid with --public-key; public keys cannot be derived")]
-    HdPathNotSupportedForPublicKey,
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -60,7 +57,12 @@ pub struct Cmd {
     pub config_locator: locator::Args,
 
     /// Add a public key, ed25519, or muxed account, e.g. G1.., M2..
-    #[arg(long, conflicts_with = "seed_phrase", conflicts_with = "secret_key")]
+    #[arg(
+        long,
+        conflicts_with = "seed_phrase",
+        conflicts_with = "secret_key",
+        conflicts_with = "hd_path"
+    )]
     pub public_key: Option<String>,
 
     /// Overwrite existing identity if it already exists. When combined with
@@ -68,9 +70,10 @@ pub struct Cmd {
     #[arg(long)]
     pub overwrite: bool,
 
-    /// When importing a seed phrase, which `hd_path` to derive the key at. Persisted on
-    /// the identity (or its Secure Store entry) so later commands derive the same account
-    /// without re-passing the flag. Not valid with `--public-key` or a raw secret key.
+    /// When importing a seed phrase, which `hd_path` to derive the key at.
+    /// Persisted on the identity so later commands derive the same account
+    /// without re-passing the flag. Not valid with `--public-key` or a raw
+    /// secret key.
     #[arg(long)]
     pub hd_path: Option<usize>,
 }
@@ -78,10 +81,6 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = Print::new(global_args.quiet);
-
-        if self.public_key.is_some() && self.hd_path.is_some() {
-            return Err(Error::HdPathNotSupportedForPublicKey);
-        }
 
         if self.config_locator.read_identity(&self.name).is_ok() {
             if !self.overwrite {
@@ -268,10 +267,22 @@ mod tests {
     }
 
     #[test]
-    fn test_run_rejects_hd_path_with_public_key() {
-        let (_tmp, _locator, cmd) = cmd_with_public_key(PUBLIC_KEY, Some(3));
-        let result = cmd.run(&global_args());
-        assert!(matches!(result, Err(Error::HdPathNotSupportedForPublicKey)));
+    fn test_clap_rejects_hd_path_with_public_key() {
+        // clap-level conflict: --public-key cannot be combined with --hd-path.
+        // Driving through `try_parse_from` rather than constructing `Cmd`
+        // directly is what exercises the conflict.
+        use clap::Parser;
+
+        let result = Cmd::try_parse_from([
+            "add",
+            "test_name",
+            "--public-key",
+            PUBLIC_KEY,
+            "--hd-path",
+            "3",
+        ]);
+        let err = result.expect_err("clap must reject --public-key + --hd-path");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/cmd/soroban-cli/src/commands/keys/generate.rs
+++ b/cmd/soroban-cli/src/commands/keys/generate.rs
@@ -50,7 +50,10 @@ pub struct Cmd {
     #[command(flatten)]
     pub config_locator: locator::Args,
 
-    /// With `--as-secret` or `--secure-store`, which `hd_path` to derive the key at from the seed phrase.
+    /// Which `hd_path` to derive the key at from the seed phrase. Honored across all
+    /// storage modes: with `--as-secret` it picks which derived key is stored, with
+    /// `--secure-store` or plain seed-phrase storage it is persisted on the identity
+    /// so later commands derive the same account without re-passing the flag.
     #[arg(long)]
     pub hd_path: Option<usize>,
 
@@ -127,7 +130,10 @@ impl Cmd {
             let secret: Secret = seed_phrase.into();
             Ok(secret.private_key(self.hd_path)?.into())
         } else {
-            Ok(seed_phrase.into())
+            Ok(Secret::SeedPhrase {
+                seed_phrase: seed_phrase.seed_phrase.into_phrase(),
+                hd_path: self.hd_path,
+            })
         }
     }
 
@@ -140,7 +146,7 @@ impl Cmd {
 mod tests {
     use crate::config::{address::KeyName, key::Key, secret::Secret};
 
-    fn set_up_test() -> (super::locator::Args, super::Cmd) {
+    fn set_up_test() -> (super::locator::Args, super::Cmd, tempfile::TempDir) {
         let temp_dir = tempfile::tempdir().unwrap();
         let locator = super::locator::Args {
             config_dir: Some(temp_dir.path().to_path_buf()),
@@ -158,7 +164,7 @@ mod tests {
             overwrite: false,
         };
 
-        (locator, cmd)
+        (locator, cmd, temp_dir)
     }
 
     fn global_args() -> super::global::Args {
@@ -170,7 +176,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_storing_secret_as_a_seed_phrase() {
-        let (test_locator, cmd) = set_up_test();
+        let (test_locator, cmd, _temp_dir) = set_up_test();
         let global_args = global_args();
 
         let result = cmd.run(&global_args).await;
@@ -180,8 +186,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_generate_seed_phrase_persists_hd_path() {
+        let (test_locator, mut cmd, _temp_dir) = set_up_test();
+        cmd.hd_path = Some(7);
+        let global_args = global_args();
+
+        cmd.run(&global_args).await.unwrap();
+
+        let identity = test_locator.read_identity("test_name").unwrap();
+        match identity {
+            Key::Secret(Secret::SeedPhrase { hd_path, .. }) => {
+                assert_eq!(hd_path, Some(7));
+            }
+            other => panic!("expected SeedPhrase variant, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_storing_secret_as_a_secret_key() {
-        let (test_locator, mut cmd) = set_up_test();
+        let (test_locator, mut cmd, _temp_dir) = set_up_test();
         cmd.as_secret = true;
         let global_args = global_args();
 
@@ -196,7 +219,7 @@ mod tests {
     async fn test_storing_secret_in_secure_store() {
         use keyring::{mock, set_default_credential_builder};
         set_default_credential_builder(mock::default_credential_builder());
-        let (test_locator, mut cmd) = set_up_test();
+        let (test_locator, mut cmd, _temp_dir) = set_up_test();
         cmd.secure_store = true;
         let global_args = global_args();
 
@@ -211,7 +234,7 @@ mod tests {
     async fn test_generate_secure_store_caches_public_key_on_disk() {
         use keyring::{mock, set_default_credential_builder};
         set_default_credential_builder(mock::default_credential_builder());
-        let (test_locator, mut cmd) = set_up_test();
+        let (test_locator, mut cmd, _temp_dir) = set_up_test();
         cmd.secure_store = true;
         let global_args = global_args();
 
@@ -237,7 +260,7 @@ mod tests {
     #[cfg(not(feature = "additional-libs"))]
     #[tokio::test]
     async fn test_storing_in_secure_store_returns_error_when_additional_libs_not_enabled() {
-        let (test_locator, mut cmd) = set_up_test();
+        let (test_locator, mut cmd, _temp_dir) = set_up_test();
         cmd.secure_store = true;
         let global_args = global_args();
 

--- a/cmd/soroban-cli/src/commands/keys/secret.rs
+++ b/cmd/soroban-cli/src/commands/keys/secret.rs
@@ -49,7 +49,7 @@ impl Cmd {
     pub fn seed_phrase(&self) -> Result<String, Error> {
         let key = self.locator.read_identity(&self.name)?;
 
-        if let Key::Secret(Secret::SeedPhrase { seed_phrase }) = key {
+        if let Key::Secret(Secret::SeedPhrase { seed_phrase, .. }) = key {
             Ok(seed_phrase)
         } else {
             Err(Error::UnknownSeedPhrase)

--- a/cmd/soroban-cli/src/config/key.rs
+++ b/cmd/soroban-cli/src/config/key.rs
@@ -185,7 +185,10 @@ mod test {
     #[test]
     fn secret_seed_phrase() {
         let seed_phrase = "singer swing mango apple singer swing mango apple singer swing mango apple singer swing mango apple".to_string();
-        let secret = Secret::SeedPhrase { seed_phrase };
+        let secret = Secret::SeedPhrase {
+            seed_phrase,
+            hd_path: None,
+        };
         let key = Key::Secret(secret);
         round_trip(&key);
     }

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -322,14 +322,19 @@ impl Args {
         if let Key::Secret(Secret::SecureStore {
             entry_name,
             public_key: None,
-            ..
+            hd_path: persisted_hd_path,
         }) = &key
         {
-            let pk = secure_store::get_public_key(entry_name, hd_path)?;
+            // Honor the persisted hd_path when the caller passes None. Without
+            // this the cache gets populated at index 0 even when the identity
+            // was added with `--hd-path N`, which silently locks every later
+            // read to the wrong account.
+            let effective = hd_path.or(*persisted_hd_path);
+            let pk = secure_store::get_public_key(entry_name, effective)?;
             let migrated = Key::Secret(Secret::SecureStore {
                 entry_name: entry_name.clone(),
                 public_key: Some(pk.to_string()),
-                hd_path,
+                hd_path: effective,
             });
             // Best-effort write-back: if persistence fails we still return the
             // freshly-derived value so the current call succeeds.

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -62,6 +62,12 @@ pub enum Secret {
     },
     SeedPhrase {
         seed_phrase: String,
+        // Persisted derivation index. Lets `--hd-path` set on `keys generate` /
+        // `keys add` travel with the identity, so later commands derive the
+        // intended account without re-passing the flag. Optional for backwards
+        // compatibility with files written before this field existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hd_path: Option<usize>,
     },
     Ledger,
     SecureStore {
@@ -87,6 +93,7 @@ impl FromStr for Secret {
         } else if sep5::SeedPhrase::from_str(s).is_ok() {
             Ok(Secret::SeedPhrase {
                 seed_phrase: s.to_string(),
+                hd_path: None,
             })
         } else if s == "ledger" {
             Ok(Secret::Ledger)
@@ -120,6 +127,7 @@ impl From<SeedPhrase> for Secret {
     fn from(value: SeedPhrase) -> Self {
         Secret::SeedPhrase {
             seed_phrase: value.seed_phrase.into_phrase(),
+            hd_path: None,
         }
     }
 }
@@ -128,9 +136,12 @@ impl Secret {
     pub fn private_key(&self, index: Option<usize>) -> Result<PrivateKey, Error> {
         Ok(match self {
             Secret::SecretKey { secret_key } => PrivateKey::from_string(secret_key)?,
-            Secret::SeedPhrase { seed_phrase } => PrivateKey::from_payload(
+            Secret::SeedPhrase {
+                seed_phrase,
+                hd_path,
+            } => PrivateKey::from_payload(
                 &sep5::SeedPhrase::from_str(seed_phrase)?
-                    .from_path_index(index.unwrap_or_default(), None)?
+                    .from_path_index(index.or(*hd_path).unwrap_or_default(), None)?
                     .private()
                     .0,
             )?,
@@ -148,10 +159,11 @@ impl Secret {
             hd_path,
         } = self
         {
-            if let Some(cached) = cached_public_key(public_key.as_deref(), *hd_path, index) {
+            let effective = index.or(*hd_path);
+            if let Some(cached) = cached_public_key(public_key.as_deref(), *hd_path, effective) {
                 return Ok(cached);
             }
-            Ok(secure_store::get_public_key(entry_name, index)?)
+            Ok(secure_store::get_public_key(entry_name, effective)?)
         } else {
             let key = self.key_pair(index)?;
             Ok(stellar_strkey::ed25519::PublicKey::from_payload(
@@ -178,11 +190,12 @@ impl Secret {
                 public_key,
                 hd_path: cached_hd_path,
             } => {
+                let effective = hd_path.or(*cached_hd_path);
                 let cached_public_key =
-                    cached_public_key(public_key.as_deref(), *cached_hd_path, hd_path);
+                    cached_public_key(public_key.as_deref(), *cached_hd_path, effective);
                 SignerKind::SecureStore(SecureStoreEntry {
                     name: entry_name.clone(),
-                    hd_path,
+                    hd_path: effective,
                     public_key: cached_public_key,
                 })
             }
@@ -327,6 +340,20 @@ mod tests {
     }
 
     #[test]
+    fn test_secure_store_public_key_falls_back_to_persisted_hd_path() {
+        // Bogus entry_name guarantees a keychain lookup would fail. The cache is
+        // populated at the persisted hd_path; calling public_key(None) must fall
+        // back to that hd_path and hit the cache rather than re-deriving at index 0.
+        let secret = Secret::SecureStore {
+            entry_name: "secure_store:org.stellar.cli-no-such-entry".to_string(),
+            public_key: Some(TEST_PUBLIC_KEY.to_string()),
+            hd_path: Some(5),
+        };
+        let pk = secret.public_key(None).unwrap();
+        assert_eq!(pk.to_string(), TEST_PUBLIC_KEY);
+    }
+
+    #[test]
     fn test_cached_public_key_treats_none_and_zero_as_equal() {
         // `unwrap_or_default()` is used everywhere else for hd_path, so the
         // cache must treat None and Some(0) as the same path.
@@ -346,5 +373,63 @@ mod tests {
         // the keychain instead of erroring out.
         assert!(cached_public_key(Some("not-a-public-key"), None, None).is_none());
         assert!(cached_public_key(Some(""), None, None).is_none());
+    }
+
+    #[test]
+    fn test_seed_phrase_toml_round_trip_with_hd_path() {
+        let secret = Secret::SeedPhrase {
+            seed_phrase: TEST_SEED_PHRASE.to_string(),
+            hd_path: Some(5),
+        };
+        let serialized = toml::to_string(&secret).unwrap();
+        assert!(
+            serialized.contains("hd_path"),
+            "expected hd_path field in TOML, got: {serialized}"
+        );
+        let parsed: Secret = toml::from_str(&serialized).unwrap();
+        assert_eq!(secret, parsed);
+    }
+
+    #[test]
+    fn test_seed_phrase_legacy_toml_parses_with_none_hd_path() {
+        // Identity files written before this feature only contain seed_phrase.
+        // They must still parse, with hd_path defaulting to None.
+        let toml_str = format!("seed_phrase = \"{TEST_SEED_PHRASE}\"\n");
+        let secret: Secret = toml::from_str(&toml_str).unwrap();
+        match secret {
+            Secret::SeedPhrase {
+                seed_phrase,
+                hd_path,
+            } => {
+                assert_eq!(seed_phrase, TEST_SEED_PHRASE);
+                assert_eq!(hd_path, None);
+            }
+            other => panic!("expected SeedPhrase variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_seed_phrase_uses_persisted_hd_path_when_caller_passes_none() {
+        // When the caller passes None, the persisted hd_path should drive derivation.
+        let secret = Secret::SeedPhrase {
+            seed_phrase: TEST_SEED_PHRASE.to_string(),
+            hd_path: Some(1),
+        };
+        let pk_at_0 = secret.public_key(Some(0)).unwrap();
+        let pk_default = secret.public_key(None).unwrap();
+        assert_ne!(pk_at_0.to_string(), pk_default.to_string());
+    }
+
+    #[test]
+    fn test_seed_phrase_caller_hd_path_overrides_persisted() {
+        // Caller's explicit hd_path argument always wins over the persisted value.
+        let secret = Secret::SeedPhrase {
+            seed_phrase: TEST_SEED_PHRASE.to_string(),
+            hd_path: Some(1),
+        };
+        let pk = secret.public_key(Some(0)).unwrap();
+        let sk = secret.private_key(Some(0)).unwrap();
+        assert_eq!(pk.to_string(), TEST_PUBLIC_KEY);
+        assert_eq!(sk.to_string(), TEST_SECRET_KEY);
     }
 }

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -182,7 +182,7 @@ impl Secret {
                 let hd_path: u32 = hd_path
                     .unwrap_or_default()
                     .try_into()
-                    .expect("uszie bigger than u32");
+                    .expect("usize bigger than u32");
                 SignerKind::Ledger(ledger::new(hd_path).await?)
             }
             Secret::SecureStore {


### PR DESCRIPTION
### What

Persist `--hd-path` on seed-phrase identities (both plain seed-phrase and Secure Store) for `stellar keys generate` and `stellar keys add`, and honor it as a default in later derivations:

- `Secret::SeedPhrase` gains an optional `hd_path` field that travels with the identity.
- `Secret::public_key` / `private_key` / `signer` fall back to the persisted `hd_path` when the caller passes `None`.
- `Secret::SecureStore` already persisted `hd_path` on disk (see #2533), but ignored it at derivation time. It now also falls back to the persisted value when the caller passes `None`, matching `Secret::SeedPhrase`. Caller-supplied indices still take precedence.
- `keys add` rejects `--hd-path` against incompatible inputs (raw secret keys, `--public-key`).

Closes #2538.

### Why

`--hd-path` was accepted but silently dropped on the plain seed-phrase path, and was persisted-but-ignored for Secure Store, so later commands derived index `0` unless the user re-passed the flag every time. Approach (3) from the issue (persist on the identity, schema-bumped with `#[serde(default)]`) keeps behavior consistent across all storage modes — without breaking identity files written before this field existed.

The Secure Store fallback was added during review after empirical testing showed `keys public-key <name>` returned the index-0 key even though `hd_path` was already on disk.

### Known limitations

- Identity files written before this PR have no `hd_path` field; they parse fine and behave as before (derivation index defaults to `0`). Re-running `keys add` / `keys generate` with `--hd-path` is the way to migrate them, but this is not required.
- `--hd-path` against a raw secret key or `--public-key` is now a hard error rather than being silently ignored. This is intentional but is a behavior change for anyone who was passing the flag in those modes.
