### PR TITLE
Upgrade to stable dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1989,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -2763,7 +2763,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4297,7 +4297,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4334,9 +4334,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4697,7 +4697,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4710,7 +4710,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4768,7 +4768,7 @@ dependencies = [
  "security-framework 3.4.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5368,9 +5368,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df78c69d87834af6a53e47323a8fa02d68d92ab233476c860db643f8d1801cfe"
+checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5442,7 +5442,7 @@ dependencies = [
  "stellar-asset-spec",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.15",
+ "stellar-strkey 0.0.16",
  "stellar-xdr",
  "strsim",
  "strum 0.17.1",
@@ -5471,9 +5471,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08582c2c21bd3f7b737bcb76db9d4ca473f8349d65f8952a50eeed8823f44aef"
+checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
 dependencies = [
  "arbitrary",
  "crate-git-revision 0.0.6",
@@ -5490,9 +5490,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad436ff91576ce4c231b474aecd521ccf890df62042fc0234ffc2006b72fa1b"
+checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -5500,9 +5500,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662cd060f6a3be269e23d0611bd2ea9eb6a0e7db77e11427e09de0efe547f8b"
+checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5537,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.2"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5489ee232e1fa56c817ac57e2cba8b788685c48902928fecbae05cba97f065"
+checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5556,9 +5556,9 @@ version = "26.0.0"
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8330f1ba47d85183b96f6a5f1f774d76100cd40baa79cada77147e11fb4c7b5"
+checksum = "231ae1585d14b5059adde392ce80f6b151e0264ed62b121bca9fe025e8ace460"
 dependencies = [
  "serde",
  "serde_json",
@@ -5570,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc156a0183eb584e57d45f63f3bd7023165980131d6eecc939fe5cda2490c63"
+checksum = "5de6ad39b7070e8703d01c3abad13e75ea5e65b1a5ce5e86b98d724773282044"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5594,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422af96b2e135390beb043480eb376b27943bd79e6857e5c950e307da057d0ad"
+checksum = "72cd5e180920e224d209562cccffd27c35884d14c4dc296b295dfcebef46b6f1"
 dependencies = [
  "darling",
  "heck 0.5.0",
@@ -5614,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5077ba171ede4dd69428095a2760b01196291b9bd467a4f4ba27bdfec206ade5"
+checksum = "680c70a2ab6d7cde343e9a51dd141f2f4304a7282452df8dc540b9bf62565886"
 dependencies = [
  "base64 0.22.1",
  "sha2 0.10.9",
@@ -5627,9 +5627,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddc78f9da68c1d20fd25194e43113fdd0bf40ad51d891c20c90268379af4390"
+checksum = "6e368f91c6633c25cd2d143fd82f84206b8e58718fc630d344f2fa33e6d31b1b"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5654,7 +5654,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-spec",
- "stellar-strkey 0.0.15",
+ "stellar-strkey 0.0.16",
  "stellar-xdr",
  "thiserror 1.0.69",
  "tokio",
@@ -5709,7 +5709,7 @@ dependencies = [
  "soroban-spec-tools",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.15",
+ "stellar-strkey 0.0.16",
  "test-case",
  "testcontainers",
  "thiserror 1.0.69",
@@ -5726,18 +5726,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1898e882f2af93b2bda2c11543b9f189b8778110a66387df7e135f64f7f694e3"
+checksum = "4113612698f58df1e900359f05636d26e1434dca6ff3bc189a7e9471c8de4da4"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfbce7705b66fc8adddf3170154a021f069584d9a541d9059ca748698c1cd5"
+checksum = "2af3b760ff3c2bd33f4259b5f7e785409134a58c9b46cbefcaffb1ebc5a097bd"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5786,9 +5786,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "26.0.0-rc.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca300556416dcb206b69a973612b8ae6adb6563942265d16c1f0b6ef69294343"
+checksum = "ed169ac8777d89cb3f22cef3cd9c9002bae16226e134078d5dd3b5a93c840bc4"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5830,7 +5830,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
- "stellar-strkey 0.0.15",
+ "stellar-strkey 0.0.16",
  "stellar-xdr",
  "test-case",
  "testcontainers",
@@ -5841,9 +5841,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-rpc-client"
-version = "26.0.0-rc.2"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552320c1293e7adf4a127fa0ec6b42c6acc0ca6405fc208012f0f2fc47a3ecf1"
+checksum = "3a4e271a65180323e7b9f5ce5d8a251a25eb3d34b388496902ac5f5ad9bf75b1"
 dependencies = [
  "clap",
  "hex",
@@ -5856,7 +5856,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "stellar-strkey 0.0.15",
+ "stellar-strkey 0.0.16",
  "stellar-xdr",
  "termcolor",
  "termcolor_output",
@@ -5876,13 +5876,14 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.15"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e1a364048067bfcd24e6f1a93bba43eeb79c16b854596c841c3e8bab0bfa0c"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
 dependencies = [
  "clap",
  "crate-git-revision 0.0.6",
  "data-encoding",
+ "heapless",
  "serde",
  "serde_json",
  "serde_with",
@@ -5890,21 +5891,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-strkey"
-version = "0.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
-dependencies = [
- "crate-git-revision 0.0.6",
- "data-encoding",
- "heapless",
-]
-
-[[package]]
 name = "stellar-xdr"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea3195594b044ea3a5b05906f81d945480825f00db4e3ae7d77526bf546ff3a"
+checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -6112,7 +6102,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,38 +44,38 @@ path = "cmd/crates/stellar-ledger"
 
 # Dependencies from the rs-stellar-xdr repo:
 [workspace.dependencies.stellar-xdr]
-version = "26.0.0"
+version = "26.0.1"
 
 # Dependencies from the rs-soroban-sdk repo:
 [workspace.dependencies.soroban-spec]
-version = "26.0.0-rc.1"
+version = "26.0.1"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "26.0.0-rc.1"
+version = "26.0.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "26.0.0-rc.1"
+version = "26.0.1"
 
 [workspace.dependencies.soroban-env-host]
-version = "26.0.0-rc.1"
+version = "26.1.3"
 
 [workspace.dependencies.soroban-token-sdk]
-version = "26.0.0-rc.1"
+version = "26.0.1"
 
 [workspace.dependencies.stellar-asset-spec]
-version = "26.0.0-rc.1"
+version = "26.0.1"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "26.0.0-rc.1"
+version = "26.0.1"
 
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-version = "26.0.0-rc.2"
+version = "26.0.0"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]
-stellar-strkey = "0.0.15"
+stellar-strkey = "0.0.16"
 sep5 = "0.1.0"
 base64 = "0.21.2"
 thiserror = "1.0.46"

--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -1105,18 +1105,18 @@ pub fn to_json(v: &ScVal) -> Result<Value, Error> {
 fn sc_address_to_json(v: &ScAddress) -> Value {
     match v {
         ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(k)))) => {
-            Value::String(stellar_strkey::ed25519::PublicKey(*k).to_string())
+            Value::String(format!("{}", stellar_strkey::ed25519::PublicKey(*k)))
         }
         ScAddress::Contract(ContractId(h)) => {
-            Value::String(stellar_strkey::Contract(h.clone().into()).to_string())
+            Value::String(format!("{}", stellar_strkey::Contract(h.clone().into())))
         }
-        ScAddress::MuxedAccount(MuxedEd25519Account { ed25519, id }) => Value::String(
+        ScAddress::MuxedAccount(MuxedEd25519Account { ed25519, id }) => Value::String(format!(
+            "{}",
             stellar_strkey::ed25519::MuxedAccount {
                 ed25519: ed25519.0,
                 id: *id,
             }
-            .to_string(),
-        ),
+        )),
         ScAddress::ClaimableBalance(_) => todo!("ClaimableBalance is not supported"),
         ScAddress::LiquidityPool(_) => todo!("LiquidityPool is not supported"),
     }

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -292,10 +292,12 @@ impl TestEnv {
 
     /// Returns the private key corresponding to the test keys's `hd_path`
     pub fn test_show(&self, hd_path: usize) -> String {
-        self.cmd::<keys::secret::Cmd>(&format!("--hd-path={hd_path}"))
-            .private_key()
-            .unwrap()
-            .to_string()
+        format!(
+            "{}",
+            self.cmd::<keys::secret::Cmd>(&format!("--hd-path={hd_path}"))
+                .private_key()
+                .unwrap()
+        )
     }
 
     /// Copy the contents of the current `TestEnv` to another `TestEnv`

--- a/cmd/crates/soroban-test/tests/it/integration/tx/set_options.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/set_options.rs
@@ -108,7 +108,10 @@ async fn set_options() {
     assert_eq!(100, after.signers[0].weight);
     assert_eq!(alice, after.signers[0].key.to_string());
     let xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(key)) = after.inflation_dest.unwrap().0;
-    assert_eq!(alice, stellar_strkey::ed25519::PublicKey(key).to_string());
+    assert_eq!(
+        alice,
+        format!("{}", stellar_strkey::ed25519::PublicKey(key))
+    );
     assert_eq!("test.com", after.home_domain.to_string());
     sandbox
         .new_assert_cmd("tx")

--- a/cmd/crates/soroban-test/tests/it/integration/util.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/util.rs
@@ -103,7 +103,7 @@ pub async fn deploy_contract(
             commands::txn_result::TxnEnvelopeResult::Res(_) => todo!(),
         },
     }
-    res.into_result().unwrap().to_string()
+    format!("{}", res.into_result().unwrap())
 }
 
 pub async fn extend_contract(sandbox: &TestEnv, id: &str) {

--- a/cmd/soroban-cli/src/assembled.rs
+++ b/cmd/soroban-cli/src/assembled.rs
@@ -425,7 +425,7 @@ mod tests {
         };
         assert_eq!(
             SOURCE.to_string(),
-            stellar_strkey::ed25519::PublicKey(address.0).to_string()
+            format!("{}", stellar_strkey::ed25519::PublicKey(address.0))
         );
     }
 

--- a/cmd/soroban-cli/src/commands/contract/info/interface.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/interface.rs
@@ -41,6 +41,8 @@ pub enum Error {
     NoInterfacePresent(),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Generate(#[from] soroban_spec_rust::GenerateError),
 }
 
 impl Cmd {
@@ -73,7 +75,7 @@ impl Cmd {
             // emitting spec strings as `Literal::string` or rustdocs, this
             // path becomes a terminal-escape-injection vector and must be
             // sanitized before printing.
-            InfoOutput::Rust => soroban_spec_rust::generate_without_file(&spec)
+            InfoOutput::Rust => soroban_spec_rust::generate_without_file(&spec)?
                 .to_formatted_string()
                 .expect("Unexpected spec format error"),
         };

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -447,9 +447,10 @@ impl Cmd {
             .contract_ids
             .iter()
             .map(|id| {
-                Ok(id
-                    .resolve_contract_id(&self.locator, &network.network_passphrase)?
-                    .to_string())
+                Ok(format!(
+                    "{}",
+                    id.resolve_contract_id(&self.locator, &network.network_passphrase)?
+                ))
             })
             .collect::<Result<Vec<_>, Error>>()?;
 

--- a/cmd/soroban-cli/src/commands/keys/add.rs
+++ b/cmd/soroban-cli/src/commands/keys/add.rs
@@ -128,7 +128,7 @@ impl Cmd {
             .await?;
         Ok(Secret::Ledger {
             hardware: HardwareKind::Ledger,
-            public_key: public_key.to_string(),
+            public_key: format!("{public_key}"),
             hd_path: self.hd_path,
         })
     }

--- a/cmd/soroban-cli/src/commands/keys/fund.rs
+++ b/cmd/soroban-cli/src/commands/keys/fund.rs
@@ -29,7 +29,7 @@ impl Cmd {
             .address
             .name
             .as_ref()
-            .map_or_else(|| addr.to_string(), ToString::to_string);
+            .map_or_else(|| format!("{addr}"), ToString::to_string);
         network.fund_address(&addr).await?;
         print.checkln(format!(
             "Account {} funded on {:?}",

--- a/cmd/soroban-cli/src/config/key.rs
+++ b/cmd/soroban-cli/src/config/key.rs
@@ -177,7 +177,7 @@ mod test {
     }
     #[test]
     fn secret_key() {
-        let secret_key = stellar_strkey::ed25519::PrivateKey([0; 32]).to_string();
+        let secret_key = format!("{}", stellar_strkey::ed25519::PrivateKey([0; 32]));
         let secret = Secret::SecretKey { secret_key };
         let key = Key::Secret(secret);
         round_trip(&key);

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -332,7 +332,7 @@ impl Args {
             let pk = secure_store::get_public_key(entry_name, effective)?;
             let migrated = Key::Secret(Secret::SecureStore {
                 entry_name: entry_name.clone(),
-                public_key: Some(pk.to_string()),
+                public_key: Some(format!("{pk}")),
                 hd_path: effective,
             });
             // Best-effort write-back: if persistence fails we still return the
@@ -479,7 +479,7 @@ impl Args {
         let mut data: alias::Data = serde_json::from_str(&content).unwrap_or_default();
 
         data.ids
-            .insert(network_passphrase.into(), contract_id.to_string());
+            .insert(network_passphrase.into(), format!("{contract_id}"));
 
         let content = serde_json::to_string(&data)?;
         write_hardened_file(&path, content.as_bytes())?;

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -130,7 +130,7 @@ impl FromStr for Secret {
 impl From<PrivateKey> for Secret {
     fn from(value: PrivateKey) -> Self {
         Secret::SecretKey {
-            secret_key: value.to_string(),
+            secret_key: format!("{value}"),
         }
     }
 }

--- a/cmd/soroban-cli/src/log/auth.rs
+++ b/cmd/soroban-cli/src/log/auth.rs
@@ -140,11 +140,18 @@ fn format_create_contract(
 fn format_address(address: &ScAddress) -> String {
     match address {
         ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(bytes)))) => {
-            stellar_strkey::Strkey::PublicKeyEd25519(stellar_strkey::ed25519::PublicKey(*bytes))
-                .to_string()
+            format!(
+                "{}",
+                stellar_strkey::Strkey::PublicKeyEd25519(stellar_strkey::ed25519::PublicKey(
+                    *bytes
+                ))
+            )
         }
         ScAddress::Contract(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(bytes))) => {
-            stellar_strkey::Strkey::Contract(stellar_strkey::Contract(*bytes)).to_string()
+            format!(
+                "{}",
+                stellar_strkey::Strkey::Contract(stellar_strkey::Contract(*bytes))
+            )
         }
         _ => format!("{address:?}"),
     }

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -126,8 +126,10 @@ pub async fn sign_soroban_authorizations(
                 // This address is for a contract. This means we're using a custom
                 // smart-contract account. Currently the CLI doesn't support that yet.
                 return Err(Error::MissingSignerForAddress {
-                    address: stellar_strkey::Strkey::Contract(stellar_strkey::Contract(*c))
-                        .to_string(),
+                    address: format!(
+                        "{}",
+                        stellar_strkey::Strkey::Contract(stellar_strkey::Contract(*c))
+                    ),
                 });
             }
         };
@@ -162,10 +164,12 @@ pub async fn sign_soroban_authorizations(
             }
             None => {
                 return Err(Error::MissingSignerForAddress {
-                    address: stellar_strkey::Strkey::PublicKeyEd25519(
-                        stellar_strkey::ed25519::PublicKey(*auth_address_bytes),
-                    )
-                    .to_string(),
+                    address: format!(
+                        "{}",
+                        stellar_strkey::Strkey::PublicKeyEd25519(
+                            stellar_strkey::ed25519::PublicKey(*auth_address_bytes),
+                        )
+                    ),
                 });
             }
         }

--- a/cmd/soroban-cli/src/signer/secure_store.rs
+++ b/cmd/soroban-cli/src/signer/secure_store.rs
@@ -60,7 +60,7 @@ mod secure_store_impl {
             .from_path_index(hd_path.unwrap_or_default() as usize, None)?
             .public()
             .0;
-        let public_key = PublicKey(public_key_bytes).to_string();
+        let public_key = format!("{}", PublicKey(public_key_bytes));
 
         Ok(Secret::SecureStore {
             entry_name,

--- a/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
+++ b/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "25"
+soroban-sdk = "26"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What

Upgrades workspace dependencies to their stable releases: `stellar-xdr` to `26.0.1`, `stellar-strkey` to `0.0.16`, the `soroban-*` crates (`soroban-spec`, `soroban-spec-rust`, `soroban-sdk`, `soroban-env-host`, `soroban-token-sdk`, `stellar-asset-spec`, `soroban-ledger-snapshot`) to `26.0.0`, and `stellar-rpc-client` to `26.0.0`. Adapts call sites for two breaking API changes: `stellar-strkey`'s inherent `to_string()` now returns `heapless::String<N>`, so call sites that need `std::string::String` use `format!("{x}")` to go through `Display`; and `soroban-spec-rust::generate_without_file` now returns `Result<TokenStream, GenerateError>`, propagated via `?` with a new variant on the local error enum.

### Why

Move the workspace off pre-release/RC versions onto the stable releases.

### Known limitations

N/A