### PR TITLE
Escape --manifest-path arg in build --print-commands-only tests.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,8 +94,7 @@ jobs:
           rust-version: ${{ matrix.rust }}
 
   build-and-test-windows:
-    # TODO: restore before merge
-    # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,7 +94,8 @@ jobs:
           rust-version: ${{ matrix.rust }}
 
   build-and-test-windows:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
+    # TODO: restore before merge
+    # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -15,12 +15,12 @@ fn build_all() {
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/");
     let expected = format!(
-        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
-cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release
-cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
-        add_path(),
-        call_path(),
-        add2_path()
+        "cargo rustc {} --crate-type=cdylib --target=wasm32v1-none --release
+cargo rustc {} --crate-type=cdylib --target=wasm32v1-none --release
+cargo rustc {} --crate-type=cdylib --target=wasm32v1-none --release",
+        manifest_path_arg(&add_path()),
+        manifest_path_arg(&call_path()),
+        manifest_path_arg(&add2_path()),
     );
     sandbox
         .new_assert_cmd("contract")
@@ -38,8 +38,8 @@ fn build_package_by_name() {
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/");
     let expected = format!(
-        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
-        add_path()
+        "cargo rustc {} --crate-type=cdylib --target=wasm32v1-none --release",
+        manifest_path_arg(&add_path()),
     );
     sandbox
         .new_assert_cmd("contract")
@@ -113,8 +113,8 @@ fn build_all_when_in_non_package_directory() {
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace/contracts/add/src/");
     let expected = format!(
-        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
-        parent_path()
+        "cargo rustc {} --crate-type=cdylib --target=wasm32v1-none --release",
+        manifest_path_arg(&parent_path()),
     );
 
     sandbox
@@ -133,8 +133,8 @@ fn build_default_members() {
     let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_path = cargo_dir.join("tests/fixtures/workspace-with-default-members/");
     let expected = format!(
-        "cargo rustc --manifest-path={} --crate-type=cdylib --target=wasm32v1-none --release",
-        add_path()
+        "cargo rustc {} --crate-type=cdylib --target=wasm32v1-none --release",
+        manifest_path_arg(&add_path()),
     );
 
     sandbox
@@ -605,6 +605,11 @@ fn get_entries(fixture_path: &Path, outdir: &Path) -> Vec<ScMetaEntry> {
     })
     .collect::<Result<Vec<_>, _>>()
     .unwrap()
+}
+
+fn manifest_path_arg(path: &str) -> String {
+    let arg = format!("--manifest-path={path}");
+    escape(std::borrow::Cow::Owned(arg)).into_owned()
 }
 
 fn add_path() -> String {


### PR DESCRIPTION
### What

Escape the `--manifest-path=<path>` arg in the expected output of `build::build_all`, `build::build_default_members`, `build::build_all_when_in_non_package_directory`, and `build::build_package_by_name` so the assertions match what production emits on Windows.

Adds a `manifest_path_arg` helper in `cmd/crates/soroban-test/tests/it/build.rs` that wraps `format!("--manifest-path={path}")` with `shell_escape::escape`, the same way `serialize_command` (cmd/soroban-cli/src/commands/contract/build.rs:594) escapes each cargo arg.

### Why

The Windows CI matrix has been red since #2502 (Shell-escape build command args in --print-commands-only output). On Windows `PathBuf::join` produces backslashes, and `shell_escape::escape` treats `\` as a shell-special character and wraps the whole token in single quotes, so the CLI emits `'--manifest-path=contracts\add\Cargo.toml'`. The tests' expected strings interpolate the manifest path raw, so they never matched the actual output.

Fix is in the tests rather than production: both `'--key=value'` and `--key='value'` parse to the same arg token in a shell, so the current production output is functionally correct, just visually unusual on Windows. Mirroring it in the tests is the smaller, lower-risk change.

### Verification

To run the Windows matrix on this PR, the `if:` gate on `build-and-test-windows` was temporarily commented out, then restored. Both Windows jobs passed with the fix:

- msrv: https://github.com/stellar/stellar-cli/actions/runs/26538566467/job/78173877101 (23m33s)
- latest: https://github.com/stellar/stellar-cli/actions/runs/26538566467/job/78173877224 (25m45s)

### Known limitations

N/A