### PR TITLE
Add retries to the install action for resilience

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,9 @@ runs:
         # Download to a file (rather than piping straight into tar) so that
         # curl's retries can safely restart a transfer without corrupting the
         # tar stream. Retry on transient network failures with backoff so a
-        # single blip doesn't fail the whole job.
+        # single blip doesn't fail the whole job. Use a fixed local filename
+        # so the download path never depends on the (untrusted) version string.
+        archive="$RUNNER_TEMP/stellar-cli.tar.gz"
         curl -fL \
           --retry 5 \
           --retry-delay 5 \
@@ -77,9 +79,9 @@ runs:
           --retry-all-errors \
           --connect-timeout 30 \
           --max-time 300 \
-          -o "$RUNNER_TEMP/$file" \
+          -o "$archive" \
           "$url"
-        tar xvz -C $HOME/.local/bin -f "$RUNNER_TEMP/$file"
+        tar xvz -C $HOME/.local/bin -f "$archive"
 
     - name: Verify binary against attestation
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -66,11 +66,6 @@ runs:
         file="stellar-cli-$version-$os_arch.tar.gz"
         url="https://github.com/stellar/stellar-cli/releases/download/v$version/$file"
         echo "$url"
-        # Download to a file (rather than piping straight into tar) so that
-        # curl's retries can safely restart a transfer without corrupting the
-        # tar stream. Retry on transient network failures with backoff so a
-        # single blip doesn't fail the whole job. Use a fixed local filename
-        # so the download path never depends on the (untrusted) version string.
         archive="$RUNNER_TEMP/stellar-cli.tar.gz"
         curl -fL \
           --retry 5 \
@@ -89,8 +84,6 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         version="${{ steps.version.outputs.version }}"
-        # gh attestation verify hits the network, so retry on transient
-        # failures with exponential backoff before giving up.
         attempts=5
         delay=5
         for attempt in $(seq 1 "$attempts"); do

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,20 @@ runs:
         file="stellar-cli-$version-$os_arch.tar.gz"
         url="https://github.com/stellar/stellar-cli/releases/download/v$version/$file"
         echo "$url"
-        curl -fL "$url" | tar xvz -C $HOME/.local/bin
+        # Download to a file (rather than piping straight into tar) so that
+        # curl's retries can safely restart a transfer without corrupting the
+        # tar stream. Retry on transient network failures with backoff so a
+        # single blip doesn't fail the whole job.
+        curl -fL \
+          --retry 5 \
+          --retry-delay 5 \
+          --retry-connrefused \
+          --retry-all-errors \
+          --connect-timeout 30 \
+          --max-time 300 \
+          -o "$RUNNER_TEMP/$file" \
+          "$url"
+        tar xvz -C $HOME/.local/bin -f "$RUNNER_TEMP/$file"
 
     - name: Verify binary against attestation
       shell: bash
@@ -74,7 +87,22 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         version="${{ steps.version.outputs.version }}"
-        subject="$(gh attestation verify ~/.local/bin/${{ env.stellar_binary }} --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"
+        # gh attestation verify hits the network, so retry on transient
+        # failures with exponential backoff before giving up.
+        attempts=5
+        delay=5
+        for attempt in $(seq 1 "$attempts"); do
+          if subject="$(gh attestation verify ~/.local/bin/${{ env.stellar_binary }} --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"; then
+            break
+          fi
+          if [[ "$attempt" -eq "$attempts" ]]; then
+            echo "Attestation verification failed after $attempts attempts" >&2
+            exit 1
+          fi
+          echo "Attestation verification attempt $attempt failed; retrying in ${delay}s" >&2
+          sleep "$delay"
+          delay=$((delay * 2))
+        done
         echo "Found subject: $subject" >&2
         expected_subject="https://github.com/stellar/stellar-cli/.github/workflows/binaries.yml@refs/tags/v$version"
         echo "Expected subject: $expected_subject" >&2

--- a/action.yml
+++ b/action.yml
@@ -84,20 +84,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         version="${{ steps.version.outputs.version }}"
-        attempts=5
-        delay=5
-        for attempt in $(seq 1 "$attempts"); do
-          if subject="$(gh attestation verify ~/.local/bin/${{ env.stellar_binary }} --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"; then
-            break
-          fi
-          if [[ "$attempt" -eq "$attempts" ]]; then
-            echo "Attestation verification failed after $attempts attempts" >&2
-            exit 1
-          fi
-          echo "Attestation verification attempt $attempt failed; retrying in ${delay}s" >&2
-          sleep "$delay"
-          delay=$((delay * 2))
-        done
+        subject="$(gh attestation verify ~/.local/bin/${{ env.stellar_binary }} --repo stellar/stellar-cli --format json -q '.[].verificationResult.signature.certificate.subjectAlternativeName')"
         echo "Found subject: $subject" >&2
         expected_subject="https://github.com/stellar/stellar-cli/.github/workflows/binaries.yml@refs/tags/v$version"
         echo "Expected subject: $expected_subject" >&2


### PR DESCRIPTION
## What

Make the `stellar/stellar-cli` install action resilient to transient network failures during the binary download.

The `curl` call that fetches the release tarball now retries up to 5 times with backoff (`--retry 5 --retry-delay 5 --retry-connrefused --retry-all-errors`), bounded by `--connect-timeout 30` and `--max-time 300`. The download now writes to a fixed file in `$RUNNER_TEMP` and is extracted by `tar` afterwards, rather than piping `curl` straight into `tar`, so that a retried transfer can safely restart without corrupting the tar stream. Using a fixed local filename also keeps the download path independent of the (untrusted) version string.

## Why

A single transient network blip previously failed the whole job — for example [this rs-soroban-sdk run](https://github.com/stellar/rs-soroban-sdk/actions/runs/27120352954/job/80046147824) failed during the install step. With retries in place, a momentary failure is retried instead of failing the build.

This mirrors the approach taken in [stellar/actions#104](https://github.com/stellar/actions/pull/104), which added curl's built-in retry flags to harden a similar download path.

## Notes

The `gh attestation verify` step is intentionally left unchanged: the `gh` CLI already retries attestation fetches internally (up to 3 times on 5xx responses), so a separate retry loop there added little.