### PR TITLE
Tag `:latest` only for the newest released version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           path: source
+          fetch-depth: 0
 
       - name: Check out Dockerfile ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,7 +53,9 @@ jobs:
           path: dockerfile
 
       # Resolve both refs to SHAs and compute Docker tags from the source ref.
-      # - Version tag (e.g. v1.2.3): push versioned + latest tags.
+      # - Highest version tag (e.g. v1.2.3): push versioned + latest tags.
+      # - Older version tag: push only the versioned tag, so :latest never
+      #   moves back to an older line (e.g. a 25.x patch after 26.x ships).
       # - Any other ref: push a tag for the resolved source commit SHA.
       - name: Resolve refs and tags
         id: resolve
@@ -65,7 +68,17 @@ jobs:
 
           if [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             version="${ref#v}"
-            echo "tags=-t ${REGISTRY_IMAGE}:${version} -t ${REGISTRY_IMAGE}:latest" >> $GITHUB_OUTPUT
+            highest="$(git -C source tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)"
+            if [[ -z "$highest" ]]; then
+              echo "::error::Could not determine the highest version tag."
+              exit 1
+            fi
+            if [[ "$ref" == "$highest" ]]; then
+              echo "tags=-t ${REGISTRY_IMAGE}:${version} -t ${REGISTRY_IMAGE}:latest" >> $GITHUB_OUTPUT
+            else
+              echo "tags=-t ${REGISTRY_IMAGE}:${version}" >> $GITHUB_OUTPUT
+            fi
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             echo "::error::Release tag '${ref}' is not a valid version tag (expected vX.Y.Z)."
             exit 1


### PR DESCRIPTION
### What

The Docker workflow now pushes the `:latest` tag only when the version being built is the highest released `vX.Y.Z` tag. Building an older version tag publishes its versioned tag but leaves `:latest` untouched. The source checkout also fetches tags so the comparison has the full tag list.

### Why

`:latest` was pushed for any ref matching `vX.Y.Z`, with no version comparison. Releasing a back-port or re-running an older version tag (e.g. a 25.x patch after 26.x shipped) would clobber `:latest` to point at the older release. This guard ensures `:latest` only ever advances to the newest version.

### Known limitations

N/A