### PR TITLE
chore: startup quickstart before ledger tests

### DIFF
--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -70,6 +70,8 @@ jobs:
         run: sudo apt update && sudo apt install -y libudev-dev libdbus-1-dev
         if: runner.os == 'Linux'
 
+      - run: RUST_BACKTRACE=1 make build-test-wasms
+
       - run: RUST_BACKTRACE=1 cargo test --manifest-path cmd/crates/stellar-ledger/Cargo.toml --features "emulator-tests" -- --nocapture $TEST_THREADS
 
       - run: RUST_BACKTRACE=1 cargo build --features emulator-tests,additional-libs

--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -34,6 +34,9 @@ jobs:
       CI_TESTS: true
       TEST_THREADS: ${{ contains(matrix.sys, 'macos') && '--test-threads=1' || '' }} # macOS has limited resources, so we run tests (that rely on `testcontainers`) with 1 thread
     steps:
+      - uses: stellar/quickstart@main
+        with:
+          tag: future
       - uses: actions/checkout@v6
 
       - uses: stellar/actions/rust-cache@main

--- a/cmd/crates/soroban-test/tests/it/emulator.rs
+++ b/cmd/crates/soroban-test/tests/it/emulator.rs
@@ -124,6 +124,13 @@ async fn invoke_auth_with_ledger_identity(ledger_device_model: &str, hd_path: u3
         .assert()
         .success();
 
+    sandbox
+        .new_assert_cmd("keys")
+        .arg("fund")
+        .arg("testone")
+        .assert()
+        .success();
+
     let addr = sandbox
         .new_assert_cmd("keys")
         .arg("address")


### PR DESCRIPTION
### What

Run quickstart before emulator tests in CI

### Why

New emulator tests submit transactions

### Known limitations

Quickstart can be slow to start in CI. Two alternatives:
1. Once `tx sign` supports auth entries, use that directly instead of submitting transactions
2. Run emulator tests in `rpc-test` job
