### PR TITLE
Show alias name as plain string in overwrite warning

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -243,7 +243,7 @@ impl Cmd {
                     {
                         let print = Print::new(global_args.quiet);
                         print.warnln(format!(
-                            "Overwriting existing alias {alias:?} that currently links to contract ID: {existing_contract}"
+                            "Overwriting existing alias '{alias}' that currently links to contract ID: {existing_contract}"
                         ));
                     }
 


### PR DESCRIPTION
### What

When deploying a contract with `--alias` over an existing alias, the warning message printed the alias using its `Debug` representation, producing output like `AliasName("auth")`. This change switches it to the `Display` representation with single quotes — `'auth'` — matching how aliases are formatted elsewhere (e.g. `alias add`, `alias remove`).

### Why

The `AliasName(...)` debug form leaked the wrapper type name into user-facing output. The other alias commands already format aliases as `'<name>'`, so this aligns the deploy warning with the rest of the CLI.

### Known limitations

N/A