### PR TITLE
Fix tar usage on Windows.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: stellar/stellar-cli@main
         with:
-          version: v23.1.4
+          version: v26.1.0

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
           --max-time 300 \
           -o "$archive" \
           "$url"
-        tar xvz -C $HOME/.local/bin -f "$archive"
+        tar xvz -C "$HOME/.local/bin" < "$archive"
 
     - name: Verify binary against attestation
       shell: bash


### PR DESCRIPTION
### What

Fix tar usage on Windows.

### Why

PRs are failing when smoke-testing this on Windows.

### Known limitations

Can only test the fix once it reaches `main`.
