### PR TITLE
fix: verify signature against cached public key after signing (#2571)

### DIFF
--- a/cmd/soroban-cli/src/signer/ledger.rs
+++ b/cmd/soroban-cli/src/signer/ledger.rs
@@ -16,6 +16,9 @@ pub enum Error {
 
     #[error(transparent)]
     Xdr(#[from] xdr::Error),
+
+    #[error(transparent)]
+    Validation(#[from] crate::signer::validation::Error),
 }
 
 #[cfg(feature = "additional-libs")]
@@ -47,13 +50,17 @@ mod ledger_impl {
                 Some(pk) => pk,
                 None => live.public_key().await?,
             };
+            let sig_bytes = live
+                .signer
+                .sign_transaction_hash(live.index, &tx_hash)
+                .await?;
+            // Only the cached-pubkey path can drift; the cacheless path fetched the
+            // key live from the same device that just signed.
+            if self.public_key.is_some() {
+                crate::signer::validation::verify_signature(&key, &tx_hash, &sig_bytes)?;
+            }
             let hint = SignatureHint(key.0[28..].try_into()?);
-            let signature = Signature(
-                live.signer
-                    .sign_transaction_hash(live.index, &tx_hash)
-                    .await?
-                    .try_into()?,
-            );
+            let signature = Signature(sig_bytes.try_into()?);
             Ok(DecoratedSignature { hint, signature })
         }
 
@@ -63,6 +70,9 @@ mod ledger_impl {
                 .signer
                 .sign_transaction_hash(live.index, &payload)
                 .await?;
+            if let Some(pk) = self.public_key {
+                crate::signer::validation::verify_signature(&pk, &payload, &bytes)?;
+            }
             Ok(Ed25519Signature::from_bytes(bytes.as_slice().try_into()?))
         }
     }

--- a/cmd/soroban-cli/src/signer/ledger.rs
+++ b/cmd/soroban-cli/src/signer/ledger.rs
@@ -56,8 +56,8 @@ mod ledger_impl {
                 .await?;
             // Only the cached-pubkey path can drift; the cacheless path fetched the
             // key live from the same device that just signed.
-            if self.public_key.is_some() {
-                crate::signer::validation::verify_signature(&key, &tx_hash, &sig_bytes)?;
+            if let Some(pk) = self.public_key {
+                crate::signer::validation::verify_signature(&pk, &tx_hash, &sig_bytes)?;
             }
             let hint = SignatureHint(key.0[28..].try_into()?);
             let signature = Signature(sig_bytes.try_into()?);

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -59,6 +59,8 @@ pub enum Error {
     Ledger(#[from] ledger::Error),
     #[error(transparent)]
     Decode(#[from] stellar_strkey::DecodeError),
+    #[error(transparent)]
+    Validation(#[from] validation::Error),
 }
 
 /// Sign all SorobanAuthorizationEntry's in the transaction with the given signers. Returns a new
@@ -472,12 +474,19 @@ impl SecureStoreEntry {
 
         let signed_tx_hash = secure_store::sign_tx_data(&self.name, self.hd_path, &tx_hash)?;
 
+        if let Some(pk) = self.public_key {
+            validation::verify_signature(&pk, &tx_hash, &signed_tx_hash)?;
+        }
+
         let signature = Signature(signed_tx_hash.clone().try_into()?);
         Ok(DecoratedSignature { hint, signature })
     }
 
     pub fn sign_payload(&self, payload: [u8; 32]) -> Result<Ed25519Signature, Error> {
         let signed_bytes = secure_store::sign_tx_data(&self.name, self.hd_path, &payload)?;
+        if let Some(pk) = self.public_key {
+            validation::verify_signature(&pk, &payload, &signed_bytes)?;
+        }
         let sig = Ed25519Signature::from_bytes(signed_bytes.as_slice().try_into()?);
         Ok(sig)
     }

--- a/cmd/soroban-cli/src/signer/validation.rs
+++ b/cmd/soroban-cli/src/signer/validation.rs
@@ -1,5 +1,35 @@
 use crate::xdr::{HostFunction, SorobanAuthorizedFunction, SorobanAuthorizedInvocation};
 
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(
+        "the produced signature does not match the cached public key {public_key}; \
+the cached key may be stale — check the correct device is connected / the alias's \
+hd-path is right, or re-add the key"
+    )]
+    SignatureMismatch { public_key: String },
+}
+
+/// Verify that `signature` over `message` was produced by the secret key
+/// corresponding to `public_key`. Used as a post-sign drift guard for
+/// cached-pubkey signers (Ledger / Secure Store): the signature is produced on a
+/// live device/keychain while the hint and embedded public key are derived from a
+/// cached value, so a stale cache yields a transaction the network silently
+/// rejects. This catches that locally with a clear error.
+pub fn verify_signature(
+    public_key: &stellar_strkey::ed25519::PublicKey,
+    message: &[u8; 32],
+    signature: &[u8],
+) -> Result<(), Error> {
+    use ed25519_dalek::{Signature, VerifyingKey};
+    let mismatch = || Error::SignatureMismatch {
+        public_key: format!("{public_key}"),
+    };
+    let vk = VerifyingKey::from_bytes(&public_key.0).map_err(|_| mismatch())?;
+    let sig = Signature::from_slice(signature).map_err(|_| mismatch())?;
+    vk.verify_strict(message, &sig).map_err(|_| mismatch())
+}
+
 /// Classification of an `Address`-credential auth entry's relationship to the
 /// transaction's host function.
 ///
@@ -123,6 +153,40 @@ mod tests {
             }),
             sub_invocations: VecM::default(),
         }
+    }
+
+    #[test]
+    fn test_verify_signature_roundtrip() {
+        use ed25519_dalek::{ed25519::signature::Signer as _, SigningKey};
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let public_key =
+            ed25519::PublicKey::from_payload(signing_key.verifying_key().as_bytes()).unwrap();
+        let message = [42u8; 32];
+        let signature = signing_key.sign(&message).to_bytes();
+
+        // Matching key + untampered signature verifies.
+        verify_signature(&public_key, &message, &signature).unwrap();
+
+        // A different public key is rejected.
+        let cached_pk = ed25519::PublicKey::from_payload(
+            SigningKey::from_bytes(&[9u8; 32])
+                .verifying_key()
+                .as_bytes(),
+        )
+        .unwrap();
+        assert!(matches!(
+            verify_signature(&cached_pk, &message, &signature),
+            Err(Error::SignatureMismatch { .. })
+        ));
+
+        // A tampered signature is rejected.
+        let mut tampered = signature;
+        tampered[0] ^= 0xff;
+        assert!(matches!(
+            verify_signature(&public_key, &message, &tampered),
+            Err(Error::SignatureMismatch { .. })
+        ));
     }
 
     #[test]

--- a/cmd/soroban-cli/src/signer/validation.rs
+++ b/cmd/soroban-cli/src/signer/validation.rs
@@ -8,6 +8,12 @@ the cached key may be stale — check the correct device is connected / the alia
 hd-path is right, or re-add the key"
     )]
     SignatureMismatch { public_key: String },
+
+    #[error("the cached public key {public_key} is not a valid ed25519 public key")]
+    InvalidPublicKey { public_key: String },
+
+    #[error("the signer returned a malformed ed25519 signature ({len} bytes, expected 64)")]
+    InvalidSignature { len: usize },
 }
 
 /// Verify that `signature` over `message` was produced by the secret key
@@ -22,12 +28,16 @@ pub fn verify_signature(
     signature: &[u8],
 ) -> Result<(), Error> {
     use ed25519_dalek::{Signature, VerifyingKey};
-    let mismatch = || Error::SignatureMismatch {
+    let vk = VerifyingKey::from_bytes(&public_key.0).map_err(|_| Error::InvalidPublicKey {
         public_key: format!("{public_key}"),
-    };
-    let vk = VerifyingKey::from_bytes(&public_key.0).map_err(|_| mismatch())?;
-    let sig = Signature::from_slice(signature).map_err(|_| mismatch())?;
-    vk.verify_strict(message, &sig).map_err(|_| mismatch())
+    })?;
+    let sig = Signature::from_slice(signature).map_err(|_| Error::InvalidSignature {
+        len: signature.len(),
+    })?;
+    vk.verify_strict(message, &sig)
+        .map_err(|_| Error::SignatureMismatch {
+            public_key: format!("{public_key}"),
+        })
 }
 
 /// Classification of an `Address`-credential auth entry's relationship to the
@@ -186,6 +196,12 @@ mod tests {
         assert!(matches!(
             verify_signature(&public_key, &message, &tampered),
             Err(Error::SignatureMismatch { .. })
+        ));
+
+        // A wrong-length signature is reported as malformed, not as a mismatch.
+        assert!(matches!(
+            verify_signature(&public_key, &message, &signature[..63]),
+            Err(Error::InvalidSignature { len: 63 })
         ));
     }
 

--- a/cmd/soroban-cli/src/signer/validation.rs
+++ b/cmd/soroban-cli/src/signer/validation.rs
@@ -203,6 +203,15 @@ mod tests {
             verify_signature(&public_key, &message, &signature[..63]),
             Err(Error::InvalidSignature { len: 63 })
         ));
+
+        // A cached public key whose bytes are not a valid ed25519 point (here,
+        // 0x02 repeated, which fails curve decompression) is reported as an
+        // invalid key, not a signature mismatch.
+        let invalid_pk = ed25519::PublicKey([0x02u8; 32]);
+        assert!(matches!(
+            verify_signature(&invalid_pk, &message, &signature),
+            Err(Error::InvalidPublicKey { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### What

Add a post-sign ed25519 verification step to the Ledger and Secure Store signing paths. After producing a signature, we verify it against the signer's cached public key and fail locally with a clear error if they don't match. Covers `LedgerEntry::sign_tx_hash`, `LedgerEntry::sign_payload`, `SecureStoreEntry::sign_tx_hash`, and `SecureStoreEntry::sign_payload`.

The check is gated on a cached public key actually being present, so the cacheless `--sign-with-ledger` flow (which fetches the pubkey live) is unaffected.

Closes #2571.

### Why

Both `LedgerEntry` (added in #2569) and `SecureStoreEntry` carry a cached/derived public key alongside the underlying signing primitive. The `SignatureHint` (and, for Soroban auth entries, the embedded `public_key` ScVal) is derived from that cached key, while the actual signature is produced live on the device/keychain.

If the cached key ever drifts from what the underlying signer actually produces (corrupted TOML, wrong device plugged in, alias pointing at a different hd-path, schema migration glitch), the transaction carries a hint/pubkey that disagrees with its signature. Today that only surfaces as an opaque Horizon rejection after submission. ed25519 verification is microseconds, so catching this locally with a clear message is essentially free.

`SignerKind::Local` and `SignerKind::Lab` are intentionally out of scope: their public key is derived from the same in-process primitive that signs, so drift is not possible.

### Known limitations

The verification only runs when a cached public key is present. The cacheless `--sign-with-ledger` path fetches the public key live from the same device that signs, so there is nothing to drift from and no check is needed there.
