### PR TITLE
Update stellar dependencies to protocol 27

### DIFF
--- a/.github/workflows/bindings-ts.yml
+++ b/.github/workflows/bindings-ts.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: stellar/quickstart@main
         with:
           tag: testing
-          protocol_version: 26
+          protocol_version: 27
       - uses: actions/setup-node@v6
         with:
           node-version: "20.x"

--- a/.github/workflows/bindings-ts.yml
+++ b/.github/workflows/bindings-ts.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: stellar/quickstart@main
         with:
-          tag: testing
+          tag: nightly
           protocol_version: 27
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: stellar/quickstart@main
         with:
-          tag: future
+          tag: nightly
           protocol_version: 27
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: stellar/quickstart@main
         with:
           tag: future
+          protocol_version: 27
       - uses: actions/checkout@v6
 
       - uses: stellar/actions/rust-cache@main

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: stellar/quickstart@main
         with:
-          tag: future
+          tag: nightly
           protocol_version: 27
       - uses: actions/checkout@v6
       - uses: stellar/actions/rust-cache@main

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: stellar/quickstart@main
         with:
           tag: future
+          protocol_version: 27
       - uses: actions/checkout@v6
       - uses: stellar/actions/rust-cache@main
       - run: rustup update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,9 +941,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-lit"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adabf37211a5276e46335feabcbb1530c95eb3fdf85f324c7db942770aa025d"
+checksum = "9b04f2b1d34cb428043f14aa4c853d14294532e8bbde3b6a3bc2faaaae31a1dd"
 dependencies = [
  "num-bigint",
  "proc-macro2",
@@ -5368,9 +5368,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.3"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
+checksum = "d769030e3b2c27873e9be4931decbbe79787b943d5b30e31f8c395eae83144b8"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5471,9 +5471,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.3"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
+checksum = "5aa50d998c0baafcc6078cb94f5228040c7719b1608c15debc3fc78365dc22f5"
 dependencies = [
  "arbitrary",
  "crate-git-revision 0.0.6",
@@ -5490,9 +5490,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.3"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
+checksum = "fde1064f5e92dbcc8018ecc8e92728bf5bbff0236abaf792c6858367a6853415"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -5500,9 +5500,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.3"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
+checksum = "f47762a1b75b9ccd07558f28e1a0289ca6adec56810c581cde5cf16e329e00b9"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5537,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.3"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
+checksum = "bc04b813a9e32456b37875fc41cdb05912a9e947000b9414b7985bffe07a889a"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5556,9 +5556,8 @@ version = "26.1.0"
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231ae1585d14b5059adde392ce80f6b151e0264ed62b121bca9fe025e8ace460"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -5570,13 +5569,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de6ad39b7070e8703d01c3abad13e75ea5e65b1a5ce5e86b98d724773282044"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "arbitrary",
  "bytes-lit",
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
@@ -5594,9 +5592,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cd5e180920e224d209562cccffd27c35884d14c4dc296b295dfcebef46b6f1"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "darling",
  "heck 0.5.0",
@@ -5614,9 +5611,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680c70a2ab6d7cde343e9a51dd141f2f4304a7282452df8dc540b9bf62565886"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "base64 0.22.1",
  "sha2 0.10.9",
@@ -5627,9 +5623,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e368f91c6633c25cd2d143fd82f84206b8e58718fc630d344f2fa33e6d31b1b"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5726,18 +5721,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4113612698f58df1e900359f05636d26e1434dca6ff3bc189a7e9471c8de4da4"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af3b760ff3c2bd33f4259b5f7e785409134a58c9b46cbefcaffb1ebc5a097bd"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5786,9 +5779,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed169ac8777d89cb3f22cef3cd9c9002bae16226e134078d5dd3b5a93c840bc4"
+version = "26.1.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5842,8 +5834,7 @@ dependencies = [
 [[package]]
 name = "stellar-rpc-client"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4e271a65180323e7b9f5ce5d8a251a25eb3d34b388496902ac5f5ad9bf75b1"
+source = "git+https://github.com/stellar/rs-stellar-rpc-client?branch=main#301106b508fad329d0915b85d3e8c461dbf1b718"
 dependencies = [
  "clap",
  "hex",
@@ -5892,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.1"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
+checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +86,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -105,15 +111,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -224,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -237,7 +252,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -276,7 +291,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -518,7 +533,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -586,7 +601,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -603,7 +618,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -627,7 +642,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -651,7 +666,7 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -659,21 +674,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper 1.7.0",
  "hyper-named-pipe",
@@ -948,7 +948,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1036,7 +1036,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1083,11 +1083,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -1104,21 +1104,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -1456,7 +1456,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1485,7 +1485,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1499,7 +1499,7 @@ dependencies = [
  "indexmap 2.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1518,7 +1518,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1527,8 +1527,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1542,7 +1552,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.106",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1551,9 +1574,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1619,7 +1653,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1630,7 +1664,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1716,7 +1750,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1825,7 +1859,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1929,7 +1963,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1950,7 +1984,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1969,7 +2003,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "anstream",
+ "anstream 0.6.20",
  "anstyle",
  "env_filter",
  "jiff",
@@ -2246,7 +2280,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2341,12 +2375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,7 +2438,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.11.0",
  "slab",
  "tokio",
@@ -2549,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2575,7 +2603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2586,7 +2614,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2671,7 +2699,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2704,7 +2732,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper 1.7.0",
  "hyper-util",
  "log",
@@ -2756,14 +2784,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3004,17 +3032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,7 +3135,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3162,7 +3179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3194,7 +3211,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
@@ -3236,7 +3253,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3384,9 +3401,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -3474,7 +3491,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3533,13 +3550,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3552,7 +3569,7 @@ dependencies = [
  "bytes",
  "colored",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
@@ -3670,7 +3687,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3711,15 +3728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3774,7 +3782,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3930,7 +3938,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4012,7 +4020,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4047,7 +4055,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4207,7 +4215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4230,9 +4238,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -4272,7 +4280,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4297,7 +4305,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4334,16 +4342,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4480,7 +4488,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4525,7 +4533,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
@@ -4634,7 +4642,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.106",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -4659,12 +4667,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4881,7 +4883,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5072,7 +5074,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5083,20 +5085,21 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.11.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -5117,7 +5120,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5143,11 +5146,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5155,8 +5159,7 @@ dependencies = [
  "schemars 0.8.22",
  "schemars 0.9.0",
  "schemars 1.0.4",
- "serde",
- "serde_derive",
+ "serde_core",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -5164,14 +5167,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5196,7 +5199,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5358,12 +5361,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5375,7 +5378,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5547,7 +5550,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5556,8 +5559,9 @@ version = "26.1.0"
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2272e9ee6f44cae1f3fe38b16f83e37ae6b55d002ecd7cbd45e02fde277c5a0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5569,8 +5573,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4cf66a6ec501ca3bb6018e36d3293ffbcd9b83651d8ae5afa03a4c8dd02fd1"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5592,10 +5597,11 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ecdb16404a2a973c88193ccbfe519aa44b02cd2ff838dd61ce49117a2537c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck 0.5.0",
  "itertools 0.13.0",
  "macro-string",
@@ -5606,13 +5612,14 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85665c21947b7e9fff81a8e81c866e2e774040039856f75af9cb06ec75191c8"
 dependencies = [
  "base64 0.22.1",
  "sha2 0.10.9",
@@ -5623,8 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb924883f555ca020951e861025d153657481e0a88dddec9f853e2aad76ddc9"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5632,7 +5640,7 @@ dependencies = [
  "sha2 0.10.9",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.106",
+ "syn 2.0.118",
  "thiserror 1.0.69",
 ]
 
@@ -5721,16 +5729,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6be88fe99c858b5d79411a0a4b51b0f5fafca1b82b5fcb651bada1e2f52d190"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "407dbf1edb3935637eb348945a9a756696a5dda1d4084735fbdeb5c8177bcc03"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5779,8 +5789,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "26.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?branch=main#afa3fb93ad15c332326920acdbe330b8998b41c5"
+version = "27.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ec90d05795ccf631203555c775765916aca130c41521c403532d687444ad7"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5833,12 +5844,13 @@ dependencies = [
 
 [[package]]
 name = "stellar-rpc-client"
-version = "26.0.0"
-source = "git+https://github.com/stellar/rs-stellar-rpc-client?branch=main#301106b508fad329d0915b85d3e8c461dbf1b718"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b65ae2e8788c09fba690afa3b589094fd67ff4d7d5ec4502ec4f2d7d870576"
 dependencies = [
  "clap",
  "hex",
- "http 1.4.0",
+ "http 1.4.2",
  "itertools 0.10.5",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -5932,7 +5944,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5943,7 +5955,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5999,7 +6011,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6021,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6047,7 +6059,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6156,7 +6168,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6167,7 +6179,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "test-case-core",
 ]
 
@@ -6250,7 +6262,7 @@ dependencies = [
  "etcetera",
  "ferroid",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "itertools 0.14.0",
  "log",
  "memchr",
@@ -6292,7 +6304,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6303,7 +6315,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6419,33 +6431,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6545,7 +6554,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
@@ -6553,7 +6562,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -6602,7 +6611,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
@@ -6654,7 +6663,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6814,7 +6823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -6892,7 +6901,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6986,7 +6995,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -7021,7 +7030,7 @@ checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7313,7 +7322,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7324,7 +7333,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7710,7 +7719,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.11.0",
  "prettyplease",
- "syn 2.0.106",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7726,7 +7735,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7849,7 +7858,7 @@ checksum = "c9c5a56d688dd492c201011c19933a9d0e64452d3763bc88624dde91fff37164"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7878,7 +7887,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7923,7 +7932,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "zvariant_utils",
 ]
 
@@ -7955,7 +7964,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7975,7 +7984,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7996,7 +8005,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8029,8 +8038,14 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
@@ -8054,7 +8069,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "zvariant_utils",
 ]
 
@@ -8066,5 +8081,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,34 +44,41 @@ path = "cmd/crates/stellar-ledger"
 
 # Dependencies from the rs-stellar-xdr repo:
 [workspace.dependencies.stellar-xdr]
-version = "26.0.1"
+version = "27.0.0"
 
-# Dependencies from the rs-soroban-sdk repo:
+# Dependencies from the rs-soroban-sdk repo (main branch until the p27 release):
 [workspace.dependencies.soroban-spec]
-version = "26.0.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+branch = "main"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "26.0.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+branch = "main"
 
 [workspace.dependencies.soroban-sdk]
-version = "26.0.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+branch = "main"
 
 [workspace.dependencies.soroban-env-host]
-version = "26.1.3"
+version = "27.0.0"
 
 [workspace.dependencies.soroban-token-sdk]
-version = "26.0.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+branch = "main"
 
 [workspace.dependencies.stellar-asset-spec]
-version = "26.0.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+branch = "main"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "26.0.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+branch = "main"
 
-# Dependencies from the rs-stellar-rpc-client repo:
+# Dependencies from the rs-stellar-rpc-client repo (main branch until the p27 release):
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-version = "26.0.0"
+git = "https://github.com/stellar/rs-stellar-rpc-client"
+branch = "main"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,39 +46,33 @@ path = "cmd/crates/stellar-ledger"
 [workspace.dependencies.stellar-xdr]
 version = "27.0.0"
 
-# Dependencies from the rs-soroban-sdk repo (main branch until the p27 release):
-[workspace.dependencies.soroban-spec]
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "main"
-
-[workspace.dependencies.soroban-spec-rust]
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "main"
-
-[workspace.dependencies.soroban-sdk]
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "main"
-
+# Dependencies from the rs-stellar-env repo:
 [workspace.dependencies.soroban-env-host]
 version = "27.0.0"
 
+# Dependencies from the rs-soroban-sdk repo:
+[workspace.dependencies.soroban-spec]
+version = "27.0.0-rc.1"
+
+[workspace.dependencies.soroban-spec-rust]
+version = "27.0.0-rc.1"
+
+[workspace.dependencies.soroban-sdk]
+version = "27.0.0-rc.1"
+
 [workspace.dependencies.soroban-token-sdk]
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "main"
+version = "27.0.0-rc.1"
 
 [workspace.dependencies.stellar-asset-spec]
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "main"
+version = "27.0.0-rc.1"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-git = "https://github.com/stellar/rs-soroban-sdk"
-branch = "main"
+version = "27.0.0-rc.1"
 
-# Dependencies from the rs-stellar-rpc-client repo (main branch until the p27 release):
+# Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-git = "https://github.com/stellar/rs-stellar-rpc-client"
-branch = "main"
+version = "27.0.0"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]

--- a/cmd/crates/soroban-spec-tools/Cargo.toml
+++ b/cmd/crates/soroban-spec-tools/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["rlib"]
 [dependencies]
 soroban-spec = { workspace = true }
 stellar-strkey = { workspace = true }
-stellar-xdr = { workspace = true, features = ["curr", "std", "serde", "base64"] }
+stellar-xdr = { workspace = true, features = ["std", "serde", "base64"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 itertools = { workspace = true }

--- a/cmd/crates/soroban-spec-tools/src/contract.rs
+++ b/cmd/crates/soroban-spec-tools/src/contract.rs
@@ -4,7 +4,7 @@ use std::{
     io::{self, Cursor},
 };
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     self as xdr, Limited, Limits, ReadXdr, ScEnvMetaEntry, ScEnvMetaEntryInterfaceVersion,
     ScMetaEntry, ScMetaV0, ScSpecEntry, ScSpecFunctionV0, ScSpecUdtEnumV0, ScSpecUdtErrorEnumV0,
     ScSpecUdtStructV0, ScSpecUdtUnionV0, StringM, WriteXdr,

--- a/cmd/crates/soroban-spec-tools/src/contract.rs
+++ b/cmd/crates/soroban-spec-tools/src/contract.rs
@@ -220,7 +220,7 @@ fn write_union(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtUnionV0) -> std::
         )?;
     }
     writeln!(f, "     Cases:")?;
-    for case in udt.cases.iter() {
+    for case in &udt.cases {
         writeln!(f, "      • {}", indent(&format!("{case:#?}"), 8).trim())?;
     }
     writeln!(f)?;
@@ -237,7 +237,7 @@ fn write_struct(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtStructV0) -> std
         )?;
     }
     writeln!(f, "     Fields:")?;
-    for field in udt.fields.iter() {
+    for field in &udt.fields {
         writeln!(
             f,
             "      • {}: {}",
@@ -262,7 +262,7 @@ fn write_enum(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtEnumV0) -> std::fm
         )?;
     }
     writeln!(f, "     Cases:")?;
-    for case in udt.cases.iter() {
+    for case in &udt.cases {
         writeln!(f, "      • {}", indent(&format!("{case:#?}"), 8).trim())?;
     }
     writeln!(f)?;
@@ -279,7 +279,7 @@ fn write_error(f: &mut std::fmt::Formatter<'_>, udt: &ScSpecUdtErrorEnumV0) -> s
         )?;
     }
     writeln!(f, "     Cases:")?;
-    for case in udt.cases.iter() {
+    for case in &udt.cases {
         writeln!(f, "      • {}", indent(&format!("{case:#?}"), 8).trim())?;
     }
     writeln!(f)?;

--- a/cmd/crates/soroban-spec-tools/src/event.rs
+++ b/cmd/crates/soroban-spec-tools/src/event.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use serde::Serialize;
 use serde_json::Value;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ScSpecEventDataFormat, ScSpecEventParamLocationV0, ScSpecEventParamV0, ScSpecEventV0, ScSymbol,
     ScVal,
 };
@@ -251,7 +251,7 @@ fn extract_data_params(
 mod tests {
     use super::*;
     use serde_json::json;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Int128Parts, ScMap, ScMapEntry, ScSpecEntry, ScSpecTypeDef, ScString, ScVec, StringM, VecM,
     };
 

--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use itertools::Itertools;
 use serde_json::{json, Value};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, BytesM, ContractExecutable, ContractId, Error as XdrError, Hash, Int128Parts,
     Int256Parts, MuxedEd25519Account, PublicKey, ScAddress, ScBytes, ScContractInstance, ScMap,
     ScMapEntry, ScNonceKey, ScSpecEntry, ScSpecEventV0, ScSpecFunctionV0, ScSpecTypeDef as ScType,
@@ -1480,7 +1480,7 @@ impl Spec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{Duration, ScMap, ScSpecTypeBytesN, TimePoint};
+    use stellar_xdr::{Duration, ScMap, ScSpecTypeBytesN, TimePoint};
 
     const CUSTOM_TYPES_WASM: &[u8] =
         include_bytes!("../../../../target/wasm32v1-none/test-wasms/test_custom_types.wasm");
@@ -2331,7 +2331,7 @@ mod tests {
             name: ScSymbol(name.try_into().unwrap()),
             prefix_topics: VecM::default(),
             params: VecM::default(),
-            data_format: stellar_xdr::curr::ScSpecEventDataFormat::SingleValue,
+            data_format: stellar_xdr::ScSpecEventDataFormat::SingleValue,
         }
     }
 

--- a/cmd/crates/soroban-spec-tools/src/verify.rs
+++ b/cmd/crates/soroban-spec-tools/src/verify.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ScSpecEntry, ScSpecTypeDef as ScType, ScSpecTypeUdt, ScSpecUdtUnionCaseTupleV0,
     ScSpecUdtUnionCaseV0,
 };
@@ -215,7 +215,7 @@ fn collect_udt_names(type_def: &ScType) -> Vec<String> {
 mod tests {
     use std::str::FromStr;
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ScSpecEntry, ScSpecFunctionV0, ScSpecTypeDef as ScType, ScSpecTypeMap, ScSpecTypeOption,
         ScSpecTypeUdt, ScSpecTypeVec, ScSpecUdtStructV0, ScSymbol, StringM,
     };
@@ -237,7 +237,7 @@ mod tests {
             name: StringM::from_str(name).unwrap(),
             fields: field_types
                 .into_iter()
-                .map(|(fname, ftype)| stellar_xdr::curr::ScSpecUdtStructFieldV0 {
+                .map(|(fname, ftype)| stellar_xdr::ScSpecUdtStructFieldV0 {
                     doc: StringM::default(),
                     name: StringM::from_str(fname).unwrap(),
                     type_: ftype,
@@ -254,7 +254,7 @@ mod tests {
             name: ScSymbol(name.try_into().unwrap()),
             inputs: inputs
                 .into_iter()
-                .map(|(n, t)| stellar_xdr::curr::ScSpecFunctionInputV0 {
+                .map(|(n, t)| stellar_xdr::ScSpecFunctionInputV0 {
                     doc: StringM::default(),
                     name: StringM::from_str(n).unwrap(),
                     type_: t,

--- a/cmd/crates/soroban-spec-tools/src/verify.rs
+++ b/cmd/crates/soroban-spec-tools/src/verify.rs
@@ -124,7 +124,7 @@ fn find_undefined_types(
     match entry {
         ScSpecEntry::FunctionV0(f) => {
             let fn_name = f.name.to_utf8_string_lossy();
-            for input in f.inputs.iter() {
+            for input in &f.inputs {
                 let input_name = input.name.to_utf8_string_lossy();
                 check_type(
                     &format!("function '{fn_name}' input '{input_name}'"),
@@ -133,7 +133,7 @@ fn find_undefined_types(
                     warnings,
                 );
             }
-            for output in f.outputs.iter() {
+            for output in &f.outputs {
                 check_type(
                     &format!("function '{fn_name}' output"),
                     output,
@@ -144,7 +144,7 @@ fn find_undefined_types(
         }
         ScSpecEntry::EventV0(e) => {
             let event_name = e.name.to_utf8_string_lossy();
-            for param in e.params.iter() {
+            for param in &e.params {
                 let param_name = param.name.to_utf8_string_lossy();
                 check_type(
                     &format!("event '{event_name}' param '{param_name}'"),
@@ -156,7 +156,7 @@ fn find_undefined_types(
         }
         ScSpecEntry::UdtStructV0(s) => {
             let struct_name = s.name.to_utf8_string_lossy();
-            for field in s.fields.iter() {
+            for field in &s.fields {
                 let field_name = field.name.to_utf8_string_lossy();
                 check_type(
                     &format!("struct '{struct_name}' field '{field_name}'"),
@@ -168,7 +168,7 @@ fn find_undefined_types(
         }
         ScSpecEntry::UdtUnionV0(u) => {
             let union_name = u.name.to_utf8_string_lossy();
-            for case in u.cases.iter() {
+            for case in &u.cases {
                 if let ScSpecUdtUnionCaseV0::TupleV0(ScSpecUdtUnionCaseTupleV0 {
                     name,
                     type_,
@@ -176,7 +176,7 @@ fn find_undefined_types(
                 }) = case
                 {
                     let case_name = name.to_utf8_string_lossy();
-                    for t in type_.iter() {
+                    for t in type_ {
                         check_type(
                             &format!("union '{union_name}' case '{case_name}'"),
                             t,

--- a/cmd/crates/soroban-spec-typescript/Cargo.toml
+++ b/cmd/crates/soroban-spec-typescript/Cargo.toml
@@ -25,7 +25,7 @@ base64 = { workspace = true }
 
 [dependencies.stellar-xdr]
 workspace = true
-features = ["curr", "std", "serde", "base64"]
+features = ["std", "serde", "base64"]
 
 [dev-dependencies]
 temp-dir = "0.1.11"

--- a/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
+++ b/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
@@ -213,7 +213,7 @@ mod test {
     // TODO : fix the test below :
     // the test below should verify only a certain subset of the files were copied
     // rather then the entire directory.
-    #[ignore]
+    #[ignore = "compares the entire output directory; needs narrowing to the copied subset (see TODO above)"]
     #[test]
     fn test_project_dir_location() {
         // TODO: Ensure windows support
@@ -226,7 +226,7 @@ mod test {
         assert_dirs_equal(temp_dir.path(), &fixture);
     }
 
-    #[ignore]
+    #[ignore = "regenerates the ts snapshot fixtures; run manually"]
     #[test]
     fn build_package() {
         let root = PathBuf::from("./fixtures/ts");
@@ -329,7 +329,6 @@ mod test {
                 let content2 = fs::read_to_string(path2).unwrap();
                 pretty_assertions::assert_eq!(content1, content2, "{:?} != {:?}", path1, path2);
             } else if path1.is_dir() && path2.is_dir() {
-                continue;
             } else {
                 panic!(
                     "{:?} is not a file",

--- a/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
+++ b/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
@@ -6,7 +6,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
-use stellar_xdr::curr::ScSpecEntry;
+use stellar_xdr::ScSpecEntry;
 
 use super::{generate, sanitize_string, validate_npm_package_name};
 

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -9,7 +9,7 @@ use std::{fs, io};
 use crate::types::Type;
 use itertools::Itertools;
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{Limits, ScSpecEntry, WriteXdr};
+use stellar_xdr::{Limits, ScSpecEntry, WriteXdr};
 
 use types::{Entry, ErrorEnumCase};
 
@@ -25,7 +25,7 @@ pub enum GenerateFromFileError {
     #[error("sha256 does not match, expected: {expected}")]
     VerifySha256 { expected: String },
     #[error("parsing contract spec: {0}")]
-    Parse(stellar_xdr::curr::Error),
+    Parse(stellar_xdr::Error),
     #[error("getting contract spec: {0}")]
     GetSpec(FromWasmError),
 }

--- a/cmd/crates/soroban-spec-typescript/src/types.rs
+++ b/cmd/crates/soroban-spec-typescript/src/types.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ScSpecEntry, ScSpecFunctionInputV0, ScSpecTypeDef, ScSpecUdtEnumCaseV0,
     ScSpecUdtErrorEnumCaseV0, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseV0,
 };

--- a/cmd/crates/stellar-ledger/Cargo.toml
+++ b/cmd/crates/stellar-ledger/Cargo.toml
@@ -33,7 +33,7 @@ testcontainers = { workspace = true, optional = true }
 
 [dependencies.stellar-xdr]
 workspace = true
-features = ["curr", "std", "serde"]
+features = ["std", "serde"]
 
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/cmd/crates/stellar-ledger/src/emulator_test_support/util.rs
+++ b/cmd/crates/stellar-ledger/src/emulator_test_support/util.rs
@@ -10,7 +10,7 @@ use super::{http_transport::Emulator, speculos::Speculos};
 
 use std::{collections::HashMap, time::Duration};
 
-use stellar_xdr::curr::Hash;
+use stellar_xdr::Hash;
 
 use testcontainers::{core::ContainerPort, runners::AsyncRunner, ContainerAsync, ImageExt};
 use tokio::time::sleep;

--- a/cmd/crates/stellar-ledger/src/lib.rs
+++ b/cmd/crates/stellar-ledger/src/lib.rs
@@ -11,7 +11,7 @@ pub use ledger_transport_hid::TransportNativeHID;
 
 use std::vec;
 use stellar_strkey::DecodeError;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     self as xdr, Hash, Limits, Transaction, TransactionSignaturePayload,
     TransactionSignaturePayloadTaggedTransaction, WriteXdr,
 };
@@ -345,7 +345,7 @@ mod test {
 
     use crate::{test_network_hash, Error, LedgerSigner};
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Memo, MuxedAccount, PaymentOp, Preconditions, SequenceNumber, TransactionExt,
     };
 

--- a/cmd/crates/stellar-ledger/tests/test/emulator_tests.rs
+++ b/cmd/crates/stellar-ledger/tests/test/emulator_tests.rs
@@ -3,7 +3,7 @@ use stellar_ledger::{Blob, Error};
 
 use std::sync::Arc;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     self as xdr, Memo, MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions,
     SequenceNumber, Transaction, TransactionExt, Uint256,
 };

--- a/cmd/soroban-cli/src/assembled.rs
+++ b/cmd/soroban-cli/src/assembled.rs
@@ -1,5 +1,5 @@
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     self as xdr, Hash, LedgerFootprint, Limits, OperationBody, ReadXdr, SorobanAuthorizationEntry,
     SorobanAuthorizedFunction, SorobanResources, SorobanTransactionData, Transaction,
     TransactionEnvelope, TransactionExt, TransactionSignaturePayload,
@@ -287,7 +287,7 @@ mod tests {
 
     use soroban_rpc::SimulateHostFunctionResultRaw;
     use stellar_strkey::ed25519::PublicKey as Ed25519PublicKey;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, ChangeTrustAsset, ChangeTrustOp, Hash, HostFunction, InvokeContractArgs,
         InvokeHostFunctionOp, LedgerFootprint, Memo, MuxedAccount, Operation, Preconditions,
         PublicKey, ScAddress, ScSymbol, ScVal, SequenceNumber, SorobanAuthorizedFunction,
@@ -325,7 +325,7 @@ mod tests {
             }),
             root_invocation: SorobanAuthorizedInvocation {
                 function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
-                    contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(
+                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(
                         [0; 32],
                     ))),
                     function_name: ScSymbol("fn".try_into().unwrap()),
@@ -359,7 +359,7 @@ mod tests {
                 source_account: None,
                 body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
                     host_function: HostFunction::InvokeContract(InvokeContractArgs {
-                        contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(
+                        contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(
                             [0x0; 32],
                         ))),
                         function_name: ScSymbol::default(),

--- a/cmd/soroban-cli/src/assembled.rs
+++ b/cmd/soroban-cli/src/assembled.rs
@@ -325,9 +325,7 @@ mod tests {
             }),
             root_invocation: SorobanAuthorizedInvocation {
                 function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
-                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(
-                        [0; 32],
-                    ))),
+                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash([0; 32]))),
                     function_name: ScSymbol("fn".try_into().unwrap()),
                     args: VecM::default(),
                 }),

--- a/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
+++ b/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
@@ -17,7 +17,7 @@ use std::env;
 use std::ffi::OsString;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use stellar_xdr::curr::ContractId;
+use stellar_xdr::ContractId;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -204,7 +204,7 @@ fn parse_function_arguments(
 }
 
 fn parse_single_argument(
-    input: &stellar_xdr::curr::ScSpecFunctionInputV0,
+    input: &stellar_xdr::ScSpecFunctionInputV0,
     matches_: &clap::ArgMatches,
     spec: &Spec,
     config: &config::Args,
@@ -451,9 +451,9 @@ fn resolve_address(addr_or_alias: &str, config: &config::Args) -> Result<String,
             match addr {
                 xdr::ScAddress::Account(account) => account.to_string(),
                 contract @ xdr::ScAddress::Contract(_) => contract.to_string(),
-                stellar_xdr::curr::ScAddress::MuxedAccount(account) => account.to_string(),
-                stellar_xdr::curr::ScAddress::ClaimableBalance(_)
-                | stellar_xdr::curr::ScAddress::LiquidityPool(_) => {
+                stellar_xdr::ScAddress::MuxedAccount(account) => account.to_string(),
+                stellar_xdr::ScAddress::ClaimableBalance(_)
+                | stellar_xdr::ScAddress::LiquidityPool(_) => {
                     return Err(Error::UnsupportedScAddress {
                         address: addr.to_string(),
                     })
@@ -772,7 +772,7 @@ fn resolve_aliases_in_json(
 
 fn resolve_aliases_in_udt(
     value: &mut serde_json::Value,
-    udt: &stellar_xdr::curr::ScSpecTypeUdt,
+    udt: &stellar_xdr::ScSpecTypeUdt,
     spec: &Spec,
     config: &config::Args,
 ) -> Result<bool, Error> {
@@ -818,11 +818,11 @@ fn resolve_aliases_in_udt(
 
 fn resolve_aliases_in_union(
     value: &mut serde_json::Value,
-    union: &stellar_xdr::curr::ScSpecUdtUnionV0,
+    union: &stellar_xdr::ScSpecUdtUnionV0,
     spec: &Spec,
     config: &config::Args,
 ) -> Result<bool, Error> {
-    use stellar_xdr::curr::ScSpecUdtUnionCaseV0;
+    use stellar_xdr::ScSpecUdtUnionCaseV0;
 
     let serde_json::Value::Object(obj) = value else {
         return Ok(false);
@@ -855,7 +855,7 @@ fn resolve_aliases_in_union(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{ScSpecTypeBytesN, ScSpecTypeDef, ScSpecTypeOption, ScSpecTypeVec};
+    use stellar_xdr::{ScSpecTypeBytesN, ScSpecTypeDef, ScSpecTypeOption, ScSpecTypeVec};
 
     #[test]
     fn test_get_type_name_primitives() {
@@ -974,7 +974,7 @@ mod tests {
 
     #[test]
     fn test_context_aware_error_messages() {
-        use stellar_xdr::curr::ScSpecTypeDef;
+        use stellar_xdr::ScSpecTypeDef;
 
         // Test context-aware suggestions for different types
 
@@ -1014,7 +1014,7 @@ mod tests {
 
     #[test]
     fn test_union_udt_bare_string_accepted() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecEntry, ScSpecTypeDef, ScSpecTypeUdt, ScSpecUdtUnionCaseV0,
             ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0, StringM,
         };
@@ -1064,7 +1064,7 @@ mod tests {
 
     #[test]
     fn test_union_udt_tuple_variant_still_requires_json() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecEntry, ScSpecTypeDef, ScSpecTypeUdt, ScSpecUdtUnionCaseTupleV0,
             ScSpecUdtUnionCaseV0, ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0, StringM,
         };
@@ -1108,7 +1108,7 @@ mod tests {
 
     #[test]
     fn test_error_message_format() {
-        use stellar_xdr::curr::ScSpecTypeDef;
+        use stellar_xdr::ScSpecTypeDef;
 
         // Test that our CannotParseArg error formats correctly
         let error = Error::CannotParseArg {
@@ -1133,7 +1133,7 @@ mod tests {
     }
 
     fn struct_spec(name: &'static str, fields: &[(&str, ScSpecTypeDef)]) -> (Spec, ScSpecTypeDef) {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecEntry, ScSpecTypeUdt, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM,
         };
         let struct_name: StringM<60> = name.try_into().unwrap();
@@ -1160,7 +1160,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_vec_of_address() {
-        use stellar_xdr::curr::ScSpecTypeVec;
+        use stellar_xdr::ScSpecTypeVec;
 
         let ty = ScSpecTypeDef::Vec(Box::new(ScSpecTypeVec {
             element_type: Box::new(ScSpecTypeDef::Address),
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_tuple() {
-        use stellar_xdr::curr::ScSpecTypeTuple;
+        use stellar_xdr::ScSpecTypeTuple;
 
         let ty = ScSpecTypeDef::Tuple(Box::new(ScSpecTypeTuple {
             value_types: vec![ScSpecTypeDef::Address, ScSpecTypeDef::U32]
@@ -1207,7 +1207,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_struct_field() {
-        use stellar_xdr::curr::ScSpecTypeVec;
+        use stellar_xdr::ScSpecTypeVec;
 
         let (spec, ty) = struct_spec(
             "Operator",
@@ -1241,7 +1241,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_union_tuple_variant() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecEntry, ScSpecTypeUdt, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
             ScSpecUdtUnionV0, StringM,
         };
@@ -1279,7 +1279,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_single_element_union_variant() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ScSpecEntry, ScSpecTypeUdt, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
             ScSpecUdtUnionV0, StringM,
         };
@@ -1316,7 +1316,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_option_and_map() {
-        use stellar_xdr::curr::{ScSpecTypeMap, ScSpecTypeOption};
+        use stellar_xdr::{ScSpecTypeMap, ScSpecTypeOption};
 
         let opt_ty = ScSpecTypeDef::Option(Box::new(ScSpecTypeOption {
             value_type: Box::new(ScSpecTypeDef::Address),
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_result_inner_types() {
-        use stellar_xdr::curr::ScSpecTypeResult;
+        use stellar_xdr::ScSpecTypeResult;
 
         let ty = ScSpecTypeDef::Result(Box::new(ScSpecTypeResult {
             ok_type: Box::new(ScSpecTypeDef::Address),
@@ -1373,7 +1373,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_preserves_input_when_nothing_mutated() {
-        use stellar_xdr::curr::ScSpecTypeVec;
+        use stellar_xdr::ScSpecTypeVec;
 
         // Type with no Address positions: input is returned verbatim,
         // including whitespace that compact JSON re-serialization would drop.
@@ -1402,7 +1402,7 @@ mod tests {
 
     #[test]
     fn resolve_aliases_in_json_walks_map_keys() {
-        use stellar_xdr::curr::ScSpecTypeMap;
+        use stellar_xdr::ScSpecTypeMap;
 
         let map_ty = ScSpecTypeDef::Map(Box::new(ScSpecTypeMap {
             key_type: Box::new(ScSpecTypeDef::Address),

--- a/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
+++ b/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
@@ -196,7 +196,7 @@ fn parse_function_arguments(
     let mut parsed_args = Vec::with_capacity(func.inputs.len());
     let mut signers = Vec::<Signer>::new();
 
-    for i in func.inputs.iter() {
+    for i in &func.inputs {
         parse_single_argument(i, matches_, spec, config, &mut signers, &mut parsed_args)?;
     }
 
@@ -797,7 +797,7 @@ fn resolve_aliases_in_udt(
                     }
                 }
                 serde_json::Value::Object(obj) => {
-                    for field in strukt.fields.iter() {
+                    for field in &strukt.fields {
                         let key = field.name.to_utf8_string_lossy();
                         if let Some(field_val) = obj.get_mut(key.as_str()) {
                             mutated |=

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -15,7 +15,7 @@ use std::{
     path::{self, Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
 };
-use stellar_xdr::curr::{Limited, Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
+use stellar_xdr::{Limited, Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
 #[cfg(feature = "additional-libs")]
 use crate::commands::contract::optimize;
@@ -190,7 +190,7 @@ pub enum Error {
     CargoConfiguration(String),
 
     #[error(transparent)]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     #[cfg(feature = "additional-libs")]
     #[error(transparent)]
@@ -818,7 +818,7 @@ fn check_overflow_checks(doc: &toml_edit::DocumentMut, profile: &str) -> Result<
 /// to a single occurrence.
 #[allow(clippy::implicit_hasher)]
 pub fn filter_and_dedup_spec(
-    entries: Vec<stellar_xdr::curr::ScSpecEntry>,
+    entries: Vec<stellar_xdr::ScSpecEntry>,
     markers: &HashSet<soroban_spec::shaking::Marker>,
 ) -> Result<Vec<u8>, Error> {
     let mut seen = HashSet::new();

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -191,7 +191,7 @@ fn build_wrap_token_tx(
     _network_passphrase: &str,
     source_account: MuxedAccount,
 ) -> Result<Transaction, Error> {
-    let contract = ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(contract_id.0)));
+    let contract = ScAddress::Contract(stellar_xdr::ContractId(Hash(contract_id.0)));
     let mut read_write = vec![
         ContractData(LedgerKeyContractData {
             contract: contract.clone(),

--- a/cmd/soroban-cli/src/commands/contract/info/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/build.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use soroban_spec_tools::contract;
 use soroban_spec_tools::contract::Spec;
 use std::fmt::Debug;
-use stellar_xdr::curr::{ScMetaEntry, ScMetaV0};
+use stellar_xdr::{ScMetaEntry, ScMetaV0};
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]

--- a/cmd/soroban-cli/src/commands/contract/info/meta.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/meta.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use soroban_spec_tools::contract;
 use soroban_spec_tools::contract::Spec;
 use soroban_spec_tools::sanitize;
-use stellar_xdr::curr::{ScMetaEntry, ScMetaV0};
+use stellar_xdr::{ScMetaEntry, ScMetaV0};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Cmd {

--- a/cmd/soroban-cli/src/commands/contract/info/shared.rs
+++ b/cmd/soroban-cli/src/commands/contract/info/shared.rs
@@ -12,7 +12,7 @@ use crate::{
     xdr,
 };
 
-use stellar_xdr::curr::ContractId;
+use stellar_xdr::ContractId;
 
 #[derive(Debug, clap::Args, Clone, Default)]
 #[command(group(

--- a/cmd/soroban-cli/src/commands/doctor.rs
+++ b/cmd/soroban-cli/src/commands/doctor.rs
@@ -81,7 +81,7 @@ fn show_data_path(print: &Print) -> Result<(), Error> {
 fn show_xdr_version(print: &Print) {
     let xdr = stellar_xdr::VERSION;
 
-    print.infoln(format!("XDR version: {}", xdr.xdr_curr));
+    print.infoln(format!("XDR version: {}", xdr.xdr));
 }
 
 async fn print_network(

--- a/cmd/soroban-cli/src/commands/ledger/entry/fetch/contract_data.rs
+++ b/cmd/soroban-cli/src/commands/ledger/entry/fetch/contract_data.rs
@@ -45,7 +45,7 @@ pub enum Error {
     #[error(transparent)]
     Spec(#[from] soroban_spec_tools::Error),
     #[error(transparent)]
-    StellarXdr(#[from] stellar_xdr::curr::Error),
+    StellarXdr(#[from] stellar_xdr::Error),
 }
 
 impl Cmd {

--- a/cmd/soroban-cli/src/commands/network/settings.rs
+++ b/cmd/soroban-cli/src/commands/network/settings.rs
@@ -2,7 +2,7 @@ use crate::config::network;
 use crate::print::Print;
 use crate::{commands::global, config};
 use semver::Version;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ConfigSettingId, ConfigUpgradeSet, LedgerEntryData, LedgerKey, LedgerKeyConfigSetting, Limits,
     WriteXdr as _,
 };
@@ -14,7 +14,7 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] network::Error),
     #[error(transparent)]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error(transparent)]

--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -14,7 +14,7 @@ use std::{
     str::FromStr,
     time::{Duration, Instant},
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     self as xdr, AccountId, Asset, BucketEntry, ConfigSettingEntry, ContractExecutable, Frame,
     Hash, LedgerEntryData, LedgerHeaderHistoryEntry, LedgerKey, Limited, Limits, ReadXdr,
     ScAddress, ScContractInstance, ScVal,
@@ -498,7 +498,7 @@ impl Cmd {
     // C-address or a contract alias.
     fn resolve_contract(&self, address: &str, network_passphrase: &str) -> Option<ScAddress> {
         address.parse().ok().or_else(|| {
-            Some(ScAddress::Contract(stellar_xdr::curr::ContractId(
+            Some(ScAddress::Contract(stellar_xdr::ContractId(
                 self.locator
                     .resolve_contract_id(address, network_passphrase)
                     .ok()?

--- a/cmd/soroban-cli/src/commands/snapshot/merge.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/merge.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use soroban_ledger_snapshot::LedgerSnapshot;
 use std::{collections::HashMap, path::PathBuf};
-use stellar_xdr::curr::LedgerKey;
+use stellar_xdr::LedgerKey;
 
 use crate::{commands::global, print};
 
@@ -21,7 +21,7 @@ fn merge_snapshots(snapshots: Vec<LedgerSnapshot>) -> LedgerSnapshot {
     let max_entry_ttl = last_snapshot.max_entry_ttl;
 
     // Use a HashMap to track entries by key, with last-wins semantics
-    let mut merged_entries: HashMap<LedgerKey, (Box<stellar_xdr::curr::LedgerEntry>, Option<u32>)> =
+    let mut merged_entries: HashMap<LedgerKey, (Box<stellar_xdr::LedgerEntry>, Option<u32>)> =
         HashMap::new();
 
     // Iterate through snapshots in order, so later entries override earlier ones

--- a/cmd/soroban-cli/src/commands/tx/decode.rs
+++ b/cmd/soroban-cli/src/commands/tx/decode.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use std::ffi::OsString;
-use stellar_xdr::{cli::Channel, curr::TypeVariant};
+use stellar_xdr::TypeVariant;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -62,7 +62,7 @@ impl Cmd {
             input_format: self.input_format.into(),
             output_format: self.output_format.into(),
         };
-        cmd.run(&Channel::Curr)?;
+        cmd.run()?;
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/edit.rs
+++ b/cmd/soroban-cli/src/commands/tx/edit.rs
@@ -9,7 +9,6 @@ use std::{
 use tempfile::TempDir;
 
 use serde_json::json;
-use stellar_xdr::curr;
 
 use crate::{commands::global, print::Print};
 
@@ -24,7 +23,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
-    StellarXdr(#[from] stellar_xdr::curr::Error),
+    StellarXdr(#[from] stellar_xdr::Error),
 
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
@@ -51,7 +50,7 @@ impl Cmd {
             let mut input = String::new();
             stdin().read_line(&mut input)?;
             let input = input.trim();
-            xdr_to_json::<curr::TransactionEnvelope>(input)?
+            xdr_to_json::<stellar_xdr::TransactionEnvelope>(input)?
         };
 
         let (_temp_dir, path) = tmp_file(&json)?;
@@ -61,7 +60,7 @@ impl Cmd {
         open_editor(&print, &editor, &path)?;
 
         let contents = fs::read_to_string(&path)?;
-        let xdr = json_to_xdr::<curr::TransactionEnvelope>(&contents)?;
+        let xdr = json_to_xdr::<stellar_xdr::TransactionEnvelope>(&contents)?;
 
         println!("{xdr}");
 
@@ -149,9 +148,9 @@ fn open_editor(print: &Print, editor: &Editor, path: &PathBuf) -> Result<(), Err
 
 fn xdr_to_json<T>(xdr_string: &str) -> Result<String, Error>
 where
-    T: curr::ReadXdr + serde::Serialize,
+    T: stellar_xdr::ReadXdr + serde::Serialize,
 {
-    let tx = T::from_xdr_base64(xdr_string, curr::Limits::none())?;
+    let tx = T::from_xdr_base64(xdr_string, stellar_xdr::Limits::none())?;
     let mut schema: serde_json::Value = serde_json::to_value(tx)?;
     schema["$schema"] = json!(schema_url());
     let json = serde_json::to_string_pretty(&schema)?;
@@ -161,7 +160,7 @@ where
 
 fn json_to_xdr<T>(json_string: &str) -> Result<String, Error>
 where
-    T: serde::de::DeserializeOwned + curr::WriteXdr,
+    T: serde::de::DeserializeOwned + stellar_xdr::WriteXdr,
 {
     let mut schema: serde_json::Value = serde_json::from_str(json_string)?;
 
@@ -174,10 +173,10 @@ where
     let value: T = serde_json::from_str(json_string.as_str())?;
     let mut data = Vec::new();
     let cursor = Cursor::new(&mut data);
-    let mut limit = curr::Limited::new(cursor, curr::Limits::none());
+    let mut limit = stellar_xdr::Limited::new(cursor, stellar_xdr::Limits::none());
     value.write_xdr(&mut limit)?;
 
-    Ok(value.to_xdr_base64(curr::Limits::none())?)
+    Ok(value.to_xdr_base64(stellar_xdr::Limits::none())?)
 }
 
 fn default_json() -> String {

--- a/cmd/soroban-cli/src/commands/tx/encode.rs
+++ b/cmd/soroban-cli/src/commands/tx/encode.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use std::ffi::OsString;
-use stellar_xdr::{cli::Channel, curr::TypeVariant};
+use stellar_xdr::TypeVariant;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -60,7 +60,7 @@ impl Cmd {
             input_format: self.input_format.into(),
             output_format: self.output_format.into(),
         };
-        cmd.run(&Channel::Curr)?;
+        cmd.run()?;
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/send.rs
+++ b/cmd/soroban-cli/src/commands/tx/send.rs
@@ -7,8 +7,6 @@ use crate::{
     config::{self, locator, network},
 };
 
-use stellar_xdr::curr;
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -22,7 +20,7 @@ pub enum Error {
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error("xdr processing error: {0}")]
-    Xdr(#[from] curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 }
 
 #[derive(Debug, clap::Parser, Clone)]

--- a/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
+++ b/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
@@ -1,4 +1,4 @@
-use stellar_xdr::curr::MuxedAccount;
+use stellar_xdr::MuxedAccount;
 
 use crate::{
     commands::{

--- a/cmd/soroban-cli/src/commands/tx/xdr.rs
+++ b/cmd/soroban-cli/src/commands/tx/xdr.rs
@@ -6,12 +6,12 @@ use std::fs::File;
 use std::io::{stdin, Read};
 use std::io::{Cursor, IsTerminal};
 use std::path::Path;
-use stellar_xdr::curr::Limited;
+use stellar_xdr::Limited;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to decode XDR: {0}")]
-    XDRDecode(#[from] stellar_xdr::curr::Error),
+    XDRDecode(#[from] stellar_xdr::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("only transaction v1 is supported")]

--- a/cmd/soroban-cli/src/commands/version.rs
+++ b/cmd/soroban-cli/src/commands/version.rs
@@ -54,8 +54,8 @@ pub fn long() -> String {
         format!("{}{git_rev}", pkg()),
         format!(
             "stellar-xdr {} ({})
-xdr curr ({})",
-            xdr.pkg, xdr.rev, xdr.xdr_curr,
+xdr ({})",
+            xdr.pkg, xdr.rev, xdr.xdr,
         ),
     ]
     .join("\n")

--- a/cmd/soroban-cli/src/config/sc_address.rs
+++ b/cmd/soroban-cli/src/config/sc_address.rs
@@ -57,11 +57,11 @@ impl UnresolvedScAddress {
                 eprintln!(
                     "Warning: ScAddress alias {alias} is ambiguous, assuming it is a contract"
                 );
-                Ok(xdr::ScAddress::Contract(stellar_xdr::curr::ContractId(
+                Ok(xdr::ScAddress::Contract(stellar_xdr::ContractId(
                     xdr::Hash(contract.0),
                 )))
             }
-            (Ok(contract), _) => Ok(xdr::ScAddress::Contract(stellar_xdr::curr::ContractId(
+            (Ok(contract), _) => Ok(xdr::ScAddress::Contract(stellar_xdr::ContractId(
                 xdr::Hash(contract.0),
             ))),
             (_, Ok(key)) => Ok(xdr::ScAddress::Account(

--- a/cmd/soroban-cli/src/key.rs
+++ b/cmd/soroban-cli/src/key.rs
@@ -106,7 +106,7 @@ impl Args {
             .into_iter()
             .map(|key| {
                 LedgerKey::ContractData(LedgerKeyContractData {
-                    contract: ScAddress::Contract(stellar_xdr::curr::ContractId(xdr::Hash(
+                    contract: ScAddress::Contract(stellar_xdr::ContractId(xdr::Hash(
                         contract.0,
                     ))),
                     durability: (&self.durability).into(),

--- a/cmd/soroban-cli/src/key.rs
+++ b/cmd/soroban-cli/src/key.rs
@@ -106,9 +106,7 @@ impl Args {
             .into_iter()
             .map(|key| {
                 LedgerKey::ContractData(LedgerKeyContractData {
-                    contract: ScAddress::Contract(stellar_xdr::ContractId(xdr::Hash(
-                        contract.0,
-                    ))),
+                    contract: ScAddress::Contract(stellar_xdr::ContractId(xdr::Hash(contract.0))),
                     durability: (&self.durability).into(),
                     key,
                 })

--- a/cmd/soroban-cli/src/lib.rs
+++ b/cmd/soroban-cli/src/lib.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 pub(crate) use soroban_rpc as rpc;
-pub use stellar_xdr::curr as xdr;
+pub use stellar_xdr as xdr;
 
 mod cli;
 pub use cli::main;

--- a/cmd/soroban-cli/src/log/auth.rs
+++ b/cmd/soroban-cli/src/log/auth.rs
@@ -12,8 +12,15 @@ pub fn format_auth_entry(entry: &SorobanAuthorizationEntry) -> String {
     let mut result = String::from("  Auth Entry:\n");
 
     match &entry.credentials {
-        SorobanCredentials::Address(creds) => {
+        SorobanCredentials::Address(creds) | SorobanCredentials::AddressV2(creds) => {
             let _ = writeln!(result, "    Signer: {}", format_address(&creds.address));
+        }
+        SorobanCredentials::AddressWithDelegates(creds) => {
+            let _ = writeln!(
+                result,
+                "    Signer: {}",
+                format_address(&creds.address_credentials.address)
+            );
         }
         SorobanCredentials::SourceAccount => {
             result.push_str("    Signer: <source account>\n");
@@ -147,7 +154,7 @@ fn format_address(address: &ScAddress) -> String {
                 ))
             )
         }
-        ScAddress::Contract(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(bytes))) => {
+        ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash(bytes))) => {
             format!(
                 "{}",
                 stellar_strkey::Strkey::Contract(stellar_strkey::Contract(*bytes))

--- a/cmd/soroban-cli/src/log/auth.rs
+++ b/cmd/soroban-cli/src/log/auth.rs
@@ -59,7 +59,7 @@ fn format_invocation(
             let _ = writeln!(result, "{prefix}  Fn: {fn_name}");
             if !args.is_empty() {
                 let _ = writeln!(result, "{prefix}  Args:");
-                for arg in args.iter() {
+                for arg in args {
                     let _ = writeln!(
                         result,
                         "{prefix}    {}",
@@ -132,7 +132,7 @@ fn format_create_contract(
     if let Some(args) = constructor_args {
         if !args.is_empty() {
             let _ = writeln!(result, "{prefix}    Constructor Args:");
-            for arg in args.iter() {
+            for arg in args {
                 let _ = writeln!(
                     result,
                     "{prefix}      {}",

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -68,6 +68,7 @@ pub enum Error {
 ///
 /// If a SorobanAuthorizationEntry needs signing, but a signature cannot be produced for it,
 /// return an Error
+#[allow(clippy::too_many_lines)]
 pub async fn sign_soroban_authorizations(
     raw: &Transaction,
     signers: &[Signer],

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -255,7 +255,8 @@ async fn sign_soroban_authorization_entry(
     let (credentials, is_v2) = match &mut auth.credentials {
         SorobanCredentials::Address(credentials) => (credentials, false),
         SorobanCredentials::AddressV2(credentials) => (credentials, true),
-        // Doesn't need special signing (SourceAccount / AddressWithDelegates).
+        // SourceAccount does not need special signing
+        // AddressWithDelegates is not supported yet, and a warning is emitted earlier
         _ => return Ok(auth),
     };
 

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -91,15 +91,21 @@ pub async fn sign_soroban_authorizations(
     let mut auths_modified = false;
     let mut signed_auths = Vec::with_capacity(body.auth.len());
     for raw_auth in body.auth.as_slice() {
-        let SorobanAuthorizationEntry {
-            credentials:
-                SorobanCredentials::Address(credentials) | SorobanCredentials::AddressV2(credentials),
-            ..
-        } = raw_auth
-        else {
-            // Doesn't need special signing (SourceAccount / AddressWithDelegates)
-            signed_auths.push(raw_auth.clone());
-            continue;
+        let credentials = match &raw_auth.credentials {
+            SorobanCredentials::Address(credentials)
+            | SorobanCredentials::AddressV2(credentials) => credentials,
+            SorobanCredentials::AddressWithDelegates(_) => {
+                print.warnln(
+                    "Skipping auth entry with delegated signers: not supported yet; entry left unsigned.",
+                );
+                signed_auths.push(raw_auth.clone());
+                continue;
+            }
+            // Source account is authorized by the transaction signature itself; nothing to sign here.
+            SorobanCredentials::SourceAccount => {
+                signed_auths.push(raw_auth.clone());
+                continue;
+            }
         };
         let SorobanAddressCredentials { address, .. } = credentials;
 

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -122,7 +122,7 @@ pub async fn sign_soroban_authorizations(
             ScAddress::ClaimableBalance(_) => todo!("claimable balance not supported"),
             ScAddress::LiquidityPool(_) => todo!("liquidity pool not supported"),
             ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(ref a)))) => a,
-            ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(c))) => {
+            ScAddress::Contract(stellar_xdr::ContractId(Hash(c))) => {
                 // This address is for a contract. This means we're using a custom
                 // smart-contract account. Currently the CLI doesn't support that yet.
                 return Err(Error::MissingSignerForAddress {
@@ -498,7 +498,7 @@ mod tests {
 
     fn invoke_args(contract: [u8; 32], fn_name: &str) -> InvokeContractArgs {
         InvokeContractArgs {
-            contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(contract))),
+            contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(contract))),
             function_name: ScSymbol(fn_name.try_into().unwrap()),
             args: VecM::default(),
         }

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -4,10 +4,11 @@ use crate::{
     utils::fee_bump_transaction_hash,
     xdr::{
         self, AccountId, DecoratedSignature, FeeBumpTransactionEnvelope, Hash, HashIdPreimage,
-        HashIdPreimageSorobanAuthorization, Limits, MuxedAccount, Operation, OperationBody,
-        PublicKey, ScAddress, ScMap, ScSymbol, ScVal, Signature, SignatureHint,
-        SorobanAddressCredentials, SorobanAuthorizationEntry, SorobanCredentials, Transaction,
-        TransactionEnvelope, TransactionV1Envelope, Uint256, VecM, WriteXdr,
+        HashIdPreimageSorobanAuthorization, HashIdPreimageSorobanAuthorizationWithAddress, Limits,
+        MuxedAccount, Operation, OperationBody, PublicKey, ScAddress, ScMap, ScSymbol, ScVal,
+        Signature, SignatureHint, SorobanAddressCredentials, SorobanAuthorizationEntry,
+        SorobanCredentials, Transaction, TransactionEnvelope, TransactionV1Envelope, Uint256, VecM,
+        WriteXdr,
     },
 };
 use ed25519_dalek::{ed25519::signature::Signer as _, Signature as Ed25519Signature};
@@ -91,11 +92,12 @@ pub async fn sign_soroban_authorizations(
     let mut signed_auths = Vec::with_capacity(body.auth.len());
     for raw_auth in body.auth.as_slice() {
         let SorobanAuthorizationEntry {
-            credentials: SorobanCredentials::Address(credentials),
+            credentials:
+                SorobanCredentials::Address(credentials) | SorobanCredentials::AddressV2(credentials),
             ..
         } = raw_auth
         else {
-            // Doesn't need special signing
+            // Doesn't need special signing (SourceAccount / AddressWithDelegates)
             signed_auths.push(raw_auth.clone());
             continue;
         };
@@ -240,22 +242,37 @@ async fn sign_soroban_authorization_entry(
     network_id: &Hash,
 ) -> Result<SorobanAuthorizationEntry, Error> {
     let mut auth = raw.clone();
-    let SorobanAuthorizationEntry {
-        credentials: SorobanCredentials::Address(ref mut credentials),
-        ..
-    } = auth
-    else {
-        // Doesn't need special signing
-        return Ok(auth);
+    let invocation = auth.root_invocation.clone();
+    // `Address` (V1) and `AddressV2` share the same credential struct; only the
+    // signature payload differs. The RPC returns V1 by default, but we sign
+    // whichever variant the entry carries and preserve it on the way out.
+    let (credentials, is_v2) = match &mut auth.credentials {
+        SorobanCredentials::Address(credentials) => (credentials, false),
+        SorobanCredentials::AddressV2(credentials) => (credentials, true),
+        // Doesn't need special signing (SourceAccount / AddressWithDelegates).
+        _ => return Ok(auth),
     };
-    let SorobanAddressCredentials { nonce, .. } = credentials;
 
-    let preimage = HashIdPreimage::SorobanAuthorization(HashIdPreimageSorobanAuthorization {
-        network_id: network_id.clone(),
-        invocation: auth.root_invocation.clone(),
-        nonce: *nonce,
-        signature_expiration_ledger,
-    })
+    // V2 binds the signer's address into the payload (CAP-0071-02) via the
+    // `SorobanAuthorizationWithAddress` preimage; V1 omits it.
+    let preimage = if is_v2 {
+        HashIdPreimage::SorobanAuthorizationWithAddress(
+            HashIdPreimageSorobanAuthorizationWithAddress {
+                network_id: network_id.clone(),
+                nonce: credentials.nonce,
+                signature_expiration_ledger,
+                address: credentials.address.clone(),
+                invocation,
+            },
+        )
+    } else {
+        HashIdPreimage::SorobanAuthorization(HashIdPreimageSorobanAuthorization {
+            network_id: network_id.clone(),
+            invocation,
+            nonce: credentials.nonce,
+            signature_expiration_ledger,
+        })
+    }
     .to_xdr(Limits::none())?;
 
     let payload = Sha256::digest(preimage);
@@ -284,7 +301,6 @@ async fn sign_soroban_authorization_entry(
         vec![ScVal::Map(Some(map))].try_into().map_err(Error::Xdr)?,
     ));
     credentials.signature_expiration_ledger = signature_expiration_ledger;
-    auth.credentials = SorobanCredentials::Address(credentials.clone());
     Ok(auth)
 }
 
@@ -728,6 +744,166 @@ mod tests {
         assert_eq!(
             signer.get_public_key().unwrap().to_string(),
             TEST_PUBLIC_KEY
+        );
+    }
+
+    // ---- AddressV2 (CAP-0071-02) ----
+
+    fn address_auth_v2(
+        address: ScAddress,
+        invocation: SorobanAuthorizedInvocation,
+    ) -> SorobanAuthorizationEntry {
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::AddressV2(SorobanAddressCredentials {
+                address,
+                nonce: 0,
+                signature_expiration_ledger: 0,
+                signature: ScVal::Void,
+            }),
+            root_invocation: invocation,
+        }
+    }
+
+    /// Pull the embedded 64-byte signature out of a signed Address-cred entry.
+    fn extract_signed_signature(creds: &SorobanAddressCredentials) -> [u8; 64] {
+        let ScVal::Vec(Some(outer)) = &creds.signature else {
+            panic!("expected ScVal::Vec signature");
+        };
+        let Some(ScVal::Map(Some(map))) = outer.first() else {
+            panic!("expected ScVal::Map inside signature vec");
+        };
+        map.iter()
+            .find_map(|e| match (&e.key, &e.val) {
+                (ScVal::Symbol(s), ScVal::Bytes(b)) if s.0.as_slice() == b"signature" => {
+                    Some(b.as_slice().try_into().unwrap())
+                }
+                _ => None,
+            })
+            .expect("signature entry")
+    }
+
+    /// Borrow the `SorobanAddressCredentials` from the first auth entry,
+    /// whether it is an `Address` (V1) or `AddressV2` entry.
+    fn first_address_creds(tx: &Transaction) -> &SorobanAddressCredentials {
+        let OperationBody::InvokeHostFunction(body) = &tx.operations[0].body else {
+            panic!("expected InvokeHostFunction");
+        };
+        match &body.auth[0].credentials {
+            SorobanCredentials::Address(c) | SorobanCredentials::AddressV2(c) => c,
+            _ => panic!("expected address credentials"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_signs_address_v2_entry_with_with_address_preimage() {
+        use ed25519_dalek::{Verifier, VerifyingKey};
+
+        let signer = local_signer([1u8; 32]);
+        let signer_pk = signer_pubkey(&signer);
+        let source = MuxedAccount::Ed25519(Uint256([9u8; 32]));
+        let contract = [42u8; 32];
+
+        let entry = address_auth_v2(ed25519_address(signer_pk), invocation(contract, "hello"));
+        let host_fn = HostFunction::InvokeContract(invoke_args(contract, "hello"));
+        let tx = build_tx(source, host_fn, vec![entry]);
+
+        let signed_auth_tx = sign_soroban_authorizations(
+            &tx,
+            &[signer],
+            EXPIRATION_LEDGER,
+            NETWORK,
+            false,
+            &Print::new(true),
+        )
+        .await
+        .unwrap()
+        .expect("signing modifies the transaction");
+
+        let OperationBody::InvokeHostFunction(body) = &signed_auth_tx.operations[0].body else {
+            panic!("expected InvokeHostFunction");
+        };
+        // The variant must be preserved as AddressV2 (not downgraded to V1).
+        let SorobanCredentials::AddressV2(creds) = &body.auth[0].credentials else {
+            panic!("expected AddressV2 credentials to be preserved");
+        };
+        assert_eq!(creds.signature_expiration_ledger, EXPIRATION_LEDGER);
+        assert_eq!(extract_signed_pubkey(creds), signer_pk);
+
+        // The signature must validate against the V2 `WithAddress` preimage,
+        // which binds the signer's address into the payload.
+        let network_id = Hash(Sha256::digest(NETWORK.as_bytes()).into());
+        let preimage = HashIdPreimage::SorobanAuthorizationWithAddress(
+            HashIdPreimageSorobanAuthorizationWithAddress {
+                network_id,
+                nonce: creds.nonce,
+                signature_expiration_ledger: EXPIRATION_LEDGER,
+                address: creds.address.clone(),
+                invocation: body.auth[0].root_invocation.clone(),
+            },
+        )
+        .to_xdr(Limits::none())
+        .unwrap();
+        let payload: [u8; 32] = Sha256::digest(preimage).into();
+
+        let vk = VerifyingKey::from_bytes(&signer_pk).unwrap();
+        let sig = Ed25519Signature::from_bytes(&extract_signed_signature(creds));
+        vk.verify(&payload, &sig)
+            .expect("V2 signature must validate against the WithAddress preimage");
+    }
+
+    #[tokio::test]
+    async fn test_address_v1_and_v2_signatures_differ() {
+        let signer_pk = signer_pubkey(&local_signer([1u8; 32]));
+        let source = MuxedAccount::Ed25519(Uint256([9u8; 32]));
+        let contract = [42u8; 32];
+        let host_fn = HostFunction::InvokeContract(invoke_args(contract, "hello"));
+
+        let v1_tx = build_tx(
+            source.clone(),
+            host_fn.clone(),
+            vec![address_auth(
+                ed25519_address(signer_pk),
+                invocation(contract, "hello"),
+            )],
+        );
+        let v2_tx = build_tx(
+            source,
+            host_fn,
+            vec![address_auth_v2(
+                ed25519_address(signer_pk),
+                invocation(contract, "hello"),
+            )],
+        );
+
+        let v1_signed = sign_soroban_authorizations(
+            &v1_tx,
+            &[local_signer([1u8; 32])],
+            EXPIRATION_LEDGER,
+            NETWORK,
+            false,
+            &Print::new(true),
+        )
+        .await
+        .unwrap()
+        .expect("signing modifies the transaction");
+        let v2_signed = sign_soroban_authorizations(
+            &v2_tx,
+            &[local_signer([1u8; 32])],
+            EXPIRATION_LEDGER,
+            NETWORK,
+            false,
+            &Print::new(true),
+        )
+        .await
+        .unwrap()
+        .expect("signing modifies the transaction");
+
+        // Same address/nonce/invocation, but V2 binds the address into the
+        // payload, so the resulting signatures must differ.
+        assert_ne!(
+            first_address_creds(&v1_signed).signature,
+            first_address_creds(&v2_signed).signature,
+            "V2 must bind the address, producing a different signature than V1",
         );
     }
 }

--- a/cmd/soroban-cli/src/signer/validation.rs
+++ b/cmd/soroban-cli/src/signer/validation.rs
@@ -103,9 +103,7 @@ mod tests {
     ) -> SorobanAuthorizedInvocation {
         SorobanAuthorizedInvocation {
             function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
-                contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(
-                    contract,
-                ))),
+                contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(contract))),
                 function_name: ScSymbol(fn_name.try_into().unwrap()),
                 args: args.to_vec().try_into().unwrap(),
             }),

--- a/cmd/soroban-cli/src/signer/validation.rs
+++ b/cmd/soroban-cli/src/signer/validation.rs
@@ -79,7 +79,7 @@ mod tests {
 
     fn host_fn_invoke(contract: [u8; 32], fn_name: &str, args: &[ScVal]) -> HostFunction {
         HostFunction::InvokeContract(InvokeContractArgs {
-            contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(contract))),
+            contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(contract))),
             function_name: ScSymbol(fn_name.try_into().unwrap()),
             args: args.try_into().unwrap(),
         })
@@ -103,7 +103,7 @@ mod tests {
     ) -> SorobanAuthorizedInvocation {
         SorobanAuthorizedInvocation {
             function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
-                contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(
+                contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(
                     contract,
                 ))),
                 function_name: ScSymbol(fn_name.try_into().unwrap()),

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -361,7 +361,7 @@ pub mod args {
 pub mod rpc {
     use crate::xdr;
     use soroban_rpc::{Client, Error};
-    use stellar_xdr::curr::{Hash, LedgerEntryData, LedgerKey, Limits, ReadXdr};
+    use stellar_xdr::{Hash, LedgerEntryData, LedgerKey, Limits, ReadXdr};
 
     pub async fn get_remote_wasm_from_hash(client: &Client, hash: &Hash) -> Result<Vec<u8>, Error> {
         let code_key = LedgerKey::ContractCode(xdr::LedgerKeyContractCode { hash: hash.clone() });
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn test_verify_wasm_hash_matching() {
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
 
         let wasm_bytes = b"\0asm fake wasm content";
         let correct_hash = Hash(Sha256::digest(wasm_bytes).into());
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     fn test_verify_wasm_hash_mismatch() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
 
         let wasm_bytes = b"\0asm fake wasm content";
         let wrong_hash = Hash([0xAB; 32]);

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -5,7 +5,7 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
 };
-use stellar_xdr::curr::{ContractDataEntry, ContractExecutable, ScVal};
+use stellar_xdr::{ContractDataEntry, ContractExecutable, ScVal};
 
 use crate::{
     config::{


### PR DESCRIPTION
### What

Updates protocol dependencies to protocol 27, cleans up clippy warnings, and adds the ability to sign AddressV2 auth entries.

### Known limitations

Support for signing with delegated signers does not exist at this time

### TODO
- [x] Update `rs-soroban-sdk` packages once an RC release is available