### PR TITLE
correct an old link to the deprecated soroban docs

### DIFF
--- a/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
+++ b/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
@@ -17,7 +17,7 @@ panic = "abort"
 codegen-units = 1
 lto = true
 
-# For more information about this profile see https://soroban.stellar.org/docs/basic-tutorials/logging#cargotoml-profile
+# For more information about this profile see https://developers.stellar.org/docs/build/smart-contracts/example-contracts/logging#cargotoml-profile
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true


### PR DESCRIPTION
### What

An old link to the now defunct `soroban.stellar.org` documentation site remains in the workspace template's `Cargo.toml` file. This is seen when someone uses the `stellar contract init` command.

### Why

Current redirects still take users to the desired location on the correct page. However, in the interest of keeping documentation references as fresh as possible, this link should be corrected here.

### Known limitations

N/A
