### PR TITLE
Make the Docker rust base image configurable.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,11 +38,33 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libudev-dev libdbus-1-dev
+      - name: Resolve rust image
+        run: |
+          rust_image="${{ github.event_name == 'workflow_dispatch' && inputs.rust_image || 'latest' }}"
+          echo "RUST_IMAGE=${rust_image}" >> "$GITHUB_ENV"
 
+      # Build inside the rust_image container so the binary's glibc and linked
+      # libraries match the runtime base image. Each matrix runner is native
+      # arch, so docker pulls the matching variant from the multi-arch manifest
+      # — no QEMU emulation.
       - name: Build binary
-        run: cargo build --package stellar-cli --release
+        run: |
+          # Compute the revision on the host so we don't need git inside the
+          # container. soroban-cli's source reads GIT_REVISION via env!() at
+          # compile time; setting it here lets cargo pass it through to rustc.
+          git_revision="$(git rev-parse HEAD)"
+          docker run --rm \
+            -v "$(pwd):/src" \
+            -w /src \
+            -e "GIT_REVISION=${git_revision}" \
+            "rust:${RUST_IMAGE}" \
+            sh -c "
+              apt-get update && \
+              apt-get install -y --no-install-recommends \
+                build-essential cmake pkg-config \
+                libssl-dev libudev-dev libdbus-1-dev && \
+              cargo build --package stellar-cli --release
+            "
 
       - name: Upload binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,12 +85,11 @@ jobs:
       # an older release tag), fall back to a known-good branch.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # NOTE: switch fallback ref to `main` once this branch lands.
-      - name: Fall back to docker-custom-image Dockerfile if missing
+      - name: Fall back to main Dockerfile if missing
         run: |
           if [[ ! -f Dockerfile ]]; then
-            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to docker-custom-image"
-            git fetch --depth=1 origin docker-custom-image
+            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to main"
+            git fetch --depth=1 origin main
             git checkout FETCH_HEAD -- Dockerfile entrypoint.sh docker/
           fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,10 +57,20 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Check out the workflow's own ref so we use the Dockerfile + entrypoint
+      # from the branch/PR running this workflow, not from the (potentially
+      # older) ref being built. If that ref doesn't carry a Dockerfile (e.g.
+      # an older release tag), fall back to a known-good branch.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
-          fetch-depth: 0
+
+      # NOTE: switch fallback ref to `main` once this branch lands.
+      - name: Fall back to docker-custom-image Dockerfile if missing
+        run: |
+          if [[ ! -f Dockerfile ]]; then
+            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to docker-custom-image"
+            git fetch --depth=1 origin docker-custom-image
+            git checkout FETCH_HEAD -- Dockerfile entrypoint.sh docker/
+          fi
 
       - name: Download binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -84,6 +94,23 @@ jobs:
         run: |
           rust_image="${{ github.event_name == 'workflow_dispatch' && inputs.rust_image || 'latest' }}"
           echo "RUST_IMAGE=${rust_image}" >> "$GITHUB_ENV"
+
+      # The docker job's checkout points at the workflow ref (for the Dockerfile),
+      # not at the binary's ref, so HEAD here doesn't represent what was built.
+      # Resolve the SHA of the binary ref via ls-remote for the SHA-tag path.
+      - name: Resolve build commit SHA
+        run: |
+          ref="${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}"
+          if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+            sha="$ref"
+          else
+            sha="$(git ls-remote https://github.com/${{ github.repository }}.git "$ref" | awk 'END{print $1}')"
+          fi
+          if [[ -z "$sha" ]]; then
+            echo "::error::Could not resolve SHA for ref: $ref"
+            exit 1
+          fi
+          echo "BUILD_SHA=${sha}" >> "$GITHUB_ENV"
 
       # Compute Docker tags from the ref and rust image.
       # - Version tag (e.g. v1.2.3) + default rust: push versioned + latest tags.
@@ -110,8 +137,7 @@ jobs:
             echo "::error::Release tag '${ref}' is not a valid version tag (expected vX.Y.Z)."
             exit 1
           else
-            commit="$(git rev-parse HEAD)"
-            echo "DOCKER_TAGS=stellar/stellar-cli:${commit}${suffix}" >> $GITHUB_ENV
+            echo "DOCKER_TAGS=stellar/stellar-cli:${BUILD_SHA}${suffix}" >> $GITHUB_ENV
           fi
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,11 +39,12 @@ jobs:
       # The binary's source is cloned by the Dockerfile itself based on CLI_REF.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Fall back to main packaging files if missing
+      # NOTE: switch fallback ref to `main` once this branch lands.
+      - name: Fall back to docker-custom-image packaging files if missing
         run: |
           if [[ ! -f Dockerfile ]]; then
-            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to main"
-            git fetch --depth=1 origin main
+            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to docker-custom-image"
+            git fetch --depth=1 origin docker-custom-image
             git checkout FETCH_HEAD -- Dockerfile .dockerignore entrypoint.sh docker/
           fi
 
@@ -96,10 +97,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # NOTE: switch fallback ref to `main` once this branch lands.
       - name: Ensure docker/README.md is available
         run: |
           if [[ ! -f docker/README.md ]]; then
-            git fetch --depth=1 origin main
+            git fetch --depth=1 origin docker-custom-image
             git checkout FETCH_HEAD -- docker/
           fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,11 @@ on:
         type: string
         required: true
         default: main
+      rust_image:
+        description: "The rust base image tag (e.g. 1.90.0-slim-bookworm). Defaults to latest."
+        type: string
+        required: false
+        default: latest
   release:
     types: [published]
 
@@ -75,22 +80,38 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Compute Docker tags from the ref.
-      # - Version tag (e.g. v1.2.3): push versioned + latest tags.
-      # - Any other ref: push a tag for the resolved commit SHA.
+      - name: Resolve rust image
+        run: |
+          rust_image="${{ github.event_name == 'workflow_dispatch' && inputs.rust_image || 'latest' }}"
+          echo "RUST_IMAGE=${rust_image}" >> "$GITHUB_ENV"
+
+      # Compute Docker tags from the ref and rust image.
+      # - Version tag (e.g. v1.2.3) + default rust: push versioned + latest tags.
+      # - Version tag + custom rust: push versioned + -rust-<image> suffix only (do not update :latest).
+      # - Any other ref: push a tag for the resolved commit SHA, with the rust suffix when custom.
       - name: Compute tags
         run: |
           ref="${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}"
 
+          suffix=""
+          if [[ "${RUST_IMAGE}" != "latest" ]]; then
+            sanitized="${RUST_IMAGE//[^A-Za-z0-9._-]/-}"
+            suffix="-rust-${sanitized}"
+          fi
+
           if [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             version="${ref#v}"
-            echo "DOCKER_TAGS=stellar/stellar-cli:${version},stellar/stellar-cli:latest" >> $GITHUB_ENV
+            if [[ -n "$suffix" ]]; then
+              echo "DOCKER_TAGS=stellar/stellar-cli:${version}${suffix}" >> $GITHUB_ENV
+            else
+              echo "DOCKER_TAGS=stellar/stellar-cli:${version},stellar/stellar-cli:latest" >> $GITHUB_ENV
+            fi
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             echo "::error::Release tag '${ref}' is not a valid version tag (expected vX.Y.Z)."
             exit 1
           else
             commit="$(git rev-parse HEAD)"
-            echo "DOCKER_TAGS=stellar/stellar-cli:${commit}" >> $GITHUB_ENV
+            echo "DOCKER_TAGS=stellar/stellar-cli:${commit}${suffix}" >> $GITHUB_ENV
           fi
 
       - name: Build and push
@@ -100,6 +121,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          build-args: |
+            RUST_IMAGE=${{ env.RUST_IMAGE }}
 
       - name: Update Docker Hub description
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ defaults:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-latest
@@ -34,73 +35,80 @@ jobs:
     permissions:
       contents: read
     steps:
+      # The workflow's own ref provides Dockerfile + entrypoint.sh + docker/.
+      # The binary's source is cloned by the Dockerfile itself based on CLI_REF.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
-      - name: Resolve rust image
+      - name: Fall back to main packaging files if missing
+        run: |
+          if [[ ! -f Dockerfile ]]; then
+            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to main"
+            git fetch --depth=1 origin main
+            git checkout FETCH_HEAD -- Dockerfile .dockerignore entrypoint.sh docker/
+          fi
+
+      - name: Resolve build args
         run: |
           rust_image="${{ github.event_name == 'workflow_dispatch' && inputs.rust_image || 'latest' }}"
+          cli_ref="${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}"
           echo "RUST_IMAGE=${rust_image}" >> "$GITHUB_ENV"
+          echo "CLI_REF=${cli_ref}" >> "$GITHUB_ENV"
 
-      # Build inside the rust_image container so the binary's glibc and linked
-      # libraries match the runtime base image. Each matrix runner is native
-      # arch, so docker pulls the matching variant from the multi-arch manifest
-      # — no QEMU emulation.
-      - name: Build binary
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: build
+        name: Build and push by digest
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=stellar/stellar-cli,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            RUST_IMAGE=${{ env.RUST_IMAGE }}
+            CLI_REF=${{ env.CLI_REF }}
+
+      - name: Export digest
         run: |
-          # Compute the revision on the host so we don't need git inside the
-          # container. soroban-cli's source reads GIT_REVISION via env!() at
-          # compile time; setting it here lets cargo pass it through to rustc.
-          git_revision="$(git rev-parse HEAD)"
-          docker run --rm \
-            -v "$(pwd):/src" \
-            -w /src \
-            -e "GIT_REVISION=${git_revision}" \
-            "rust:${RUST_IMAGE}" \
-            sh -c "
-              apt-get update && \
-              apt-get install -y --no-install-recommends \
-                build-essential cmake pkg-config \
-                libssl-dev libudev-dev libdbus-1-dev && \
-              cargo build --package stellar-cli --release
-            "
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
 
-      - name: Upload binary
+      - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: stellar-${{ matrix.arch }}
-          path: target/release/stellar
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
           retention-days: 1
 
-  docker:
+  manifest:
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      # Check out the workflow's own ref so we use the Dockerfile + entrypoint
-      # from the branch/PR running this workflow, not from the (potentially
-      # older) ref being built. If that ref doesn't carry a Dockerfile (e.g.
-      # an older release tag), fall back to a known-good branch.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Fall back to main Dockerfile if missing
+      - name: Ensure docker/README.md is available
         run: |
-          if [[ ! -f Dockerfile ]]; then
-            echo "::notice::Dockerfile not present at ${GITHUB_REF}; falling back to main"
+          if [[ ! -f docker/README.md ]]; then
             git fetch --depth=1 origin main
-            git checkout FETCH_HEAD -- Dockerfile entrypoint.sh docker/
+            git checkout FETCH_HEAD -- docker/
           fi
 
-      - name: Download binaries
+      - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: stellar-*
-          merge-multiple: false
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -116,9 +124,6 @@ jobs:
           rust_image="${{ github.event_name == 'workflow_dispatch' && inputs.rust_image || 'latest' }}"
           echo "RUST_IMAGE=${rust_image}" >> "$GITHUB_ENV"
 
-      # The docker job's checkout points at the workflow ref (for the Dockerfile),
-      # not at the binary's ref, so HEAD here doesn't represent what was built.
-      # Resolve the SHA of the binary ref via ls-remote for the SHA-tag path.
       - name: Resolve build commit SHA
         run: |
           ref="${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}"
@@ -161,15 +166,21 @@ jobs:
             echo "DOCKER_TAGS=stellar/stellar-cli:${BUILD_SHA}${suffix}" >> $GITHUB_ENV
           fi
 
-      - name: Build and push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          build-args: |
-            RUST_IMAGE=${{ env.RUST_IMAGE }}
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          IFS=',' read -ra TAGS <<< "${DOCKER_TAGS}"
+          tag_args=()
+          for tag in "${TAGS[@]}"; do
+            tag_args+=(-t "$tag")
+          done
+
+          digest_refs=()
+          for f in *; do
+            digest_refs+=("stellar/stellar-cli@sha256:${f}")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${digest_refs[@]}"
 
       - name: Update Docker Hub description
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:latest
+ARG RUST_IMAGE=latest
+FROM rust:${RUST_IMAGE}
 
 RUN rustup target add wasm32v1-none
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,22 @@
 ARG RUST_IMAGE=latest
+
+FROM rust:${RUST_IMAGE} AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential cmake pkg-config git \
+        libssl-dev libudev-dev libdbus-1-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG CLI_REPO=https://github.com/stellar/stellar-cli
+ARG CLI_REF=main
+
+WORKDIR /src
+RUN git clone "${CLI_REPO}" . && \
+    git checkout "${CLI_REF}"
+
+RUN cargo build --package stellar-cli --release
+
 FROM rust:${RUST_IMAGE}
 
 RUN rustup target add wasm32v1-none
@@ -7,8 +25,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libudev1 libssl3 libdbus-1-3 && \
     rm -rf /var/lib/apt/lists/*
 
-ARG TARGETARCH
-COPY stellar-${TARGETARCH}/stellar /usr/local/bin/stellar
+COPY --from=builder /src/target/release/stellar /usr/local/bin/stellar
 RUN chmod +x /usr/local/bin/stellar
 
 ENV STELLAR_CONFIG_HOME=/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:${RUST_IMAGE}
 RUN rustup target add wasm32v1-none
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libudev1 libssl3 && \
+    apt-get install -y --no-install-recommends libudev1 libssl3 libdbus-1-3 && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH


### PR DESCRIPTION
### What

Make the Docker image self-contained and customizable. Closes #2542.

The Dockerfile is now multi-stage: the builder stage clones the requested CLI source from GitHub and runs `cargo build` against the target rust base image. Both stages use the same `rust:${RUST_IMAGE}` image, so glibc and shared libraries cannot drift between build and runtime.

Two knobs are exposed to the workflow:

- `rust_image` (default `latest`) — pins the rust base image used for both stages. When non-default, images are tagged with a `-rust-<sanitized>` suffix and `:latest` is not updated.
- `ref` flows into the Dockerfile as `CLI_REF` and selects which version of stellar-cli to clone and build.

Anyone can now reproduce a target configuration with a single command, no workflow knowledge required:

```sh
docker build \
  --build-arg RUST_IMAGE=1.90.0-slim-bookworm \
  --build-arg CLI_REF=v25.1.0 \
  -t stellar-cli:25.1.0-rust-1.90.0-slim-bookworm .
```

Multi-arch builds run on native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) and push per-arch by digest; a final `manifest` job combines them into the tagged manifest list — no QEMU emulation in CI.

### Why

https://stellarfoundation.slack.com/archives/C08AP4BN24E/p1778093609993929?thread_ts=1773364869.231219&cid=C08AP4BN24E

### Known limitations

N/A
