### PR TITLE
Redact archive URL password in snapshot download output

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/snapshot.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/snapshot.rs
@@ -212,6 +212,24 @@ fn snapshot_merge() {
 }
 
 #[test]
+fn snapshot_create_redacts_archive_url_password() {
+    let sandbox = &TestEnv::new();
+    sandbox
+        .new_assert_cmd("snapshot")
+        .arg("create")
+        .arg("--archive-url=https://archiveuser:supersecret@archive.invalid/")
+        .arg("--ledger=1")
+        .arg("--out=snapshot.json")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("supersecret")
+                .not()
+                .and(predicate::str::contains("redacted")),
+        );
+}
+
+#[test]
 fn snapshot_merge_conflict_resolution() {
     let sandbox = &TestEnv::new();
     let identity = "ineffable-serval-3633";

--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -31,7 +31,10 @@ use crate::{
     tx::builder,
     utils::get_name_from_stellar_asset_contract_storage,
 };
-use crate::{config::address::UnresolvedMuxedAccount, utils::http};
+use crate::{
+    config::address::UnresolvedMuxedAccount,
+    utils::{http, url::redact_url},
+};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum, Default)]
 pub enum Output {
@@ -559,7 +562,10 @@ async fn get_history(
     };
     let history_url = Url::from_str(&history_url).unwrap();
 
-    print.globeln(format!("Downloading history {history_url}"));
+    print.globeln(format!(
+        "Downloading history {}",
+        redact_url(history_url.as_str())
+    ));
 
     let response = http::client()
         .get(history_url.as_str())
@@ -589,7 +595,10 @@ async fn get_history(
         .map_err(Error::ReadHistoryHttpStream)?;
 
     print.clear_previous_line();
-    print.globeln(format!("Downloaded history {}", &history_url));
+    print.globeln(format!(
+        "Downloaded history {}",
+        redact_url(history_url.as_str())
+    ));
 
     serde_json::from_slice::<History>(&body).map_err(Error::JsonDecodingHistory)
 }
@@ -608,9 +617,13 @@ async fn get_ledger_metadata_from_archive(
         "{archive_url}/ledger/{ledger_hex_0}/{ledger_hex_1}/{ledger_hex_2}/ledger-{ledger_hex}.xdr.gz"
     );
 
-    print.globeln(format!("Downloading ledger headers {ledger_url}"));
-
     let ledger_url = Url::from_str(&ledger_url).map_err(Error::ParsingBucketUrl)?;
+
+    print.globeln(format!(
+        "Downloading ledger headers {}",
+        redact_url(ledger_url.as_str())
+    ));
+
     let response = http::client()
         .get(ledger_url.as_str())
         .send()


### PR DESCRIPTION
### What

`stellar snapshot create` printed the user/environment-supplied archive URL (`--archive-url` / `STELLAR_ARCHIVE_URL`) verbatim to stderr while downloading. When that URL carried HTTP basic-auth credentials (`https://user:password@host/`), the password was written to stderr in cleartext at three sites in `commands/snapshot/create.rs`: "Downloading history", "Downloaded history", and "Downloading ledger headers". These now pass the URL through the existing `redact_url` helper, matching how `network info`, `network ls`, and `doctor` already handle credentialed URLs.

### Why

stderr from a CLI is routinely captured in CI/CD logs, terminal recordings, and screen shares, so a private archive credential printed there is exposed to anyone who can read those. This is the same class of leak the `redact_url` work was written to prevent for RPC URLs; the snapshot command was the one display path that wasn't covered. Default flows (mainnet/testnet/futurenet) use hardcoded credential-free Stellar archives and are unaffected; this matters for operators pointing the command at a private, credentialed history archive.

### Known limitations

N/A — a codebase-wide sweep of other print/log/error sites (RPC, signer, deploy links, container, error enums, `Debug` impls) confirmed every other credentialed-URL display path already redacts, so no further sites needed changing.