### PR TITLE
Add `--raw` flag to sign and verify messages without the SEP-53 prefix

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -4936,6 +4936,8 @@ Sign an arbitrary message using SEP-53
 
 Signs a message following the SEP-53 specification for arbitrary message signing. The provided message will get prefixed with "Stellar Signed Message:\n", hashed with SHA-256, and signed with the ed25519 private key.
 
+Use --raw to instead sign the exact payload bytes directly, with no SEP-53 prefix or SHA-256 hashing, outputting the signature as hex (for protocols that require a raw ed25519 signature over a specific payload).
+
 Example: stellar message sign "Hello, World!" --sign-with-key alice
 
 **Usage:** `stellar message sign [OPTIONS] --sign-with-key <SIGN_WITH_KEY> [MESSAGE]`
@@ -4951,6 +4953,7 @@ Example: stellar message sign "Hello, World!" --sign-with-key alice
 ###### **Options:**
 
 - `--base64` — Treat the message as base64-encoded binary data
+- `--raw` — Sign the raw payload bytes directly: skip the SEP-53 prefix and SHA-256 hashing, and output the signature as hex instead of base64
 
 ###### **Signing Options:**
 
@@ -4962,6 +4965,8 @@ Example: stellar message sign "Hello, World!" --sign-with-key alice
 Verify a SEP-53 signed message
 
 Verifies that a signature was produced by the holder of the private key corresponding to the given account public key, following the SEP-53 specification. The provided message will get prefixed with "Stellar Signed Message:\n" before verification.
+
+Use --raw to verify a raw signature instead: the message bytes are verified directly (no prefix or hashing) and the signature is hex-encoded.
 
 Example: stellar message verify "Hello, World!" --signature BASE64_SIG --public-key GABC...
 
@@ -4978,7 +4983,8 @@ Example: stellar message verify "Hello, World!" --signature BASE64_SIG --public-
 ###### **Options:**
 
 - `--base64` — Treat the message as base64-encoded binary data
-- `-s`, `--signature <SIGNATURE>` — The base64-encoded signature to verify
+- `--raw` — Verify a raw signature: the message bytes were signed directly, without the SEP-53 prefix or SHA-256 hashing, and `--signature` is hex-encoded
+- `-s`, `--signature <SIGNATURE>` — The signature to verify. Base64-encoded by default, or hex-encoded with `--raw`
 - `-p`, `--public-key <PUBLIC_KEY>` — The public key to verify the signature against. Can be an identity (--public-key alice), a public key (--public-key GDKW...)
 - `--hd-path <HD_PATH>` — If public key identity is a seed phrase use this hd path, default is 0
 

--- a/cmd/crates/soroban-test/tests/it/message.rs
+++ b/cmd/crates/soroban-test/tests/it/message.rs
@@ -225,6 +225,43 @@ async fn raw_sign_message_and_verify() {
         .failure();
 }
 
+#[tokio::test]
+async fn raw_sign_preserves_stdin_trailing_newline() {
+    let sandbox = &TestEnv::new();
+
+    let secret_key = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
+
+    // Signing exact bytes with a trailing newline (positional arg, no trimming).
+    let arg_sig = sandbox
+        .new_assert_cmd("message")
+        .args(["sign", "payload\n", "--sign-with-key", secret_key, "--raw"])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    // The same bytes over stdin must produce the same signature: the raw path
+    // must not strip the trailing newline.
+    let stdin_sig = sandbox
+        .new_assert_cmd("message")
+        .write_stdin("payload\n")
+        .args(["sign", "--sign-with-key", secret_key, "--raw"])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    assert_eq!(arg_sig.trim(), stdin_sig.trim());
+
+    // And it must differ from signing the trimmed "payload" bytes.
+    let trimmed_sig = sandbox
+        .new_assert_cmd("message")
+        .args(["sign", "payload", "--sign-with-key", secret_key, "--raw"])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    assert_ne!(stdin_sig.trim(), trimmed_sig.trim());
+}
+
 #[test]
 fn message_sign_does_not_leak_secret_in_error_output() {
     let sandbox = TestEnv::default();

--- a/cmd/crates/soroban-test/tests/it/message.rs
+++ b/cmd/crates/soroban-test/tests/it/message.rs
@@ -176,6 +176,55 @@ async fn sep_53_sign_message_and_verify_with_alias() {
         .failure();
 }
 
+#[tokio::test]
+async fn raw_sign_message_and_verify() {
+    let sandbox = &TestEnv::new();
+
+    let message = "challenge-1:abc123";
+    let secret_key = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
+    let public_key = "GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L";
+
+    // --raw signs the exact bytes (no SEP-53 prefix/hash) and outputs hex.
+    let signature = sandbox
+        .new_assert_cmd("message")
+        .args(["sign", message, "--sign-with-key", secret_key, "--raw"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let signature = signature.trim();
+    assert_eq!(signature.len(), 128, "raw signature is 128 hex chars");
+    assert!(signature.chars().all(|c| c.is_ascii_hexdigit()));
+
+    sandbox
+        .new_assert_cmd("message")
+        .args([
+            "verify",
+            message,
+            "--raw",
+            "--signature",
+            signature,
+            "--public-key",
+            public_key,
+        ])
+        .assert()
+        .success();
+
+    // The raw signature must not validate on the SEP-53 path (it has no prefix
+    // or hashing), so verifying without --raw fails.
+    sandbox
+        .new_assert_cmd("message")
+        .args([
+            "verify",
+            message,
+            "--signature",
+            signature,
+            "--public-key",
+            public_key,
+        ])
+        .assert()
+        .failure();
+}
+
 #[test]
 fn message_sign_does_not_leak_secret_in_error_output() {
     let sandbox = TestEnv::default();

--- a/cmd/crates/soroban-test/tests/it/message.rs
+++ b/cmd/crates/soroban-test/tests/it/message.rs
@@ -262,6 +262,41 @@ async fn raw_sign_preserves_stdin_trailing_newline() {
     assert_ne!(stdin_sig.trim(), trimmed_sig.trim());
 }
 
+#[tokio::test]
+async fn raw_sign_base64_stdin_trims_wrapper_newline() {
+    let sandbox = &TestEnv::new();
+
+    let secret_key = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
+    let base64_payload = "2zZDP1sa1BVBfLP7TeeMk3sUbaxAkUhBhDiNdrksaFo=";
+
+    // With --base64 the payload is the decoded bytes, so a trailing newline on
+    // the base64 stdin text must still be trimmed before decoding.
+    let stdin_sig = sandbox
+        .new_assert_cmd("message")
+        .write_stdin(format!("{base64_payload}\n"))
+        .args(["sign", "--sign-with-key", secret_key, "--raw", "--base64"])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    // Same payload passed as an argument (no stdin newline) must match.
+    let arg_sig = sandbox
+        .new_assert_cmd("message")
+        .args([
+            "sign",
+            base64_payload,
+            "--sign-with-key",
+            secret_key,
+            "--raw",
+            "--base64",
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    assert_eq!(stdin_sig.trim(), arg_sig.trim());
+}
+
 #[test]
 fn message_sign_does_not_leak_secret_in_error_output() {
     let sandbox = TestEnv::default();

--- a/cmd/soroban-cli/src/commands/message/mod.rs
+++ b/cmd/soroban-cli/src/commands/message/mod.rs
@@ -15,6 +15,10 @@ pub enum Cmd {
     /// The provided message will get prefixed with "Stellar Signed Message:\n", hashed with SHA-256,
     /// and signed with the ed25519 private key.
     ///
+    /// Use --raw to instead sign the exact payload bytes directly, with no SEP-53 prefix or
+    /// SHA-256 hashing, outputting the signature as hex (for protocols that require a raw
+    /// ed25519 signature over a specific payload).
+    ///
     /// Example: stellar message sign "Hello, World!" --sign-with-key alice
     Sign(sign::Cmd),
 
@@ -23,6 +27,9 @@ pub enum Cmd {
     /// Verifies that a signature was produced by the holder of the private key
     /// corresponding to the given account public key, following the SEP-53 specification. The
     /// provided message will get prefixed with "Stellar Signed Message:\n" before verification.
+    ///
+    /// Use --raw to verify a raw signature instead: the message bytes are verified directly
+    /// (no prefix or hashing) and the signature is hex-encoded.
     ///
     /// Example: stellar message verify "Hello, World!" --signature BASE64_SIG --public-key GABC...
     Verify(verify::Cmd),

--- a/cmd/soroban-cli/src/commands/message/sign.rs
+++ b/cmd/soroban-cli/src/commands/message/sign.rs
@@ -114,8 +114,9 @@ impl Cmd {
             // Read from stdin
             let mut buffer = String::new();
             io::stdin().read_to_string(&mut buffer)?;
-            // Remove trailing newline if present
-            if buffer.ends_with('\n') {
+            // Remove trailing newline if present. The raw path signs the exact
+            // bytes provided, so it keeps the newline the shell may have added.
+            if !self.raw && buffer.ends_with('\n') {
                 buffer.pop();
                 if buffer.ends_with('\r') {
                     buffer.pop();

--- a/cmd/soroban-cli/src/commands/message/sign.rs
+++ b/cmd/soroban-cli/src/commands/message/sign.rs
@@ -116,7 +116,9 @@ impl Cmd {
             io::stdin().read_to_string(&mut buffer)?;
             // Remove trailing newline if present. The raw path signs the exact
             // bytes provided, so it keeps the newline the shell may have added.
-            if !self.raw && buffer.ends_with('\n') {
+            // With --base64 the payload is the decoded bytes, so the base64 text
+            // (and any shell newline) is still trimmed before decoding.
+            if (!self.raw || self.base64) && buffer.ends_with('\n') {
                 buffer.pop();
                 if buffer.ends_with('\r') {
                     buffer.pop();

--- a/cmd/soroban-cli/src/commands/message/sign.rs
+++ b/cmd/soroban-cli/src/commands/message/sign.rs
@@ -55,6 +55,11 @@ pub struct Cmd {
     #[arg(long)]
     pub base64: bool,
 
+    /// Sign the raw payload bytes directly: skip the SEP-53 prefix and SHA-256
+    /// hashing, and output the signature as hex instead of base64.
+    #[arg(long)]
+    pub raw: bool,
+
     // @dev: Ledger and Lab don't support signing arbitrary messages yet. Once they do, use `sign_with::Args` here.
     /// Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path.
     #[arg(
@@ -88,11 +93,17 @@ impl Cmd {
         let signer = secret.signer(self.hd_path, print.clone())?;
         let public_key = signer.get_public_key()?;
 
-        // Encode signature as base64
-        let signature_base64 = sep_53_sign(&message_bytes, signer).await?;
+        // The raw path signs the exact bytes (no SEP-53 prefix/hash) and outputs
+        // hex; the default path follows SEP-53 and outputs base64.
+        let signature = if self.raw {
+            let sig = signer.sign_data(&message_bytes)?;
+            hex::encode(sig.to_bytes())
+        } else {
+            sep_53_sign(&message_bytes, signer).await?
+        };
 
         print.infoln(format!("Signer: {public_key}"));
-        println!("{signature_base64}");
+        println!("{signature}");
         Ok(())
     }
 
@@ -187,6 +198,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: false,
+            raw: false,
             sign_with_key: TEST_SECRET_KEY.to_string(),
             hd_path: None,
             locator: locator.clone(),
@@ -209,6 +221,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: false,
+            raw: false,
             sign_with_key: TEST_SECRET_KEY.to_string(),
             hd_path: None,
             locator: locator.clone(),
@@ -231,6 +244,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: true,
+            raw: false,
             sign_with_key: TEST_SECRET_KEY.to_string(),
             hd_path: None,
             locator: locator.clone(),
@@ -241,6 +255,69 @@ mod tests {
         let signature_base64 = sep_53_sign(&message_bytes, signer).await.unwrap();
 
         assert_eq!(signature_base64, expected_signature);
+    }
+
+    /// Sign the exact bytes with ed25519 directly, bypassing the command, so the
+    /// test asserts against an independently derived value rather than the code path under test.
+    fn raw_sign_reference(message_bytes: &[u8]) -> String {
+        use ed25519_dalek::ed25519::signature::Signer as _;
+        let secret = Secret::from_str(TEST_SECRET_KEY).unwrap();
+        let signing_key = into_signing_key(&secret.private_key(None).unwrap());
+        hex::encode(signing_key.sign(message_bytes).to_bytes())
+    }
+
+    #[tokio::test]
+    async fn test_sign_raw_matches_plain_ed25519() {
+        let message = "challenge-1:abc123";
+        let expected = raw_sign_reference(message.as_bytes());
+
+        let signer = build_signer_for_test_key();
+        let sig = signer.sign_data(message.as_bytes()).unwrap();
+        let signature_hex = hex::encode(sig.to_bytes());
+
+        assert_eq!(signature_hex, expected);
+        assert_eq!(signature_hex.len(), 128, "raw signature is 128 hex chars");
+    }
+
+    #[tokio::test]
+    async fn test_sign_raw_differs_from_sep53() {
+        // The raw path must not apply the SEP-53 prefix or SHA-256 hashing, so
+        // its signature differs from the SEP-53 signature of the same message.
+        let message_bytes = b"Hello, World!".to_vec();
+
+        let raw_sig = build_signer_for_test_key()
+            .sign_data(&message_bytes)
+            .unwrap();
+        let raw_hex = hex::encode(raw_sig.to_bytes());
+
+        let sep53 = sep_53_sign(&message_bytes, build_signer_for_test_key())
+            .await
+            .unwrap();
+        let sep53_hex = hex::encode(BASE64.decode(&sep53).unwrap());
+
+        assert_ne!(raw_hex, sep53_hex);
+    }
+
+    #[tokio::test]
+    async fn test_sign_raw_with_base64_input() {
+        // `--raw` and `--base64` are orthogonal: decode the message from base64,
+        // then raw-sign the resulting bytes.
+        let message = "2zZDP1sa1BVBfLP7TeeMk3sUbaxAkUhBhDiNdrksaFo=".to_string();
+        let cmd = super::Cmd {
+            message: Some(message),
+            base64: true,
+            raw: true,
+            sign_with_key: TEST_SECRET_KEY.to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        let message_bytes = cmd.get_message_bytes().unwrap();
+        let expected = raw_sign_reference(&message_bytes);
+
+        let sig = build_signer_for_test_key()
+            .sign_data(&message_bytes)
+            .unwrap();
+        assert_eq!(hex::encode(sig.to_bytes()), expected);
     }
 
     #[test]

--- a/cmd/soroban-cli/src/commands/message/verify.rs
+++ b/cmd/soroban-cli/src/commands/message/verify.rs
@@ -132,8 +132,9 @@ impl Cmd {
             // Read from stdin
             let mut buffer = String::new();
             io::stdin().read_to_string(&mut buffer)?;
-            // Remove trailing newline if present
-            if buffer.ends_with('\n') {
+            // Remove trailing newline if present. The raw path verifies the
+            // exact bytes provided, mirroring `message sign --raw`.
+            if !self.raw && buffer.ends_with('\n') {
                 buffer.pop();
                 if buffer.ends_with('\r') {
                     buffer.pop();

--- a/cmd/soroban-cli/src/commands/message/verify.rs
+++ b/cmd/soroban-cli/src/commands/message/verify.rs
@@ -133,8 +133,10 @@ impl Cmd {
             let mut buffer = String::new();
             io::stdin().read_to_string(&mut buffer)?;
             // Remove trailing newline if present. The raw path verifies the
-            // exact bytes provided, mirroring `message sign --raw`.
-            if !self.raw && buffer.ends_with('\n') {
+            // exact bytes provided, mirroring `message sign --raw`. With --base64
+            // the payload is the decoded bytes, so the base64 text (and any shell
+            // newline) is still trimmed before decoding.
+            if (!self.raw || self.base64) && buffer.ends_with('\n') {
                 buffer.pop();
                 if buffer.ends_with('\r') {
                     buffer.pop();

--- a/cmd/soroban-cli/src/commands/message/verify.rs
+++ b/cmd/soroban-cli/src/commands/message/verify.rs
@@ -27,6 +27,9 @@ pub enum Error {
     Base64(#[from] base64::DecodeError),
 
     #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+
+    #[error(transparent)]
     StrKey(#[from] stellar_strkey::DecodeError),
 
     #[error(transparent)]
@@ -57,7 +60,12 @@ pub struct Cmd {
     #[arg(long)]
     pub base64: bool,
 
-    /// The base64-encoded signature to verify
+    /// Verify a raw signature: the message bytes were signed directly, without
+    /// the SEP-53 prefix or SHA-256 hashing, and `--signature` is hex-encoded.
+    #[arg(long)]
+    pub raw: bool,
+
+    /// The signature to verify. Base64-encoded by default, or hex-encoded with `--raw`.
     #[arg(long, short = 's')]
     pub signature: String,
 
@@ -78,17 +86,14 @@ impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let print = Print::new(global_args.quiet);
 
-        // Create the SEP-53 payload: prefix + message as utf-8 byte array
         let message_bytes = self.get_message_bytes()?;
-        let mut payload = Vec::with_capacity(SEP53_PREFIX.len() + message_bytes.len());
-        payload.extend_from_slice(SEP53_PREFIX.as_bytes());
-        payload.extend_from_slice(&message_bytes);
 
-        // Hash the payload with SHA-256
-        let hash: [u8; 32] = Sha256::digest(&payload).into();
-
-        // Decode the signature
-        let signature_bytes = BASE64.decode(&self.signature)?;
+        // Decode the signature: hex for the raw path, base64 for SEP-53.
+        let signature_bytes = if self.raw {
+            hex::decode(&self.signature)?
+        } else {
+            BASE64.decode(&self.signature)?
+        };
         if signature_bytes.len() != 64 {
             return Err(Error::InvalidSignatureLength(signature_bytes.len()));
         }
@@ -99,8 +104,19 @@ impl Cmd {
         print.infoln(format!("Verifying signature against: {public_key}"));
         let verifying_key = VerifyingKey::from_bytes(&public_key.0)?;
 
-        // Verify the signature
-        if verifying_key.verify(&hash, &signature).is_ok() {
+        // The raw path verifies over the exact message bytes; the default path
+        // verifies over SHA-256(SEP-53 prefix + message).
+        let verified = if self.raw {
+            verifying_key.verify(&message_bytes, &signature).is_ok()
+        } else {
+            let mut payload = Vec::with_capacity(SEP53_PREFIX.len() + message_bytes.len());
+            payload.extend_from_slice(SEP53_PREFIX.as_bytes());
+            payload.extend_from_slice(&message_bytes);
+            let hash: [u8; 32] = Sha256::digest(&payload).into();
+            verifying_key.verify(&hash, &signature).is_ok()
+        };
+
+        if verified {
             print.checkln("Signature valid");
             Ok(())
         } else {
@@ -189,6 +205,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: false,
+            raw: false,
             signature: signature.to_string(),
             public_key: TEST_PUBLIC_KEY.to_string(),
             hd_path: None,
@@ -209,6 +226,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: false,
+            raw: false,
             signature: signature.to_string(),
             public_key: TEST_PUBLIC_KEY.to_string(),
             hd_path: None,
@@ -229,6 +247,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: true,
+            raw: false,
             signature: signature.to_string(),
             public_key: TEST_PUBLIC_KEY.to_string(),
             hd_path: None,
@@ -247,6 +266,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: false,
+            raw: false,
             signature: FALSE_SIGNATURE.to_string(),
             public_key: TEST_PUBLIC_KEY.to_string(),
             hd_path: None,
@@ -266,6 +286,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some(message),
             base64: false,
+            raw: false,
             signature: signature.to_string(),
             public_key: FALSE_PUBLIC_KEY.to_string(),
             hd_path: None,
@@ -275,12 +296,66 @@ mod tests {
         assert!(successful.is_err());
     }
 
+    // Public key = GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L
+    const TEST_SECRET_KEY: &str = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
+
+    /// Hex ed25519 signature of the raw bytes, with no SEP-53 prefix or hashing.
+    fn raw_sign_hex(message_bytes: &[u8]) -> String {
+        use crate::{config::secret::Secret, utils::into_signing_key};
+        use ed25519_dalek::ed25519::signature::Signer as _;
+        use std::str::FromStr;
+        let secret = Secret::from_str(TEST_SECRET_KEY).unwrap();
+        let signing_key = into_signing_key(&secret.private_key(None).unwrap());
+        hex::encode(signing_key.sign(message_bytes).to_bytes())
+    }
+
+    #[test]
+    fn test_verify_raw_round_trip() {
+        let message = "challenge-1:abc123";
+        let signature = raw_sign_hex(message.as_bytes());
+
+        let cmd = super::Cmd {
+            message: Some(message.to_string()),
+            base64: false,
+            raw: true,
+            signature,
+            public_key: TEST_PUBLIC_KEY.to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        assert!(cmd.run(&global_args()).is_ok());
+    }
+
+    #[test]
+    fn test_verify_raw_rejects_sep53_signature() {
+        // A SEP-53 (base64) signature must not validate on the raw path: even if
+        // the hex decodes, it was produced over the prefixed+hashed payload.
+        let message = "Hello, World!";
+        let sep53_base64 = "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==";
+        let sep53_hex = hex::encode(BASE64.decode(sep53_base64).unwrap());
+
+        let cmd = super::Cmd {
+            message: Some(message.to_string()),
+            base64: false,
+            raw: true,
+            signature: sep53_hex,
+            public_key: TEST_PUBLIC_KEY.to_string(),
+            hd_path: None,
+            locator: setup_locator(),
+        };
+        assert!(matches!(
+            cmd.run(&global_args()),
+            Err(Error::VerificationFailed)
+        ));
+    }
+
     #[test]
     fn test_verify_rejects_raw_secret_key_as_public_key() {
         let secret_key = "SBF5HLRREHMS36XZNTUSKZ6FTXDZGNXOHF4EXKUL5UCWZLPBX3NGJ4BH";
         let cmd = super::Cmd {
             message: Some("Hello, World!".to_string()),
             base64: false,
+            raw: false,
             signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
             public_key: secret_key.to_string(),
             hd_path: None,
@@ -300,6 +375,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some("Hello, World!".to_string()),
             base64: false,
+            raw: false,
             signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
             public_key: seed_phrase.to_string(),
             hd_path: None,
@@ -317,6 +393,7 @@ mod tests {
         let cmd = super::Cmd {
             message: Some("Hello, World!".to_string()),
             base64: false,
+            raw: false,
             signature: "fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==".to_string(),
             public_key: "secure_store:org.stellar.cli-alice".to_string(),
             hd_path: None,

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -53,6 +53,8 @@ pub enum Error {
     Open(#[from] std::io::Error),
     #[error("Returning a signature from Lab is not yet supported; Transaction can be found and submitted in lab")]
     ReturningSignatureFromLab,
+    #[error("Signing arbitrary data is not supported for this signer")]
+    ArbitraryDataSigningNotSupported,
     #[error(transparent)]
     SecureStore(#[from] secure_store::Error),
     #[error(transparent)]
@@ -397,6 +399,19 @@ impl Signer {
         }
     }
 
+    /// Sign arbitrary-length data directly with ed25519, without any prefix or
+    /// hashing. Unlike `sign_payload`, which expects a fixed 32-byte digest,
+    /// this signs the exact bytes provided. Ledger and Lab signers do not
+    /// support this.
+    pub fn sign_data(&self, data: &[u8]) -> Result<Ed25519Signature, Error> {
+        match &self.kind {
+            SignerKind::Local(local_key) => Ok(local_key.key.sign(data)),
+            SignerKind::SecureStore(secure_store_entry) => secure_store_entry.sign_data(data),
+            SignerKind::Ledger(_) => Err(Error::ArbitraryDataSigningNotSupported),
+            SignerKind::Lab => Err(Error::ReturningSignatureFromLab),
+        }
+    }
+
     async fn sign_tx_hash(
         &self,
         tx_hash: [u8; 32],
@@ -478,6 +493,12 @@ impl SecureStoreEntry {
 
     pub fn sign_payload(&self, payload: [u8; 32]) -> Result<Ed25519Signature, Error> {
         let signed_bytes = secure_store::sign_tx_data(&self.name, self.hd_path, &payload)?;
+        let sig = Ed25519Signature::from_bytes(signed_bytes.as_slice().try_into()?);
+        Ok(sig)
+    }
+
+    pub fn sign_data(&self, data: &[u8]) -> Result<Ed25519Signature, Error> {
+        let signed_bytes = secure_store::sign_tx_data(&self.name, self.hd_path, data)?;
         let sig = Ed25519Signature::from_bytes(signed_bytes.as_slice().try_into()?);
         Ok(sig)
     }

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -407,8 +407,7 @@ impl Signer {
         match &self.kind {
             SignerKind::Local(local_key) => Ok(local_key.key.sign(data)),
             SignerKind::SecureStore(secure_store_entry) => secure_store_entry.sign_data(data),
-            SignerKind::Ledger(_) => Err(Error::ArbitraryDataSigningNotSupported),
-            SignerKind::Lab => Err(Error::ReturningSignatureFromLab),
+            SignerKind::Ledger(_) | SignerKind::Lab => Err(Error::ArbitraryDataSigningNotSupported),
         }
     }
 


### PR DESCRIPTION
### What

Adds a `--raw` flag to `stellar message sign` and `stellar message verify`. When set, the command signs the exact payload bytes directly with ed25519 — no `"Stellar Signed Message:\n"` prefix and no SHA-256 hashing — and outputs the signature as 128 hex characters. `message verify --raw` mirrors this, decoding a hex-encoded signature and verifying it against the raw message bytes. The default (SEP-53) behavior and its base64 output are unchanged, and `--raw` composes with the existing `--base64` input flag.

### Why

Resolves #2631. Some protocols (e.g. MPP) need a plain ed25519 signature over a specific payload such as `"{challengeId}:{txHash}"`, which the SEP-53 prefix-and-hash scheme prevents. This adds raw signing to the existing commands rather than introducing a new command.

### Known limitations

Raw signing is supported for local keys and OS secure-store keys only; Ledger and Lab signers return an error, consistent with the existing `message sign` behavior.