### PR TITLE
fix: prevent panic on no-op contract extend for non-existent entries

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -285,11 +285,17 @@ impl Cmd {
         if changes.is_empty() {
             print.infoln("No changes detected, transaction was a no-op.");
             let entry = client.get_full_ledger_entries(&keys).await?;
+            if entry.entries.is_empty() {
+                return Err(Error::LedgerEntryNotFound);
+            }
             let extension = entry.entries[0].live_until_ledger_seq.unwrap_or_default();
 
             return Ok(TxnResult::Res(extension));
         }
 
+        if changes.len() < 2 {
+            return Err(Error::LedgerEntryNotFound);
+        }
         match (&changes[0], &changes[1]) {
             (
                 LedgerEntryChange::State(_),


### PR DESCRIPTION
## Description

Fixes a panic (`index out of bounds: the len is 0 but the index is 0`) in `stellar contract extend` when the target entry does not exist.

## Problem

When `stellar contract extend` is called against a non-existent contract ID, the transaction succeeds as a no-op — the changes array is empty. The code then calls `client.get_full_ledger_entries(&keys)` which returns an empty `entries` list for a non-existent entry. Accessing `entry.entries[0]` without checking for emptiness causes an `index out of bounds` panic at `extend.rs:288`.

**Reproduction:**
```bash
stellar contract extend --id CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4 --ledgers-to-extend 1
# Transaction succeeds as no-op, then panics:
# thread 'main' panicked at .../extend.rs:288:42:
# index out of bounds: the len is 0 but the index is 0
```

## Fix

1. **Primary fix:** Check `entry.entries.is_empty()` before accessing `entries[0]` in the no-op path. Return `Error::LedgerEntryNotFound` if empty — consistent with how the same error is returned elsewhere in this function (lines 268, 277, 282).

2. **Defensive fix:** Add a `changes.len() < 2` guard before matching on `changes[0]` and `changes[1]`, preventing a potential panic if the transaction meta is malformed (fewer than 2 change entries).

Both checks use the existing `Error::LedgerEntryNotFound` variant, which is already the error returned for all other "entry not found" cases in this function.

Fixes #2599
