### PR TITLE
Build Docker images from source instead of downloading binaries.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,19 +16,69 @@ defaults:
   run:
     shell: bash
 
+env:
+  REGISTRY_IMAGE: stellar/stellar-cli
+
 jobs:
-  docker:
+  # Resolve the ref to a single immutable SHA and compute the Docker tags once,
+  # so both platform builds and the published manifest refer to one commit even
+  # if the branch advances while the workflow runs.
+  prepare:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      tags: ${{ steps.resolve.outputs.tags }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+      # Resolve the ref to a SHA and compute Docker tags.
+      # - Version tag (e.g. v1.2.3): push versioned + latest tags.
+      # - Any other ref: push a tag for the resolved commit SHA.
+      - name: Resolve ref and tags
+        id: resolve
+        run: |
+          ref="${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}"
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
+
+          if [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            version="${ref#v}"
+            echo "tags=-t ${REGISTRY_IMAGE}:${version} -t ${REGISTRY_IMAGE}:latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "::error::Release tag '${ref}' is not a valid version tag (expected vX.Y.Z)."
+            exit 1
+          else
+            echo "tags=-t ${REGISTRY_IMAGE}:${sha}" >> $GITHUB_OUTPUT
+          fi
+
+  # Build each platform on a native runner and push the image by digest.
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            platform: linux/amd64
+          - runs-on: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+    steps:
+      - name: Set platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
@@ -39,39 +89,76 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Compute Docker tags from the ref.
-      # - Version tag (e.g. v1.2.3): push versioned + latest tags.
-      # - Any other ref: push a tag for the resolved commit SHA.
-      - name: Compute tags
-        run: |
-          ref="${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}"
-
-          if [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="${ref#v}"
-            echo "DOCKER_TAGS=stellar/stellar-cli:${version},stellar/stellar-cli:latest" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "::error::Release tag '${ref}' is not a valid version tag (expected vX.Y.Z)."
-            exit 1
-          else
-            commit="$(git rev-parse HEAD)"
-            echo "DOCKER_TAGS=stellar/stellar-cli:${commit}" >> $GITHUB_ENV
-          fi
-
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.DOCKER_TAGS }}
+          platforms: ${{ matrix.platform }}
           build-args: |
-            STELLAR_CLI_REV=${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
+            STELLAR_CLI_REV=${{ needs.prepare.outputs.sha }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-platform digests into a single multi-arch manifest list
+  # and push it under the final tags.
+  merge:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          TAGS: ${{ needs.prepare.outputs.tags }}
+        run: |
+          docker buildx imagetools create ${TAGS} \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
 
       - name: Update Docker Hub description
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login/" \
-            -H "Content-Type: application/json" \
-            -d '{"username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}' \
+          TOKEN=$(jq -n --arg u "$DOCKERHUB_USERNAME" --arg p "$DOCKERHUB_TOKEN" \
+            '{username: $u, password: $p}' | \
+            curl -s -X POST "https://hub.docker.com/v2/users/login/" \
+              -H "Content-Type: application/json" \
+              -d @- \
             | jq -r .token)
 
           jq -n --arg desc "$(cat ./docker/README.md)" '{"full_description": $desc}' | \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,37 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            arch: amd64
-          - runs-on: ubuntu-24.04-arm
-            arch: arm64
-    runs-on: ${{ matrix.runs-on }}
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
-
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libudev-dev libdbus-1-dev
-
-      - name: Build binary
-        run: cargo build --package stellar-cli --release
-
-      - name: Upload binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: stellar-${{ matrix.arch }}
-          path: target/release/stellar
-          retention-days: 1
-
   docker:
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,12 +26,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           fetch-depth: 0
-
-      - name: Download binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: stellar-*
-          merge-multiple: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
@@ -100,6 +64,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          build-args: |
+            STELLAR_CLI_REV=${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
 
       - name: Update Docker Hub description
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && \
     pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
-ARG TARGETARCH
 ARG STELLAR_CLI_REV
 RUN cargo install --locked \
         --git https://github.com/stellar/stellar-cli.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,26 @@ FROM rust:latest
 RUN rustup target add wasm32v1-none
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates libdbus-1-3 libssl3 libudev1 && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    libdbus-1-dev \
+    libssl-dev \
+    libudev-dev \
+    pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-COPY stellar-${TARGETARCH}/stellar /usr/local/bin/stellar
-RUN chmod +x /usr/local/bin/stellar
+ARG STELLAR_CLI_REV
+RUN cargo install --locked \
+        --git https://github.com/stellar/stellar-cli.git \
+        --rev "${STELLAR_CLI_REV}" \
+        stellar-cli
 
 ENV STELLAR_CONFIG_HOME=/config
 ENV STELLAR_DATA_HOME=/data
+ENV STELLAR_NO_UPDATE_CHECK=1
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
### What

Build the `stellar/stellar-cli` Docker image from source via `cargo install` inside the Dockerfile, and produce a multi-arch image by building each architecture on its own native runner before merging them into a single manifest.

The `docker.yml` workflow now runs a matrix `build` job — `linux/amd64` on `ubuntu-latest` and `linux/arm64` on `ubuntu-24.04-arm` — that pushes each platform image by digest, then a `merge` job assembles those digests into one manifest list (`docker buildx imagetools create`) under the computed tags. QEMU emulation is no longer used.

### Why

The current Docker image is broken (see https://github.com/stellar/stellar-cli-docker/issues/16). The move to building the CLI from source means the image is compiled during the Docker build rather than copied in from a prebuilt binary. Compiling under QEMU emulation for a foreign architecture is prohibitively slow, so each architecture is built on a matching native runner and the results are combined into a single multi-arch manifest at publish time.

This is a temporary solution until `stellar/stellar-cli-docker` publishes images.

### Known limitations

This is a stopgap; image publishing is expected to move to `stellar/stellar-cli-docker`.