### PR TITLE
Remove undocumented `ledger` / `ledger:N` positional shorthand

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/ledger/entry.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/ledger/entry.rs
@@ -605,7 +605,7 @@ fn claimable_balance_tx_env(sender: &str, destination: &str) -> TransactionEnvel
 
     let source: UnresolvedMuxedAccount = sender.parse().unwrap();
     let resolved_source = source
-        .resolve_muxed_account_sync(&locator::Args::default(), None)
+        .resolve_muxed_account(&locator::Args::default(), None)
         .unwrap();
 
     xdr::Transaction::new_tx(resolved_source, 1000, 1, create_op).into()
@@ -642,7 +642,7 @@ fn liquidity_pool_tx_env(
 
     let source: UnresolvedMuxedAccount = test_account_address.parse().unwrap();
     let resolved_source = source
-        .resolve_muxed_account_sync(&locator::Args::default(), None)
+        .resolve_muxed_account(&locator::Args::default(), None)
         .unwrap();
 
     let tx = xdr::Transaction::new_tx(resolved_source, 1000, 1, op).into();

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -147,7 +147,7 @@ impl Cmd {
             .verify_network_passphrase(Some(&network.network_passphrase))
             .await?;
 
-        let source_account = config.source_account().await?;
+        let source_account = config.source_account()?;
 
         // Get the account sequence number
         // TODO: use symbols for the method names (both here and in serve)

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -352,7 +352,7 @@ impl Cmd {
         };
 
         let client = network.rpc_client()?;
-        let MuxedAccount::Ed25519(bytes) = config.source_account().await? else {
+        let MuxedAccount::Ed25519(bytes) = config.source_account()? else {
             return Err(Error::OnlyEd25519AccountsAllowed);
         };
         let source_account = AccountId(PublicKey::PublicKeyTypeEd25519(bytes));

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -196,7 +196,7 @@ impl Cmd {
         tracing::trace!(?network);
         let keys = self.key.parse_keys(&config.locator, &network)?;
         let client = network.rpc_client()?;
-        let source_account = config.source_account().await?;
+        let source_account = config.source_account()?;
         let extend_to = self.ledgers_to_extend(&client).await?;
 
         // Get the account sequence number

--- a/cmd/soroban-cli/src/commands/contract/id.rs
+++ b/cmd/soroban-cli/src/commands/contract/id.rs
@@ -18,10 +18,10 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub fn run(&self) -> Result<(), Error> {
         match &self {
             Cmd::Asset(asset) => asset.run()?,
-            Cmd::Wasm(wasm) => wasm.run().await?,
+            Cmd::Wasm(wasm) => wasm.run()?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/id/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/wasm.rs
@@ -29,12 +29,12 @@ pub enum Error {
     OnlyEd25519AccountsAllowed,
 }
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub fn run(&self) -> Result<(), Error> {
         let salt: [u8; 32] = soroban_spec_tools::utils::padded_hex_from_str(&self.salt, 32)
             .map_err(|_| Error::CannotParseSalt(self.salt.clone()))?
             .try_into()
             .map_err(|_| Error::CannotParseSalt(self.salt.clone()))?;
-        let source_account = match self.config.source_account().await? {
+        let source_account = match self.config.source_account()? {
             xdr::MuxedAccount::Ed25519(uint256) => stellar_strkey::ed25519::PublicKey(uint256.0),
             xdr::MuxedAccount::MuxedEd25519(_) => return Err(Error::OnlyEd25519AccountsAllowed),
         };

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -316,7 +316,7 @@ impl Cmd {
                 .await?;
 
             client
-                .get_account(&config.source_account().await?.to_string())
+                .get_account(&config.source_account()?.to_string())
                 .await?
         } else {
             if should_send == ShouldSend::DefaultNo {

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -169,7 +169,7 @@ impl Cmd {
             Cmd::Extend(extend) => extend.run(global_args).await?,
             Cmd::Alias(alias) => alias.run(global_args)?,
             Cmd::Deploy(deploy) => deploy.run(global_args).await?,
-            Cmd::Id(id) => id.run().await?,
+            Cmd::Id(id) => id.run()?,
             Cmd::Info(info) => info.run(global_args).await?,
             Cmd::Init(init) => init.run(global_args)?,
             Cmd::Inspect(inspect) => {

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -165,7 +165,7 @@ impl Cmd {
         tracing::trace!(?network);
         let entry_keys = self.key.parse_keys(&config.locator, &network)?;
         let client = network.rpc_client()?;
-        let source_account = config.source_account().await?;
+        let source_account = config.source_account()?;
 
         // Get the account sequence number
         let account_details = client

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -237,7 +237,7 @@ impl Cmd {
         }
 
         // Get the account sequence number
-        let source_account = config.source_account().await?;
+        let source_account = config.source_account()?;
 
         let account_details = client
             .get_account(&source_account.clone().to_string())

--- a/cmd/soroban-cli/src/commands/keys/public_key.rs
+++ b/cmd/soroban-cli/src/commands/keys/public_key.rs
@@ -1,12 +1,16 @@
 use crate::{
     commands::config::{address, locator},
     config::UnresolvedMuxedAccount,
+    signer::ledger,
 };
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
     Address(#[from] address::Error),
+
+    #[error(transparent)]
+    Ledger(#[from] ledger::Error),
 
     #[error("--hd-path {0} is out of range for a Ledger account index")]
     HdPathOutOfRange(usize),
@@ -44,19 +48,14 @@ impl Cmd {
         if self.ledger {
             let raw = self.hd_path.unwrap_or(0);
             let index: u32 = raw.try_into().map_err(|_| Error::HdPathOutOfRange(raw))?;
-            return Ok(public_key_from_muxed(
-                UnresolvedMuxedAccount::Ledger(index)
-                    .resolve_muxed_account(&self.locator, None)
-                    .await?,
-            ));
+            return Ok(ledger::new(index).await?.public_key().await?);
         }
         let name = self
             .name
             .as_ref()
             .expect("clap requires `name` unless --ledger is set");
         Ok(public_key_from_muxed(
-            name.resolve_muxed_account(&self.locator, self.hd_path)
-                .await?,
+            name.resolve_muxed_account(&self.locator, self.hd_path)?,
         ))
     }
 }

--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -487,9 +487,7 @@ impl Cmd {
     // G-address or a key name (as in `stellar keys address NAME`).
     fn resolve_account_sync(&self, address: &str) -> Option<AccountId> {
         let address: UnresolvedMuxedAccount = address.parse().ok()?;
-        let muxed_account = address
-            .resolve_muxed_account_sync(&self.locator, None)
-            .ok()?;
+        let muxed_account = address.resolve_muxed_account(&self.locator, None).ok()?;
         Some(muxed_account.account_id())
     }
 

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -54,7 +54,7 @@ pub enum Error {
 
 impl Args {
     pub async fn tx(&self, body: impl Into<xdr::OperationBody>) -> Result<xdr::Transaction, Error> {
-        let source_account = self.source_account().await?;
+        let source_account = self.source_account()?;
         let seq_num = self
             .config
             .next_sequence_number(source_account.clone().account_id())
@@ -121,15 +121,15 @@ impl Args {
         Ok(TxnEnvelopeResult::Res(txn_resp))
     }
 
-    pub async fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
-        Ok(self.config.source_account().await?)
+    pub fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
+        Ok(self.config.source_account()?)
     }
 
     pub fn resolve_muxed_address(
         &self,
         address: &UnresolvedMuxedAccount,
     ) -> Result<xdr::MuxedAccount, Error> {
-        Ok(address.resolve_muxed_account_sync(&self.config.locator, self.config.hd_path())?)
+        Ok(address.resolve_muxed_account(&self.config.locator, self.config.hd_path())?)
     }
 
     pub fn resolve_account_id(
@@ -137,11 +137,11 @@ impl Args {
         address: &UnresolvedMuxedAccount,
     ) -> Result<xdr::AccountId, Error> {
         Ok(address
-            .resolve_muxed_account_sync(&self.config.locator, self.config.hd_path())?
+            .resolve_muxed_account(&self.config.locator, self.config.hd_path())?
             .account_id())
     }
 
-    pub async fn add_op(
+    pub fn add_op(
         &self,
         op_body: impl Into<xdr::OperationBody>,
         tx_env: xdr::TransactionEnvelope,
@@ -149,11 +149,8 @@ impl Args {
     ) -> Result<xdr::TransactionEnvelope, Error> {
         let mut source_account = None;
         if let Some(account) = op_source {
-            source_account = Some(
-                account
-                    .resolve_muxed_account(&self.config.locator, self.config.hd_path())
-                    .await?,
-            );
+            source_account =
+                Some(account.resolve_muxed_account(&self.config.locator, self.config.hd_path())?);
         }
         let op = xdr::Operation {
             source_account,

--- a/cmd/soroban-cli/src/commands/tx/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/mod.rs
@@ -90,7 +90,7 @@ impl Cmd {
             Cmd::Hash(cmd) => cmd.run(global_args)?,
             Cmd::New(cmd) => cmd.run(global_args).await?,
             Cmd::Edit(cmd) => cmd.run(global_args)?,
-            Cmd::Operation(cmd) => cmd.run(global_args).await?,
+            Cmd::Operation(cmd) => cmd.run(global_args)?,
             Cmd::Send(cmd) => cmd.run(global_args).await?,
             Cmd::Sign(cmd) => cmd.run(global_args).await?,
             Cmd::Simulate(cmd) => cmd.run(global_args).await?,

--- a/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
@@ -135,7 +135,7 @@ impl TryFrom<&Cmd> for OperationBody {
 
 impl Cmd {
     #[allow(clippy::too_many_lines)]
-    pub async fn run(&self, _: &global::Args) -> Result<(), Error> {
+    pub fn run(&self, _: &global::Args) -> Result<(), Error> {
         let op = OperationBody::try_from(self)?;
         let res = match self {
             Cmd::AccountMerge(cmd) => cmd.op.tx.add_op(
@@ -248,8 +248,7 @@ impl Cmd {
                 tx_envelope_from_input(&cmd.args.tx_xdr)?,
                 cmd.args.source(),
             ),
-        }
-        .await?;
+        }?;
         println!("{}", res.to_xdr_base64(crate::xdr::Limits::none())?);
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/tx/op/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/mod.rs
@@ -16,9 +16,9 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
-            Cmd::Add(cmd) => cmd.run(global_args).await?,
+            Cmd::Add(cmd) => cmd.run(global_args)?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/config/address.rs
+++ b/cmd/soroban-cli/src/config/address.rs
@@ -3,10 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{
-    signer::{self, ledger},
-    xdr,
-};
+use crate::{signer, xdr};
 
 use super::{key, locator, secret, utils};
 
@@ -15,7 +12,6 @@ use super::{key, locator, secret, utils};
 pub enum UnresolvedMuxedAccount {
     Resolved(xdr::MuxedAccount),
     AliasOrSecret(String),
-    Ledger(u32),
 }
 
 impl Default for UnresolvedMuxedAccount {
@@ -31,7 +27,6 @@ impl Display for UnresolvedMuxedAccount {
             UnresolvedMuxedAccount::AliasOrSecret(alias_or_secret) => {
                 write!(f, "{alias_or_secret}")
             }
-            UnresolvedMuxedAccount::Ledger(hd_path) => write!(f, "ledger:{hd_path}"),
         }
     }
 }
@@ -48,20 +43,12 @@ pub enum Error {
     Key(#[from] key::Error),
     #[error("Address cannot be used to sign {0}")]
     CannotSign(xdr::MuxedAccount),
-    #[error("Ledger cannot reveal private keys")]
-    LedgerPrivateKeyRevealNotSupported,
-    #[error("Invalid key name: {0}\n `ledger` is not allowed")]
-    LedgerIsInvalidKeyName(String),
     #[error("Invalid key name: {0}\n only alphanumeric characters, underscores (_), and hyphens (-) are allowed.")]
     InvalidKeyNameCharacters(String),
     #[error("Invalid key name: {0}\n keys cannot exceed 250 characters")]
     InvalidKeyNameLength(String),
     #[error("Invalid key name: {0}\n keys cannot be the word \"ledger\"")]
     InvalidKeyName(String),
-    #[error("Ledger not supported in this context")]
-    LedgerNotSupported,
-    #[error(transparent)]
-    Ledger(#[from] signer::ledger::Error),
     #[error(transparent)]
     Name(#[from] utils::Error),
 }
@@ -70,11 +57,6 @@ impl FromStr for UnresolvedMuxedAccount {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if value.starts_with("ledger") {
-            if let Some(ledger) = parse_ledger(value) {
-                return Ok(UnresolvedMuxedAccount::Ledger(ledger));
-            }
-        }
         Ok(xdr::MuxedAccount::from_str(value).map_or_else(
             |_| UnresolvedMuxedAccount::AliasOrSecret(value.to_string()),
             UnresolvedMuxedAccount::Resolved,
@@ -82,34 +64,8 @@ impl FromStr for UnresolvedMuxedAccount {
     }
 }
 
-fn parse_ledger(value: &str) -> Option<u32> {
-    let vals: Vec<_> = value.split(':').collect();
-    if vals.len() > 2 {
-        return None;
-    }
-    if vals.len() == 1 {
-        return Some(0);
-    }
-    vals[1].parse().ok()
-}
-
 impl UnresolvedMuxedAccount {
-    pub async fn resolve_muxed_account(
-        &self,
-        locator: &locator::Args,
-        hd_path: Option<usize>,
-    ) -> Result<xdr::MuxedAccount, Error> {
-        match self {
-            UnresolvedMuxedAccount::Ledger(hd_path) => Ok(xdr::MuxedAccount::Ed25519(
-                ledger::new(*hd_path).await?.public_key().await?.0.into(),
-            )),
-            UnresolvedMuxedAccount::Resolved(_) | UnresolvedMuxedAccount::AliasOrSecret(_) => {
-                self.resolve_muxed_account_sync(locator, hd_path)
-            }
-        }
-    }
-
-    pub fn resolve_muxed_account_sync(
+    pub fn resolve_muxed_account(
         &self,
         locator: &locator::Args,
         hd_path: Option<usize>,
@@ -119,7 +75,6 @@ impl UnresolvedMuxedAccount {
             UnresolvedMuxedAccount::AliasOrSecret(alias_or_secret) => Ok(locator
                 .read_key_with_secure_store_cache(alias_or_secret, hd_path)?
                 .muxed_account(hd_path)?),
-            UnresolvedMuxedAccount::Ledger(_) => Err(Error::LedgerNotSupported),
         }
     }
 
@@ -131,7 +86,6 @@ impl UnresolvedMuxedAccount {
             UnresolvedMuxedAccount::AliasOrSecret(alias_or_secret) => {
                 Ok(locator.read_key(alias_or_secret)?.try_into()?)
             }
-            UnresolvedMuxedAccount::Ledger(_) => Err(Error::LedgerPrivateKeyRevealNotSupported),
         }
     }
 }
@@ -251,6 +205,22 @@ impl AsRef<std::path::Path> for ContractName {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ledger_shorthand_is_not_recognized() {
+        match "ledger".parse::<UnresolvedMuxedAccount>().unwrap() {
+            UnresolvedMuxedAccount::AliasOrSecret(s) => assert_eq!(s, "ledger"),
+            UnresolvedMuxedAccount::Resolved(m) => panic!("unexpected resolved muxed: {m}"),
+        }
+    }
+
+    #[test]
+    fn ledger_indexed_shorthand_is_not_recognized() {
+        match "ledger:5".parse::<UnresolvedMuxedAccount>().unwrap() {
+            UnresolvedMuxedAccount::AliasOrSecret(s) => assert_eq!(s, "ledger:5"),
+            UnresolvedMuxedAccount::Resolved(m) => panic!("unexpected resolved muxed: {m}"),
+        }
+    }
 
     #[test]
     fn network_name_valid() {

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -85,11 +85,10 @@ pub struct Args {
 
 impl Args {
     // TODO: Replace PublicKey with MuxedAccount once https://github.com/stellar/rs-stellar-xdr/pull/396 is merged.
-    pub async fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
+    pub fn source_account(&self) -> Result<xdr::MuxedAccount, Error> {
         Ok(self
             .source_account
-            .resolve_muxed_account(&self.locator, self.hd_path())
-            .await?)
+            .resolve_muxed_account(&self.locator, self.hd_path())?)
     }
 
     pub fn key_pair(&self) -> Result<ed25519_dalek::SigningKey, Error> {

--- a/cmd/soroban-cli/src/tx/builder/asset.rs
+++ b/cmd/soroban-cli/src/tx/builder/asset.rs
@@ -40,9 +40,7 @@ impl Asset {
     pub fn resolve(&self, locator: &locator::Args) -> Result<xdr::Asset, Error> {
         Ok(match self {
             Asset::Asset(code, issuer) => {
-                let issuer = issuer
-                    .resolve_muxed_account_sync(locator, None)?
-                    .account_id();
+                let issuer = issuer.resolve_muxed_account(locator, None)?.account_id();
                 match code.clone() {
                     AssetCode::CreditAlphanum4(asset_code) => {
                         xdr::Asset::CreditAlphanum4(AlphaNum4 { asset_code, issuer })


### PR DESCRIPTION
### What

Drop the undocumented `ledger` / `ledger:N` positional shorthand for `UnresolvedMuxedAccount`. Any command that takes an account argument (`keys fund`, `keys address`, `tx sign`, `contract invoke --source-account`, …) used to silently route to a connected Ledger device when given `ledger` or `ledger:N`. After this change, the only way to derive an address from a Ledger is the explicit `--ledger` flag.

`UnresolvedMuxedAccount::Ledger(u32)` is removed entirely. `keys address`/`keys fund` now derive the public key directly via `signer::ledger::new(index).public_key()` in their `--ledger` branch. `resolve_muxed_account_sync` collapses into `resolve_muxed_account` (the only async branch was Ledger), and several call sites lose now-unnecessary `async`/`.await`. The four dependent error variants (`LedgerNotSupported`, `LedgerPrivateKeyRevealNotSupported`, `LedgerIsInvalidKeyName`, and the `ledger::Error` `From` impl) become unreachable and are removed.

`--sign-with-ledger` and `keys add ledger` (the `Secret::Ledger` flow) are out of scope and untouched.

Closes #2559.

### Why

The shorthand was introduced in #1627 and has been live since 2025-02-14, but it was never mentioned in `--help`, `FULL_HELP_DOCS.md`, the README, or any example. With #2557 introducing an explicit `--ledger` flag (and #2558 extending it to `keys fund`), the positional shorthand becomes a confusing and undocumented second way to reach the device — and one that can't be scoped per-command.

### Known limitations

N/A