### PR TITLE
Fix descriptions for contract id commands

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -549,12 +549,12 @@ Generate the contract id for a given contract or asset
 
 ###### **Subcommands:**
 
-- `asset` — Deploy builtin Soroban Asset Contract
-- `wasm` — Deploy normal Wasm Contract
+- `asset` — Derive the contract id for a builtin Stellar Asset Contract
+- `wasm` — Derive the contract id for a Wasm contract
 
 ## `stellar contract id asset`
 
-Deploy builtin Soroban Asset Contract
+Derive the contract id for a builtin Stellar Asset Contract
 
 **Usage:** `stellar contract id asset [OPTIONS] --asset <ASSET>`
 
@@ -575,7 +575,7 @@ Deploy builtin Soroban Asset Contract
 
 ## `stellar contract id wasm`
 
-Deploy normal Wasm Contract
+Derive the contract id for a Wasm contract
 
 **Usage:** `stellar contract id wasm [OPTIONS] --salt <SALT> --source-account <SOURCE_ACCOUNT>`
 

--- a/cmd/soroban-cli/src/commands/contract/id.rs
+++ b/cmd/soroban-cli/src/commands/contract/id.rs
@@ -3,9 +3,10 @@ pub mod wasm;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
-    /// Deploy builtin Soroban Asset Contract
+    /// Derive the contract id for a builtin Stellar Asset Contract
     Asset(asset::Cmd),
-    /// Deploy normal Wasm Contract
+
+    /// Derive the contract id for a Wasm contract
     Wasm(wasm::Cmd),
 }
 
@@ -13,6 +14,7 @@ pub enum Cmd {
 pub enum Error {
     #[error(transparent)]
     Asset(#[from] asset::Error),
+
     #[error(transparent)]
     Wasm(#[from] wasm::Error),
 }
@@ -23,6 +25,7 @@ impl Cmd {
             Cmd::Asset(asset) => asset.run()?,
             Cmd::Wasm(wasm) => wasm.run()?,
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
### What

Corrects the help text for the `stellar contract id asset` and `stellar contract id wasm` subcommands. They previously read "Deploy builtin Soroban Asset Contract" and "Deploy normal Wasm Contract", which is wrong — neither deploys anything. They now read "Derive the contract id for a builtin Stellar Asset Contract" and "Derive the contract id for a Wasm contract". `FULL_HELP_DOCS.md` was regenerated to match.

### Why

These subcommands derive and print a contract ID; they do not deploy. The old descriptions were inaccurate.

### Known limitations

N/A