### PR TITLE
Add `--ledger` to `stellar keys fund`

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1169,7 +1169,7 @@ Given an identity return its address (public key)
 
 Fund an identity on a test network
 
-**Usage:** `stellar keys fund [OPTIONS] <NAME>`
+**Usage:** `stellar keys fund [OPTIONS] [NAME]`
 
 ###### **Arguments:**
 
@@ -1177,7 +1177,8 @@ Fund an identity on a test network
 
 ###### **Options:**
 
-- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
+- `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0. With --ledger this is the Ledger account index (default 0)
+- `--ledger` — Derive the address from a connected Ledger hardware wallet at `m/44'/148'/N'`, where `N` defaults to 0 and can be set with `--hd-path`
 
 ###### **Options (Global):**
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1173,7 +1173,7 @@ Fund an identity on a test network
 
 ###### **Arguments:**
 
-- `<NAME>` — Name of identity to lookup, default test identity used if not provided
+- `<NAME>` — Name of identity to lookup. Required unless `--ledger` is provided
 
 ###### **Options:**
 

--- a/cmd/soroban-cli/src/commands/keys/fund.rs
+++ b/cmd/soroban-cli/src/commands/keys/fund.rs
@@ -17,7 +17,7 @@ pub struct Cmd {
     pub network: network::Args,
     /// Address to fund
     #[command(flatten)]
-    pub address: public_key::Args,
+    pub address: public_key::Cmd,
 }
 
 impl Cmd {
@@ -25,11 +25,15 @@ impl Cmd {
         let print = Print::new(global_args.quiet);
         let addr = self.address.public_key().await?;
         let network = self.network.get(&self.address.locator)?;
-        let formatted_name = self.address.name.to_string();
+        let label = self
+            .address
+            .name
+            .as_ref()
+            .map_or_else(|| addr.to_string(), ToString::to_string);
         network.fund_address(&addr).await?;
         print.checkln(format!(
             "Account {} funded on {:?}",
-            formatted_name, network.network_passphrase
+            label, network.network_passphrase
         ));
         Ok(())
     }
@@ -43,9 +47,29 @@ mod tests {
     const PUBLIC_KEY: &str = "GAKSH6AD2IPJQELTHIOWDAPYX74YELUOWJLI2L4RIPIPZH6YQIFNUSDC";
 
     #[test]
-    fn fund_does_not_accept_ledger_flag() {
+    fn ledger_flag_parses_without_name() {
+        let cmd = Cmd::try_parse_from(["fund", "--ledger"]).expect("--ledger alone parses");
+        assert!(cmd.address.ledger);
+        assert!(cmd.address.name.is_none());
+    }
+
+    #[test]
+    fn ledger_flag_with_hd_path_parses() {
+        let cmd = Cmd::try_parse_from(["fund", "--ledger", "--hd-path", "5"]).unwrap();
+        assert!(cmd.address.ledger);
+        assert_eq!(cmd.address.hd_path, Some(5));
+    }
+
+    #[test]
+    fn ledger_flag_conflicts_with_name() {
         let err = Cmd::try_parse_from(["fund", PUBLIC_KEY, "--ledger"])
-            .expect_err("`--ledger` belongs to `keys address` only");
-        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+            .expect_err("--ledger + name must conflict");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn missing_name_without_ledger_is_rejected() {
+        let err = Cmd::try_parse_from(["fund"]).expect_err("name is required without --ledger");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 }

--- a/cmd/soroban-cli/src/commands/keys/public_key.rs
+++ b/cmd/soroban-cli/src/commands/keys/public_key.rs
@@ -12,34 +12,6 @@ pub enum Error {
     HdPathOutOfRange(usize),
 }
 
-/// The fields shared by every command that resolves an identity to a public
-/// key. Embed this with `#[command(flatten)]` to inherit `name`, `hd_path`,
-/// and the config locator without picking up `keys address`'s `--ledger`
-/// flag.
-#[derive(Debug, clap::Parser, Clone)]
-#[group(skip)]
-pub struct Args {
-    /// Name of identity to lookup, default test identity used if not provided
-    pub name: UnresolvedMuxedAccount,
-
-    /// If identity is a seed phrase use this hd path, default is 0
-    #[arg(long)]
-    pub hd_path: Option<usize>,
-
-    #[command(flatten)]
-    pub locator: locator::Args,
-}
-
-impl Args {
-    pub async fn public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
-        Ok(public_key_from_muxed(
-            self.name
-                .resolve_muxed_account(&self.locator, self.hd_path)
-                .await?,
-        ))
-    }
-}
-
 #[derive(Debug, clap::Parser, Clone)]
 #[group(skip)]
 pub struct Cmd {


### PR DESCRIPTION
### What

Add a `--ledger` flag to `stellar keys fund` that connects to an attached Ledger hardware wallet, derives the public key at `m/44'/148'/N'`, and funds the resulting account via the configured Friendbot. `N` defaults to `0` and can be set with `--hd-path N`.

```
stellar keys fund --ledger
stellar keys fund --ledger --hd-path 1
```

`fund` now flattens `public_key::Cmd` directly (the temporary `Args` shape introduced in #2557 to keep `--ledger` off `fund` is removed — `Cmd` is the single shape used by both `keys address` and `keys fund`). The `Account <X> funded on <network>` status line uses the resolved public key for `<X>` only when no name was supplied; the existing message format is unchanged when funding a named identity.

`--ledger` is mutually exclusive with the positional identity name; if neither is provided, clap rejects the command. Errors from a missing/locked device or a closed Stellar app surface through the existing `signer::ledger` error chain. Friendbot errors propagate through `network::Error` exactly as they do today.

Verified end-to-end against a real Ledger device.

Closes #2555.

### Why

Hardware wallets are a primary key-management option in the CLI, and funding a freshly-derived address on testnet/futurenet is a routine first step in any development workflow. Without `--ledger` on `fund`, Ledger users have to derive their address out-of-band and fund it via other means — inconsistent with every other key type, which can be funded directly.

### Known limitations

- Nothing is persisted — there is no `keys add --ledger` yet, so each invocation re-derives from the device and `--hd-path` lives only on the current call.