### PR TITLE
Add Claude Code PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,40 @@
+name: Claude Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+
+            Provide detailed feedback using inline comments for specific issues.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,8 @@ concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   review:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
@@ -36,5 +38,9 @@ jobs:
 
             Provide detailed feedback using inline comments for specific issues.
 
+          # --max-turns caps how many tool-use cycles Claude can run, which
+          # bounds token spend per invocation. The allowed `gh pr` commands are
+          # scoped to this PR's number so a misfire can't reach into another PR.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment ${{ github.event.pull_request.number }}:*),Bash(gh pr diff ${{ github.event.pull_request.number }}:*),Bash(gh pr view ${{ github.event.pull_request.number }}:*)"


### PR DESCRIPTION
### What
Add a GitHub Actions workflow that runs `anthropics/claude-code-action` on pull request open, sync, reopen, and ready-for-review events. The job skips drafts and forked PRs, uses concurrency to cancel superseded runs, and is scoped to inline-comment and read-only `gh` commands for posting review feedback on code quality, bugs, security, and performance.

### Why
Automate a first-pass review on every PR to catch issues earlier and reduce reviewer load. Excluding forks avoids leaking the API key, and the draft filter prevents noise on in-progress work. I've found the Claude Code agent to provide better results than Copilot.