### PR TITLE
Conceal `stellar env` output unless `--reveal` is used

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1201,8 +1201,6 @@ If there are no environment variables in use, prints the defaults.
 
 - `--reveal` — Whether to reveal the value of concealed env vars. By default, concealed env vars are hidden behind a placeholder value
 
-  Default value: `false`
-
 ## `stellar keys`
 
 Create and manage identities including keys and addresses

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1179,7 +1179,9 @@ Prints the environment variables
 
 Prints to stdout in a format that can be used as .env file. Environment variables have precedence over defaults.
 
-Pass a name to get the value of a single environment variable.
+By default, secret values are concealed. To display them, use `--reveal`.
+
+Pass a name to get the value of a single environment variable. Its raw value is printed unescaped, suitable for command substitution. Concealed variables print nothing unless `--reveal` is passed.
 
 If there are no environment variables in use, prints the defaults.
 
@@ -1194,6 +1196,12 @@ If there are no environment variables in use, prints the defaults.
 ###### **Global Options:**
 
 - `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--reveal` — Whether to reveal the value of concealed env vars. By default, concealed env vars are hidden behind a placeholder value
+
+  Default value: `false`
 
 ## `stellar keys`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1181,7 +1181,7 @@ Prints to stdout in a format that can be used as .env file. Environment variable
 
 By default, secret values are concealed. To display them, use `--reveal`.
 
-Pass a name to get the value of a single environment variable. Its raw value is printed unescaped, suitable for command substitution. Concealed variables print nothing unless `--reveal` is passed.
+Pass a name to get the value of a single environment variable. Its value is printed without shell quoting (control characters are neutralized), suitable for command substitution. Concealed variables print nothing unless `--reveal` is passed.
 
 If there are no environment variables in use, prints the defaults.
 

--- a/cmd/crates/soroban-test/tests/it/config.rs
+++ b/cmd/crates/soroban-test/tests/it/config.rs
@@ -776,6 +776,23 @@ fn env_does_not_display_secret_key() {
 }
 
 #[test]
+fn env_does_display_secret_key_when_reveal_is_provided() {
+    let sandbox = TestEnv::default();
+    sandbox
+        .new_assert_cmd("env")
+        .arg("--reveal")
+        .env(
+            "STELLAR_SECRET_KEY",
+            "SDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCQYFD",
+        )
+        .assert()
+        .stdout(predicate::str::contains(
+            "STELLAR_SECRET_KEY=SDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCQYFD",
+        ))
+        .success();
+}
+
+#[test]
 fn env_single_concealed_key_returns_empty() {
     let sandbox = TestEnv::default();
     sandbox
@@ -787,6 +804,21 @@ fn env_single_concealed_key_returns_empty() {
         )
         .assert()
         .stdout("")
+        .success();
+}
+
+#[test]
+fn env_single_is_returned_when_using_reveal() {
+    let sandbox = TestEnv::default();
+    sandbox
+        .new_assert_cmd("env")
+        .args(["STELLAR_SECRET_KEY", "--reveal"])
+        .env(
+            "STELLAR_SECRET_KEY",
+            "SDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCQYFD",
+        )
+        .assert()
+        .stdout("SDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCQYFD\n")
         .success();
 }
 

--- a/cmd/soroban-cli/src/commands/env/mod.rs
+++ b/cmd/soroban-cli/src/commands/env/mod.rs
@@ -19,7 +19,7 @@ pub struct Cmd {
 
     /// Whether to reveal the value of concealed env vars. By default, concealed env vars are
     /// hidden behind a placeholder value.
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     pub reveal: bool,
 
     #[command(flatten)]

--- a/cmd/soroban-cli/src/commands/env/mod.rs
+++ b/cmd/soroban-cli/src/commands/env/mod.rs
@@ -3,8 +3,10 @@ use crate::{
     config::locator::{self},
     env_vars,
     print::Print,
+    utils::escape_control_characters,
 };
 use clap::Parser;
+use shell_escape::escape;
 
 #[allow(clippy::doc_markdown)]
 #[derive(Debug, Parser)]
@@ -14,6 +16,11 @@ pub struct Cmd {
     /// E.g.: $ stellar env STELLAR_ACCOUNT
     #[arg()]
     pub name: Option<String>,
+
+    /// Whether to reveal the value of concealed env vars. By default, concealed env vars are
+    /// hidden behind a placeholder value.
+    #[arg(long, default_value_t = false)]
+    pub reveal: bool,
 
     #[command(flatten)]
     pub config_locator: locator::Args,
@@ -32,16 +39,20 @@ impl Cmd {
         let supported = env_vars::prefixed("STELLAR");
 
         for key in supported {
-            if let Some(v) = EnvVar::get(&key) {
+            if let Some(mut v) = EnvVar::get(&key) {
+                if self.reveal {
+                    v.reveal();
+                }
+
                 vars.push(v);
             }
         }
 
         // If a specific name is given, just print that one value
         if let Some(name) = &self.name {
-            if env_vars::is_concealed(name) {
-                if let Some(v) = vars.iter().find(|v| &v.key == name) {
-                    println!("{}", v.value);
+            if let Some(v) = vars.iter().find(|v| &v.key == name) {
+                if v.is_revealed() {
+                    println!("{}", escape_control_characters(&v.value));
                 }
             }
 
@@ -70,6 +81,7 @@ struct EnvVar {
     key: String,
     value: String,
     source: String,
+    reveal: bool,
 }
 
 impl EnvVar {
@@ -84,15 +96,25 @@ impl EnvVar {
                 key: key.to_string(),
                 value,
                 source,
+                reveal: false,
             });
         }
 
         None
     }
 
+    fn reveal(&mut self) {
+        self.reveal = true;
+    }
+
+    fn is_revealed(&self) -> bool {
+        self.reveal || !env_vars::is_concealed(&self.key)
+    }
+
     fn str(&self) -> String {
-        if env_vars::is_concealed(&self.key) {
-            format!("{}={}", self.key, self.value)
+        if self.is_revealed() {
+            let value = escape(escape_control_characters(&self.value).into());
+            format!("{}={value}", self.key)
         } else {
             format!("# {}=<concealed>", self.key)
         }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -157,7 +157,11 @@ pub enum Cmd {
     /// Prints to stdout in a format that can be used as .env file. Environment
     /// variables have precedence over defaults.
     ///
-    /// Pass a name to get the value of a single environment variable.
+    /// By default, secret values are concealed. To display them, use `--reveal`.
+    ///
+    /// Pass a name to get the value of a single environment variable. Its raw value is printed
+    /// unescaped, suitable for command substitution. Concealed variables print nothing unless
+    /// `--reveal` is passed.
     ///
     /// If there are no environment variables in use, prints the defaults.
     Env(env::Cmd),

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -159,9 +159,9 @@ pub enum Cmd {
     ///
     /// By default, secret values are concealed. To display them, use `--reveal`.
     ///
-    /// Pass a name to get the value of a single environment variable. Its raw value is printed
-    /// unescaped, suitable for command substitution. Concealed variables print nothing unless
-    /// `--reveal` is passed.
+    /// Pass a name to get the value of a single environment variable. Its value is printed without
+    /// shell quoting (control characters are neutralized), suitable for command substitution.
+    /// Concealed variables print nothing unless `--reveal` is passed.
     ///
     /// If there are no environment variables in use, prints the defaults.
     Env(env::Cmd),

--- a/cmd/soroban-cli/src/env_vars.rs
+++ b/cmd/soroban-cli/src/env_vars.rs
@@ -29,7 +29,6 @@ pub fn unprefixed() -> Vec<&'static str> {
 /// Unprefixed names of env vars that are safe to display in plain text.
 const VISIBLE: &[&str] = &[
     "ACCOUNT",
-    "ARCHIVE_URL",
     "CONFIG_HOME",
     "CONTRACT_ID",
     "DATA_HOME",
@@ -41,7 +40,6 @@ const VISIBLE: &[&str] = &[
     "NO_CACHE",
     "NO_UPDATE_CHECK",
     "OPERATION_SOURCE_ACCOUNT",
-    "RPC_URL",
     "SEND",
     "SIGN_WITH_LAB",
     "SIGN_WITH_LEDGER",
@@ -55,7 +53,7 @@ pub fn is_concealed(key: &str) -> bool {
         .strip_prefix("STELLAR_")
         .or_else(|| key.strip_prefix("SOROBAN_"))
         .unwrap_or(key);
-    VISIBLE.contains(&name)
+    !VISIBLE.contains(&name)
 }
 
 pub fn prefixed(key: &str) -> Vec<String> {

--- a/cmd/soroban-cli/src/env_vars.rs
+++ b/cmd/soroban-cli/src/env_vars.rs
@@ -45,9 +45,9 @@ const VISIBLE: &[&str] = &[
     "SIGN_WITH_LEDGER",
 ];
 
-/// Returns true if the key is one of the supported env vars that should be shown in `stellar env`.
-/// Uses an allow list approach to avoid showing any env vars that are not explicitly supported,
-/// even if they start with the expected prefix.
+/// Returns true if the key should be concealed in `stellar env` output, i.e. it is not in the
+/// allow list of vars that are safe to display. Using an allow list ensures unknown vars are
+/// concealed by default, even if they start with the expected prefix.
 pub fn is_concealed(key: &str) -> bool {
     let name = key
         .strip_prefix("STELLAR_")


### PR DESCRIPTION
### What

To reduce churn in env handling, `stellar env` now conceals secret-bearing values by default and adds a `--reveal` flag to print the real values when explicitly requested. Output values are also escaped: the full `KEY=value` listing is shell-quoted (safe for `eval "$(stellar env)"`), while a single named lookup prints the raw value with only control characters neutralized (safe for command substitution like `RPC_URL=$(stellar env STELLAR_RPC_URL --reveal)`).

### Why

The allow-list that decides which variables are safe to display had its logic inverted: variables marked "safe to display" were the ones being concealed, while everything else — including values that can embed credentials — was printed in plain text. This meant `stellar env` could leak secrets in logs, screen shares, or shell history. This change fixes the inverted check so credential-bearing values are concealed unless the user opts in with `--reveal`.

### Known limitations

N/A