### PR TITLE
Update stellar-strkey to 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4347,7 +4347,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.0",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4721,7 +4721,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5029,7 +5029,7 @@ checksum = "35a5a225b0cc092f0c818c7e51faf9d63d07da8c3157d6250096ca4b8708cfe3"
 dependencies = [
  "ed25519-dalek",
  "ows-signer",
- "stellar-strkey 0.0.18",
+ "stellar-strkey 0.0.16",
  "thiserror 2.0.18",
  "tiny-bip39",
 ]
@@ -5899,7 +5899,8 @@ dependencies = [
 [[package]]
 name = "stellar-strkey"
 version = "0.0.18"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
 dependencies = [
  "clap",
  "crate-git-revision 0.0.9",
@@ -6124,7 +6125,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,7 +5029,7 @@ checksum = "35a5a225b0cc092f0c818c7e51faf9d63d07da8c3157d6250096ca4b8708cfe3"
 dependencies = [
  "ed25519-dalek",
  "ows-signer",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.18",
  "thiserror 2.0.18",
  "tiny-bip39",
 ]
@@ -5453,7 +5453,7 @@ dependencies = [
  "stellar-asset-spec",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "stellar-xdr",
  "strsim",
  "strum 0.17.1",
@@ -5665,7 +5665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-spec",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "stellar-xdr",
  "thiserror 1.0.69",
  "tokio",
@@ -5720,7 +5720,7 @@ dependencies = [
  "soroban-spec-tools",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "test-case",
  "testcontainers",
  "thiserror 1.0.69",
@@ -5841,7 +5841,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "stellar-xdr",
  "test-case",
  "testcontainers",
@@ -5898,9 +5898,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+version = "0.0.18"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 dependencies = [
  "clap",
  "crate-git-revision 0.0.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,7 +1870,7 @@ dependencies = [
  "embedded-io-async",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -2453,6 +2453,17 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
 ]
 
 [[package]]
@@ -5442,7 +5453,7 @@ dependencies = [
  "stellar-asset-spec",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "stellar-xdr",
  "strsim",
  "strum 0.17.1",
@@ -5654,7 +5665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-spec",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "stellar-xdr",
  "thiserror 1.0.69",
  "tokio",
@@ -5709,7 +5720,7 @@ dependencies = [
  "soroban-spec-tools",
  "stellar-ledger",
  "stellar-rpc-client",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "test-case",
  "testcontainers",
  "thiserror 1.0.69",
@@ -5830,7 +5841,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.17",
  "stellar-xdr",
  "test-case",
  "testcontainers",
@@ -5880,14 +5891,26 @@ version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
 dependencies = [
- "clap",
  "crate-git-revision 0.0.6",
  "data-encoding",
- "heapless",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+dependencies = [
+ "clap",
+ "crate-git-revision 0.0.9",
+ "data-encoding",
+ "heapless 0.9.3",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ version = "26.0.0"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]
-stellar-strkey = "0.0.16"
+stellar-strkey = "0.0.17"
 sep5 = "0.1.0"
 base64 = "0.21.2"
 thiserror = "1.0.46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ version = "26.0.0"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]
-stellar-strkey = "0.0.17"
+stellar-strkey = "0.0.18"
 sep5 = "0.1.0"
 base64 = "0.21.2"
 thiserror = "1.0.46"
@@ -137,3 +137,9 @@ lto = true
 [profile.release-with-panic-unwind]
 inherits = "release"
 panic = "unwind"
+
+# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
+# the release/v0.0.18 branch so this PR can be validated against the actual
+# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,9 +137,3 @@ lto = true
 [profile.release-with-panic-unwind]
 inherits = "release"
 panic = "unwind"
-
-# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
-# the release/v0.0.18 branch so this PR can be validated against the actual
-# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
-[patch.crates-io]
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -4396,7 +4396,7 @@ Print version information
 
 Decode and encode strkey
 
-**Usage:** `stellar strkey <COMMAND>`
+**Usage:** `stellar strkey [OPTIONS] <COMMAND>`
 
 ###### **Subcommands:**
 
@@ -4405,25 +4405,25 @@ Decode and encode strkey
 - `zero` — Generate the zero strkey
 - `version` — Print version information
 
+###### **Options:**
+
+- `-q`, `--quiet` — Suppress stderr log and warning output
+
 ## `stellar strkey decode`
 
 Decode strkey
 
-**Usage:** `stellar strkey decode <STRKEY>`
+Reads the strkey from stdin.
 
-###### **Arguments:**
-
-- `<STRKEY>` — Strkey to decode
+**Usage:** `stellar strkey decode`
 
 ## `stellar strkey encode`
 
 Encode strkey
 
-**Usage:** `stellar strkey encode <JSON>`
+Reads the JSON from stdin.
 
-###### **Arguments:**
-
-- `<JSON>` — JSON for Strkey to encode
+**Usage:** `stellar strkey encode`
 
 ## `stellar strkey zero`
 

--- a/cmd/crates/soroban-spec-tools/src/utils.rs
+++ b/cmd/crates/soroban-spec-tools/src/utils.rs
@@ -22,9 +22,9 @@ pub fn contract_id_from_str(contract_id: &str) -> Result<[u8; 32], stellar_strke
         .or_else(|_| {
             // strkey failed, try to parse it as a hex string, for backwards compatibility.
             padded_hex_from_str(contract_id, 32)
-                .map_err(|_| stellar_strkey::DecodeError::Invalid)?
+                .map_err(|_| stellar_strkey::DecodeError::InvalidPayloadLength)?
                 .try_into()
-                .map_err(|_| stellar_strkey::DecodeError::Invalid)
+                .map_err(|_| stellar_strkey::DecodeError::InvalidPayloadLength)
         })
-        .map_err(|_| stellar_strkey::DecodeError::Invalid)
+        .map_err(|_| stellar_strkey::DecodeError::InvalidPayloadLength)
 }

--- a/cmd/crates/soroban-test/src/lib.rs
+++ b/cmd/crates/soroban-test/src/lib.rs
@@ -297,6 +297,7 @@ impl TestEnv {
             self.cmd::<keys::secret::Cmd>(&format!("--hd-path={hd_path}"))
                 .private_key()
                 .unwrap()
+                .as_unredacted()
         )
     }
 

--- a/cmd/crates/soroban-test/tests/it/strkey.rs
+++ b/cmd/crates/soroban-test/tests/it/strkey.rs
@@ -5,10 +5,8 @@ fn decode() {
     let sandbox = TestEnv::default();
     sandbox
         .new_assert_cmd("strkey")
-        .args([
-            "decode",
-            "GAZTAML6YJA5PGKDXONKPSHKL6FYT6OG5I2R7YB7R3B5CETRG7KIJONK",
-        ])
+        .args(["decode"])
+        .write_stdin("GAZTAML6YJA5PGKDXONKPSHKL6FYT6OG5I2R7YB7R3B5CETRG7KIJONK")
         .assert()
         .success()
         .stdout(
@@ -24,7 +22,8 @@ fn encode() {
     let sandbox = TestEnv::default();
     sandbox
         .new_assert_cmd("strkey")
-        .args(["encode", r#"{"public_key_ed25519":"3330317ec241d79943bb9aa7c8ea5f8b89f9c6ea351fe03f8ec3d1127137d484"}"#])
+        .args(["encode"])
+        .write_stdin(r#"{"public_key_ed25519":"3330317ec241d79943bb9aa7c8ea5f8b89f9c6ea351fe03f8ec3d1127137d484"}"#)
         .assert()
         .success()
         .stdout("GAZTAML6YJA5PGKDXONKPSHKL6FYT6OG5I2R7YB7R3B5CETRG7KIJONK\n");

--- a/cmd/soroban-cli/src/commands/keys/secret.rs
+++ b/cmd/soroban-cli/src/commands/keys/secret.rs
@@ -40,7 +40,7 @@ impl Cmd {
         if self.phrase {
             println!("{}", self.seed_phrase()?);
         } else {
-            println!("{}", self.private_key()?);
+            println!("{}", self.private_key()?.as_unredacted());
         }
 
         Ok(())

--- a/cmd/soroban-cli/src/commands/network/root_account/secret.rs
+++ b/cmd/soroban-cli/src/commands/network/root_account/secret.rs
@@ -13,7 +13,7 @@ impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         let root_key = self.args.root_key()?;
         let private_key = PrivateKey::from_payload(&root_key)?;
-        println!("{private_key}");
+        println!("{}", private_key.as_unredacted());
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/config/key.rs
+++ b/cmd/soroban-cli/src/config/key.rs
@@ -177,7 +177,7 @@ mod test {
     }
     #[test]
     fn secret_key() {
-        let secret_key = format!("{}", stellar_strkey::ed25519::PrivateKey([0; 32]));
+        let secret_key = format!("{}", stellar_strkey::ed25519::PrivateKey([0; 32]).as_unredacted());
         let secret = Secret::SecretKey { secret_key };
         let key = Key::Secret(secret);
         round_trip(&key);

--- a/cmd/soroban-cli/src/config/key.rs
+++ b/cmd/soroban-cli/src/config/key.rs
@@ -177,7 +177,10 @@ mod test {
     }
     #[test]
     fn secret_key() {
-        let secret_key = format!("{}", stellar_strkey::ed25519::PrivateKey([0; 32]).as_unredacted());
+        let secret_key = format!(
+            "{}",
+            stellar_strkey::ed25519::PrivateKey([0; 32]).as_unredacted()
+        );
         let secret = Secret::SecretKey { secret_key };
         let key = Key::Secret(secret);
         round_trip(&key);

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -130,7 +130,7 @@ impl FromStr for Secret {
 impl From<PrivateKey> for Secret {
     fn from(value: PrivateKey) -> Self {
         Secret::SecretKey {
-            secret_key: format!("{value}"),
+            secret_key: format!("{}", value.as_unredacted()),
         }
     }
 }
@@ -285,7 +285,7 @@ mod tests {
 
         assert!(matches!(secret, Secret::SecretKey { .. }));
         assert_eq!(public_key.to_string(), TEST_PUBLIC_KEY);
-        assert_eq!(private_key.to_string(), TEST_SECRET_KEY);
+        assert_eq!(private_key.as_unredacted().to_string(), TEST_SECRET_KEY);
     }
 
     #[test]
@@ -296,7 +296,7 @@ mod tests {
 
         assert!(matches!(secret, Secret::SeedPhrase { .. }));
         assert_eq!(public_key.to_string(), TEST_PUBLIC_KEY);
-        assert_eq!(private_key.to_string(), TEST_SECRET_KEY);
+        assert_eq!(private_key.as_unredacted().to_string(), TEST_SECRET_KEY);
     }
 
     #[test]
@@ -463,7 +463,7 @@ mod tests {
         let pk = secret.public_key(Some(0)).unwrap();
         let sk = secret.private_key(Some(0)).unwrap();
         assert_eq!(pk.to_string(), TEST_PUBLIC_KEY);
-        assert_eq!(sk.to_string(), TEST_SECRET_KEY);
+        assert_eq!(sk.as_unredacted().to_string(), TEST_SECRET_KEY);
     }
 
     #[test]

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -109,9 +109,9 @@ pub fn contract_id_from_str(
             // strkey failed, try to parse it as a hex string, for backwards compatibility.
             stellar_strkey::Contract(
                 soroban_spec_tools::utils::padded_hex_from_str(contract_id, 32)
-                    .map_err(|_| stellar_strkey::DecodeError::Invalid)?
+                    .map_err(|_| stellar_strkey::DecodeError::InvalidPayloadLength)?
                     .try_into()
-                    .map_err(|_| stellar_strkey::DecodeError::Invalid)?,
+                    .map_err(|_| stellar_strkey::DecodeError::InvalidPayloadLength)?,
             )
         },
     )

--- a/deny.toml
+++ b/deny.toml
@@ -231,7 +231,10 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
   # Only used by the unpublished doc-gen crate, temporarily until PR is merged: https://github.com/ConnorGray/clap-markdown/pull/48
-  "https://github.com/ConnorGray/clap-markdown?rev=42956b342cef3325d9060fc43995d595e7c8aa66"
+  "https://github.com/ConnorGray/clap-markdown?rev=42956b342cef3325d9060fc43995d595e7c8aa66",
+  # Temporary: stellar-strkey 0.0.18 is not yet published to crates.io; pinned to
+  # the release/v0.0.18 branch until the release. Remove once 0.0.18 is published.
+  "https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -231,10 +231,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
   # Only used by the unpublished doc-gen crate, temporarily until PR is merged: https://github.com/ConnorGray/clap-markdown/pull/48
-  "https://github.com/ConnorGray/clap-markdown?rev=42956b342cef3325d9060fc43995d595e7c8aa66",
-  # Temporary: stellar-strkey 0.0.18 is not yet published to crates.io; pinned to
-  # the release/v0.0.18 branch until the release. Remove once 0.0.18 is published.
-  "https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+  "https://github.com/ConnorGray/clap-markdown?rev=42956b342cef3325d9060fc43995d595e7c8aa66"
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
### What

Bump the `stellar-strkey` workspace dependency from 0.0.16 to 0.0.18. This change targets the stellar-strkey release line for protocol 28. The workspace-direct crates now resolve to strkey 0.0.18, while published transitive consumers pinned to `^0.0.16` (sep5, soroban-sdk, stellar-rpc-client) and the transitive 0.0.13 via stellar-xdr remain unchanged, so the lockfile carries three strkey nodes.

### Why

Adopt the latest stellar-strkey release for the protocol 28 line. Version 0.0.17 replaced the single catch-all `DecodeError::Invalid` variant with a set of specific variants, so the two hex-fallback code paths in `contract_id_from_str` (in soroban-spec-tools and soroban-cli) were updated to map their failures to `DecodeError::InvalidPayloadLength`, preserving the prior single-error behavior. It also redacts private keys behind `Unredacted`, so the CLI's secret-printing paths and tests now use `.as_unredacted()`, and removes positional input for the embedded `strkey encode`/`decode` commands in favour of stdin.

0.0.18 specifically fixes the bug that blocked the 0.0.17 bump: the embedded `strkey encode` command rejected owned JSON keys when deserializing `Decoded<Strkey>`, failing the `strkey` integration test. stellar/rs-stellar-strkey#125 fixes it.

### Known limitations

N/A

---

## Protocol 28 coordination

⚠️ This change targets versions of software that will ship for **Protocol 28**, and should **not** be merged unless this repository is ready to accept Protocol 28 changes.

This is one of a coordinated set of PRs bumping `stellar-strkey` to **0.0.18** across the Protocol 28 component stack. It is preferred that all Protocol 28 releases of these components depend on the **same** version of `stellar-strkey`:

- stellar/rs-stellar-xdr#547
- stellar/rs-soroban-env#1694
- stellar/rs-soroban-sdk#1913
- stellar/rs-stellar-rpc-client#99
- stellar/stellar-cli#2614

`stellar-strkey` 0.0.18 raises the minimum supported Rust version to 1.87 and updates/adds transitive dependencies (`heapless` 0.9, `zeroize`), so MSRV and supply-chain policy (cargo-deny / cackle) updates may be required in some repositories before CI is green.