### PR TITLE
Add `--ledger` to `stellar keys address`

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1148,7 +1148,7 @@ Add a new identity (keypair, ledger, OS specific secure store)
 
 Given an identity return its address (public key)
 
-**Usage:** `stellar keys public-key [OPTIONS] <NAME>`
+**Usage:** `stellar keys public-key [OPTIONS] [NAME]`
 
 **Command Alias:** `address`
 
@@ -1158,7 +1158,8 @@ Given an identity return its address (public key)
 
 ###### **Options:**
 
-- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
+- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0. With --ledger this is the Ledger account index (default 0)
+- `--ledger` — Derive the address from a connected Ledger hardware wallet at `m/44'/148'/N'`, where `N` defaults to 0 and can be set with `--hd-path`
 
 ###### **Options (Global):**
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1154,7 +1154,7 @@ Given an identity return its address (public key)
 
 ###### **Arguments:**
 
-- `<NAME>` — Name of identity to lookup, default test identity used if not provided
+- `<NAME>` — Name of identity to lookup. Required unless `--ledger` is provided
 
 ###### **Options:**
 

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -289,15 +289,6 @@ impl TestEnv {
         &self.temp_dir
     }
 
-    /// Returns the public key corresponding to the test keys's `hd_path`
-    pub async fn test_address(&self, hd_path: usize) -> String {
-        self.cmd::<keys::public_key::Cmd>(&format!("--hd-path={hd_path}"))
-            .public_key()
-            .await
-            .unwrap()
-            .to_string()
-    }
-
     /// Returns the private key corresponding to the test keys's `hd_path`
     pub fn test_show(&self, hd_path: usize) -> String {
         self.cmd::<keys::secret::Cmd>(&format!("--hd-path={hd_path}"))

--- a/cmd/soroban-cli/src/commands/keys/fund.rs
+++ b/cmd/soroban-cli/src/commands/keys/fund.rs
@@ -17,7 +17,7 @@ pub struct Cmd {
     pub network: network::Args,
     /// Address to fund
     #[command(flatten)]
-    pub address: public_key::Cmd,
+    pub address: public_key::Args,
 }
 
 impl Cmd {
@@ -32,5 +32,20 @@ impl Cmd {
             formatted_name, network.network_passphrase
         ));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    const PUBLIC_KEY: &str = "GAKSH6AD2IPJQELTHIOWDAPYX74YELUOWJLI2L4RIPIPZH6YQIFNUSDC";
+
+    #[test]
+    fn fund_does_not_accept_ledger_flag() {
+        let err = Cmd::try_parse_from(["fund", PUBLIC_KEY, "--ledger"])
+            .expect_err("`--ledger` belongs to `keys address` only");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 }

--- a/cmd/soroban-cli/src/commands/keys/public_key.rs
+++ b/cmd/soroban-cli/src/commands/keys/public_key.rs
@@ -43,7 +43,7 @@ impl Args {
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// Name of identity to lookup, default test identity used if not provided
+    /// Name of identity to lookup. Required unless `--ledger` is provided.
     #[arg(required_unless_present = "ledger")]
     pub name: Option<UnresolvedMuxedAccount>,
 

--- a/cmd/soroban-cli/src/commands/keys/public_key.rs
+++ b/cmd/soroban-cli/src/commands/keys/public_key.rs
@@ -7,17 +7,56 @@ use crate::{
 pub enum Error {
     #[error(transparent)]
     Address(#[from] address::Error),
+
+    #[error("--hd-path {0} is out of range for a Ledger account index")]
+    HdPathOutOfRange(usize),
 }
 
+/// The fields shared by every command that resolves an identity to a public
+/// key. Embed this with `#[command(flatten)]` to inherit `name`, `hd_path`,
+/// and the config locator without picking up `keys address`'s `--ledger`
+/// flag.
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
-pub struct Cmd {
+pub struct Args {
     /// Name of identity to lookup, default test identity used if not provided
     pub name: UnresolvedMuxedAccount,
 
     /// If identity is a seed phrase use this hd path, default is 0
     #[arg(long)]
     pub hd_path: Option<usize>,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
+impl Args {
+    pub async fn public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
+        Ok(public_key_from_muxed(
+            self.name
+                .resolve_muxed_account(&self.locator, self.hd_path)
+                .await?,
+        ))
+    }
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// Name of identity to lookup, default test identity used if not provided
+    #[arg(required_unless_present = "ledger")]
+    pub name: Option<UnresolvedMuxedAccount>,
+
+    /// If identity is a seed phrase use this hd path, default is 0.
+    /// With --ledger this is the Ledger account index (default 0).
+    #[arg(long)]
+    pub hd_path: Option<usize>,
+
+    /// Derive the address from a connected Ledger hardware wallet at
+    /// `m/44'/148'/N'`, where `N` defaults to 0 and can be set with
+    /// `--hd-path`.
+    #[arg(long, conflicts_with = "name")]
+    pub ledger: bool,
 
     #[command(flatten)]
     pub locator: locator::Args,
@@ -30,14 +69,75 @@ impl Cmd {
     }
 
     pub async fn public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
-        let muxed = self
+        if self.ledger {
+            let raw = self.hd_path.unwrap_or(0);
+            let index: u32 = raw.try_into().map_err(|_| Error::HdPathOutOfRange(raw))?;
+            return Ok(public_key_from_muxed(
+                UnresolvedMuxedAccount::Ledger(index)
+                    .resolve_muxed_account(&self.locator, None)
+                    .await?,
+            ));
+        }
+        let name = self
             .name
-            .resolve_muxed_account(&self.locator, self.hd_path)
-            .await?;
-        let bytes = match muxed {
-            soroban_sdk::xdr::MuxedAccount::Ed25519(uint256) => uint256.0,
-            soroban_sdk::xdr::MuxedAccount::MuxedEd25519(muxed_account) => muxed_account.ed25519.0,
-        };
-        Ok(stellar_strkey::ed25519::PublicKey(bytes))
+            .as_ref()
+            .expect("clap requires `name` unless --ledger is set");
+        Ok(public_key_from_muxed(
+            name.resolve_muxed_account(&self.locator, self.hd_path)
+                .await?,
+        ))
+    }
+}
+
+fn public_key_from_muxed(
+    muxed: soroban_sdk::xdr::MuxedAccount,
+) -> stellar_strkey::ed25519::PublicKey {
+    let bytes = match muxed {
+        soroban_sdk::xdr::MuxedAccount::Ed25519(uint256) => uint256.0,
+        soroban_sdk::xdr::MuxedAccount::MuxedEd25519(muxed_account) => muxed_account.ed25519.0,
+    };
+    stellar_strkey::ed25519::PublicKey(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    const PUBLIC_KEY: &str = "GAKSH6AD2IPJQELTHIOWDAPYX74YELUOWJLI2L4RIPIPZH6YQIFNUSDC";
+
+    #[test]
+    fn ledger_flag_parses_without_name() {
+        let cmd = Cmd::try_parse_from(["address", "--ledger"]).expect("--ledger alone parses");
+        assert!(cmd.ledger);
+        assert!(cmd.name.is_none());
+        assert_eq!(cmd.hd_path, None);
+    }
+
+    #[test]
+    fn ledger_flag_with_hd_path_parses() {
+        let cmd = Cmd::try_parse_from(["address", "--ledger", "--hd-path", "5"]).unwrap();
+        assert!(cmd.ledger);
+        assert_eq!(cmd.hd_path, Some(5));
+    }
+
+    #[test]
+    fn ledger_flag_conflicts_with_name() {
+        let err = Cmd::try_parse_from(["address", PUBLIC_KEY, "--ledger"])
+            .expect_err("--ledger + name must conflict");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn missing_name_without_ledger_is_rejected() {
+        let err = Cmd::try_parse_from(["address"]).expect_err("name is required without --ledger");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn name_without_ledger_parses() {
+        let cmd = Cmd::try_parse_from(["address", PUBLIC_KEY]).unwrap();
+        assert!(!cmd.ledger);
+        assert!(cmd.name.is_some());
     }
 }


### PR DESCRIPTION
### What

Add a `--ledger` flag to `stellar keys address` that connects to an attached
Ledger hardware wallet and prints the Stellar address derived at
`m/44'/148'/N'`. `N` defaults to `0` and can be set with `--hd-path N`.

```
stellar keys address --ledger
stellar keys address --ledger --hd-path 1
```

The flag is scoped to `keys address` only. `public_key::Cmd` was split into
`Args` (still flattened by `keys fund`) and `Cmd` (used by `keys address` and
adds `--ledger`), so `keys fund` does not inherit the new flag. `--ledger` is
mutually exclusive with the positional identity name; if neither is provided,
clap rejects the command. Errors from a missing/locked device or a closed
Stellar app surface through the existing `signer::ledger` error chain.

Verified end-to-end against a real Ledger device.

Closes #2556.

### Why

Knowing the address derived from a Ledger device is a fundamental operation —
needed before funding, before sharing an address with a counterparty, and
before scripting any workflow that involves a hardware wallet. Without
`--ledger`, users have to open Ledger Live or a web wallet just to look up
their own address, which breaks the CLI-first development experience.

### Known limitations

- `--ledger` is intentionally only on `keys address`. `keys fund --ledger`
  (and other commands) will be added in separate changes.
- Nothing is persisted — there is no `keys add --ledger` yet, so each
  invocation re-derives from the device and `--hd-path` lives only on the
  current call.