### PR TITLE
Add missing runtime libraries to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:latest
 RUN rustup target add wasm32v1-none
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libudev1 libssl3 && \
+    apt-get install -y --no-install-recommends ca-certificates libdbus-1-3 libssl3 libudev1 && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH


### PR DESCRIPTION
### What

Install `ca-certificates`, `libdbus-1-3`, `libssl3`, and `libudev1` in the Docker image.

### Why

The image was missing runtime libraries the CLI depends on (broke on #2544), causing it to fail on startup:

```
$ docker run -it --rm docker.io/stellar/stellar-cli:latest --version
info: component rust-std for target wasm32v1-none is up to date
stellar: error while loading shared libraries: libdbus-1.so.3: cannot open shared object file: No such file or directory
```

`ca-certificates` is also needed for TLS to remote RPC endpoints.

### Known limitations

N/A