### PR TITLE
Build Docker image from source via cargo install

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,37 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            arch: amd64
-          - runs-on: ubuntu-24.04-arm
-            arch: arm64
-    runs-on: ${{ matrix.runs-on }}
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
-
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libudev-dev libdbus-1-dev
-
-      - name: Build binary
-        run: cargo build --package stellar-cli --release
-
-      - name: Upload binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: stellar-${{ matrix.arch }}
-          path: target/release/stellar
-          retention-days: 1
-
   docker:
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,12 +26,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           fetch-depth: 0
-
-      - name: Download binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: stellar-*
-          merge-multiple: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
@@ -100,6 +64,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          build-args: |
+            STELLAR_CLI_REV=${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
 
       - name: Update Docker Hub description
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,26 @@ FROM rust:latest
 RUN rustup target add wasm32v1-none
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates libdbus-1-3 libssl3 libudev1 && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    libdbus-1-dev \
+    libssl-dev \
+    libudev-dev \
+    pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-COPY stellar-${TARGETARCH}/stellar /usr/local/bin/stellar
-RUN chmod +x /usr/local/bin/stellar
+ARG STELLAR_CLI_REV
+RUN cargo install --locked \
+        --git https://github.com/stellar/stellar-cli.git \
+        --rev "${STELLAR_CLI_REV}" \
+        stellar-cli
 
 ENV STELLAR_CONFIG_HOME=/config
 ENV STELLAR_DATA_HOME=/data
+ENV STELLAR_NO_UPDATE_CHECK=1
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
### What

The Docker image is now built from source via `cargo install --git ... --rev "${STELLAR_CLI_REV}"` instead of copying a pre-built binary downloaded from a previous workflow job. The `build` job that produced and uploaded the binary has been removed; the `docker` job passes `STELLAR_CLI_REV` (resolved from `inputs.ref` or the release tag) as a build-arg to `docker/build-push-action`.

### Why

The previously downloaded binary didn't pick up the image's runtime dependencies, so the `libdbus` error still happened at runtime. Building from source inside the image ensures the binary links against the libraries actually present in the final image.

### Known limitations

N/A