### PR TITLE
Reject secret-bearing input on public-key flag

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/keys.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/keys.rs
@@ -145,6 +145,56 @@ async fn overwrite_identity_with_add() {
 }
 
 #[tokio::test]
+async fn add_public_key_rejects_secret_bearing_input() {
+    let sandbox = &TestEnv::new();
+    let secret = "SBF5HLRREHMS36XZNTUSKZ6FTXDZGNXOHF4EXKUL5UCWZLPBX3NGJ4BH";
+
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("add")
+        .arg("public-only")
+        .arg("--public-key")
+        .arg(secret)
+        .assert()
+        .failure();
+
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("address")
+        .arg("public-only")
+        .assert()
+        .failure();
+
+    let seed = "depth decade power loud smile spatial sign movie judge february rate broccoli";
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("add")
+        .arg("public-only-seed")
+        .arg("--public-key")
+        .arg(seed)
+        .assert()
+        .failure();
+
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("add")
+        .arg("public-only-ledger")
+        .arg("--public-key")
+        .arg("ledger")
+        .assert()
+        .failure();
+
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("add")
+        .arg("public-only-secure")
+        .arg("--public-key")
+        .arg("secure_store:org.stellar.cli-alice")
+        .assert()
+        .failure();
+}
+
+#[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn set_default_identity() {
     let sandbox = &TestEnv::new();

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -170,7 +170,7 @@ mod tests {
     const SEED_PHRASE: &str =
         "depth decade power loud smile spatial sign movie judge february rate broccoli";
 
-    fn set_up_test() -> (locator::Args, Cmd) {
+    fn set_up_test() -> (tempfile::TempDir, locator::Args, Cmd) {
         let temp_dir = tempfile::tempdir().unwrap();
         let locator = locator::Args {
             config_dir: Some(temp_dir.path().to_path_buf()),
@@ -187,7 +187,7 @@ mod tests {
             overwrite: false,
             hd_path: None,
         };
-        (locator, cmd)
+        (temp_dir, locator, cmd)
     }
 
     fn global_args() -> global::Args {
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn public_key_flag_accepts_public_key() {
-        let (locator, mut cmd) = set_up_test();
+        let (_tmp, locator, mut cmd) = set_up_test();
         cmd.public_key = Some(PUBLIC_KEY.to_string());
         cmd.run(&global_args()).unwrap();
         let stored = locator.read_identity("test_name").unwrap();
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn public_key_flag_accepts_muxed_account() {
-        let (locator, mut cmd) = set_up_test();
+        let (_tmp, locator, mut cmd) = set_up_test();
         cmd.public_key = Some(MUXED_ACCOUNT.to_string());
         cmd.run(&global_args()).unwrap();
         let stored = locator.read_identity("test_name").unwrap();
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn public_key_flag_rejects_secret_key() {
-        let (locator, mut cmd) = set_up_test();
+        let (_tmp, locator, mut cmd) = set_up_test();
         cmd.public_key = Some(SECRET_KEY.to_string());
         let err = cmd.run(&global_args()).unwrap_err();
         assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn public_key_flag_rejects_seed_phrase() {
-        let (locator, mut cmd) = set_up_test();
+        let (_tmp, locator, mut cmd) = set_up_test();
         cmd.public_key = Some(SEED_PHRASE.to_string());
         let err = cmd.run(&global_args()).unwrap_err();
         assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn public_key_flag_rejects_ledger() {
-        let (locator, mut cmd) = set_up_test();
+        let (_tmp, locator, mut cmd) = set_up_test();
         cmd.public_key = Some("ledger".to_string());
         let err = cmd.run(&global_args()).unwrap_err();
         assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn public_key_flag_rejects_secure_store() {
-        let (locator, mut cmd) = set_up_test();
+        let (_tmp, locator, mut cmd) = set_up_test();
         cmd.public_key = Some("secure_store:org.stellar.cli-alice".to_string());
         let err = cmd.run(&global_args()).unwrap_err();
         assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -80,7 +80,7 @@ impl Cmd {
         }
 
         let key = if let Some(key) = self.public_key.as_ref() {
-            key.parse()?
+            key::Key::parse_public_only(key)?
         } else {
             self.read_secret(&print)?.into()
         };
@@ -155,5 +155,99 @@ fn read_password(print: &Print, prompt: &str) -> Result<String, Error> {
             return Err(Error::PasswordRead);
         }
         Ok(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::key::{self as key_mod, Key};
+
+    const PUBLIC_KEY: &str = "GAKSH6AD2IPJQELTHIOWDAPYX74YELUOWJLI2L4RIPIPZH6YQIFNUSDC";
+    const MUXED_ACCOUNT: &str =
+        "MA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAAAAAAAAAPCICBKU";
+    const SECRET_KEY: &str = "SBF5HLRREHMS36XZNTUSKZ6FTXDZGNXOHF4EXKUL5UCWZLPBX3NGJ4BH";
+    const SEED_PHRASE: &str =
+        "depth decade power loud smile spatial sign movie judge february rate broccoli";
+
+    fn set_up_test() -> (locator::Args, Cmd) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let locator = locator::Args {
+            config_dir: Some(temp_dir.path().to_path_buf()),
+        };
+        let cmd = Cmd {
+            name: "test_name".parse().unwrap(),
+            secrets: secret::Args {
+                secret_key: false,
+                seed_phrase: false,
+                secure_store: false,
+            },
+            config_locator: locator.clone(),
+            public_key: None,
+            overwrite: false,
+            hd_path: None,
+        };
+        (locator, cmd)
+    }
+
+    fn global_args() -> global::Args {
+        global::Args {
+            quiet: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn public_key_flag_accepts_public_key() {
+        let (locator, mut cmd) = set_up_test();
+        cmd.public_key = Some(PUBLIC_KEY.to_string());
+        cmd.run(&global_args()).unwrap();
+        let stored = locator.read_identity("test_name").unwrap();
+        assert!(matches!(stored, Key::PublicKey(_)));
+    }
+
+    #[test]
+    fn public_key_flag_accepts_muxed_account() {
+        let (locator, mut cmd) = set_up_test();
+        cmd.public_key = Some(MUXED_ACCOUNT.to_string());
+        cmd.run(&global_args()).unwrap();
+        let stored = locator.read_identity("test_name").unwrap();
+        assert!(matches!(stored, Key::MuxedAccount(_)));
+    }
+
+    #[test]
+    fn public_key_flag_rejects_secret_key() {
+        let (locator, mut cmd) = set_up_test();
+        cmd.public_key = Some(SECRET_KEY.to_string());
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
+        assert!(locator.read_identity("test_name").is_err());
+    }
+
+    #[test]
+    fn public_key_flag_rejects_seed_phrase() {
+        let (locator, mut cmd) = set_up_test();
+        cmd.public_key = Some(SEED_PHRASE.to_string());
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
+        assert!(locator.read_identity("test_name").is_err());
+    }
+
+    #[test]
+    fn public_key_flag_rejects_ledger() {
+        let (locator, mut cmd) = set_up_test();
+        cmd.public_key = Some("ledger".to_string());
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
+        assert!(locator.read_identity("test_name").is_err());
+    }
+
+    #[test]
+    fn public_key_flag_rejects_secure_store() {
+        let (locator, mut cmd) = set_up_test();
+        cmd.public_key = Some("secure_store:org.stellar.cli-alice".to_string());
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(err, Error::Key(key_mod::Error::PublicKeyExpected)));
+        assert!(locator.read_identity("test_name").is_err());
     }
 }

--- a/cmd/soroban-cli/src/commands/message/verify.rs
+++ b/cmd/soroban-cli/src/commands/message/verify.rs
@@ -2,7 +2,7 @@ use std::io::{self, Read};
 
 use crate::{
     commands::global,
-    config::{locator, secret},
+    config::{key, locator, secret},
     print::Print,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
@@ -28,6 +28,9 @@ pub enum Error {
 
     #[error(transparent)]
     StrKey(#[from] stellar_strkey::DecodeError),
+
+    #[error(transparent)]
+    Key(#[from] key::Error),
 
     #[error(transparent)]
     Ed25519(#[from] ed25519_dalek::SignatureError),
@@ -133,15 +136,14 @@ impl Cmd {
     }
 
     fn get_public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
-        // try to parse as stellar public key first
-        if let Ok(pk) = stellar_strkey::ed25519::PublicKey::from_string(&self.public_key) {
-            return Ok(pk);
-        }
-
-        // otherwise treat as identity and resolve
-        let account = self
-            .locator
-            .read_key(&self.public_key)?
+        // Try public-only parsing first (G... or M...); fall through to alias
+        // resolution only when the input doesn't parse as any key.
+        let key = match key::Key::parse_public_only(&self.public_key) {
+            Ok(key) => key,
+            Err(err @ key::Error::PublicKeyExpected) => return Err(Error::Key(err)),
+            Err(_) => self.locator.read_key(&self.public_key)?,
+        };
+        let account = key
             .muxed_account(self.hd_path)
             .map_err(crate::config::address::Error::from)?;
         let bytes = match account {
@@ -271,5 +273,76 @@ mod tests {
         };
         let successful = cmd.run(&global);
         assert!(successful.is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_raw_secret_key_as_public_key() {
+        let secret_key = "SBF5HLRREHMS36XZNTUSKZ6FTXDZGNXOHF4EXKUL5UCWZLPBX3NGJ4BH";
+        let cmd = super::Cmd {
+            message: Some("Hello, World!".to_string()),
+            base64: false,
+            signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
+            public_key: secret_key.to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Key(crate::config::key::Error::PublicKeyExpected)
+        ));
+    }
+
+    #[test]
+    fn test_verify_rejects_raw_seed_phrase_as_public_key() {
+        let seed_phrase =
+            "depth decade power loud smile spatial sign movie judge february rate broccoli";
+        let cmd = super::Cmd {
+            message: Some("Hello, World!".to_string()),
+            base64: false,
+            signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
+            public_key: seed_phrase.to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Key(crate::config::key::Error::PublicKeyExpected)
+        ));
+    }
+
+    #[test]
+    fn test_verify_rejects_ledger_as_public_key() {
+        let cmd = super::Cmd {
+            message: Some("Hello, World!".to_string()),
+            base64: false,
+            signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
+            public_key: "ledger".to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Key(crate::config::key::Error::PublicKeyExpected)
+        ));
+    }
+
+    #[test]
+    fn test_verify_rejects_secure_store_as_public_key() {
+        let cmd = super::Cmd {
+            message: Some("Hello, World!".to_string()),
+            base64: false,
+            signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
+            public_key: "secure_store:org.stellar.cli-alice".to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        let err = cmd.run(&global_args()).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Key(crate::config::key::Error::PublicKeyExpected)
+        ));
     }
 }

--- a/cmd/soroban-cli/src/config/key.rs
+++ b/cmd/soroban-cli/src/config/key.rs
@@ -15,6 +15,8 @@ pub enum Error {
     StrKey(#[from] stellar_strkey::DecodeError),
     #[error("failed to parse key")]
     Parse,
+    #[error("expected a public key (G...) or muxed account (M...)")]
+    PublicKeyExpected,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -52,6 +54,13 @@ impl Key {
         match self {
             Key::Secret(secret) => Ok(secret.private_key(hd_path)?),
             _ => Err(Error::SecretPublicKey),
+        }
+    }
+
+    pub fn parse_public_only(s: &str) -> Result<Self, Error> {
+        match s.parse()? {
+            key @ (Key::PublicKey(_) | Key::MuxedAccount(_)) => Ok(key),
+            Key::Secret(_) => Err(Error::PublicKeyExpected),
         }
     }
 }
@@ -179,5 +188,54 @@ mod test {
         let secret = Secret::SeedPhrase { seed_phrase };
         let key = Key::Secret(secret);
         round_trip(&key);
+    }
+
+    const PUBLIC_KEY: &str = "GAKSH6AD2IPJQELTHIOWDAPYX74YELUOWJLI2L4RIPIPZH6YQIFNUSDC";
+    const MUXED_ACCOUNT: &str =
+        "MA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAAAAAAAAAPCICBKU";
+    const SECRET_KEY: &str = "SBF5HLRREHMS36XZNTUSKZ6FTXDZGNXOHF4EXKUL5UCWZLPBX3NGJ4BH";
+    const SEED_PHRASE: &str =
+        "depth decade power loud smile spatial sign movie judge february rate broccoli";
+
+    #[test]
+    fn parse_public_only_accepts_public_key() {
+        let key = Key::parse_public_only(PUBLIC_KEY).unwrap();
+        assert!(matches!(key, Key::PublicKey(_)));
+    }
+
+    #[test]
+    fn parse_public_only_accepts_muxed_account() {
+        let key = Key::parse_public_only(MUXED_ACCOUNT).unwrap();
+        assert!(matches!(key, Key::MuxedAccount(_)));
+    }
+
+    #[test]
+    fn parse_public_only_rejects_secret_key() {
+        let err = Key::parse_public_only(SECRET_KEY).unwrap_err();
+        assert!(matches!(err, Error::PublicKeyExpected));
+    }
+
+    #[test]
+    fn parse_public_only_rejects_seed_phrase() {
+        let err = Key::parse_public_only(SEED_PHRASE).unwrap_err();
+        assert!(matches!(err, Error::PublicKeyExpected));
+    }
+
+    #[test]
+    fn parse_public_only_rejects_ledger() {
+        let err = Key::parse_public_only("ledger").unwrap_err();
+        assert!(matches!(err, Error::PublicKeyExpected));
+    }
+
+    #[test]
+    fn parse_public_only_rejects_secure_store() {
+        let err = Key::parse_public_only("secure_store:org.stellar.cli-alice").unwrap_err();
+        assert!(matches!(err, Error::PublicKeyExpected));
+    }
+
+    #[test]
+    fn parse_public_only_rejects_garbage() {
+        let err = Key::parse_public_only("not-a-key").unwrap_err();
+        assert!(matches!(err, Error::Parse));
     }
 }


### PR DESCRIPTION
### What

`stellar keys add --public-key` and `stellar message verify --public-key` now reject secret-bearing input (`SC...` secret keys, seed phrases, `ledger`, `secure_store:*` entries). Adds `Key::parse_public_only()` as the single entry point for public-only parsing, used by both call sites.

### Why

These flags are documented and named as public-only, but the underlying parser tried `Secret` before `Public`/`MuxedAccount`, so a secret passed to `--public-key` was silently stored as a signing identity (or routed through the public-key path on `verify`). That breaks the public-only safety boundary callers and automation rely on. Closes stellar/stellar-cli-internal#52.

Aliases (e.g. `--public-key alice` where `alice` is a stored secret identity) are unaffected — only the public part is consumed.

### Known limitations

N/A