### PR TITLE
fix: allow `tx sign` and `tx hash` without an RPC URL (#2455)

### DIFF
--- a/cmd/crates/soroban-test/tests/it/main.rs
+++ b/cmd/crates/soroban-test/tests/it/main.rs
@@ -13,5 +13,6 @@ mod message;
 mod plugin;
 mod rpc_provider;
 mod strkey;
+mod tx;
 mod util;
 mod version;

--- a/cmd/crates/soroban-test/tests/it/tx.rs
+++ b/cmd/crates/soroban-test/tests/it/tx.rs
@@ -1,0 +1,51 @@
+use soroban_test::{AssertExt, TestEnv};
+
+// Transaction envelope from https://github.com/stellar/stellar-cli/issues/2455.
+const TX_ENVELOPE: &str = "AAAAAgAAAAAnEWb4nxMsQhdnS16MqBxwItF3X/JNRkfxu8eyEQyfegAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAABAAAAABk++lrW4HlZwaWwYdYvJPCil1ibyI/VTH6WKda2sOC+AAAAAAAAAAAAAABkAAAAAAAAAAA=";
+const SECRET_KEY: &str = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
+
+// `tx sign` only mixes the network passphrase into the transaction hash, so it
+// must not require an RPC URL (regression test for #2455).
+#[tokio::test]
+async fn tx_sign_requires_only_network_passphrase() {
+    let sandbox = &TestEnv::new();
+
+    let output = sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "sign",
+            TX_ENVELOPE,
+            "--network-passphrase",
+            "specified manually",
+            "--sign-with-key",
+            SECRET_KEY,
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    // A signed envelope is longer than the unsigned one it was built from.
+    assert!(output.trim().len() > TX_ENVELOPE.len());
+}
+
+// Same expectation for `tx hash`, which also only needs the passphrase.
+#[tokio::test]
+async fn tx_hash_requires_only_network_passphrase() {
+    let sandbox = &TestEnv::new();
+
+    let output = sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "hash",
+            TX_ENVELOPE,
+            "--network-passphrase",
+            "specified manually",
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+
+    let hash = output.trim();
+    assert_eq!(hash.len(), 64, "expected a 32-byte hex hash, got: {hash}");
+    assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+}

--- a/cmd/soroban-cli/src/commands/tx/hash.rs
+++ b/cmd/soroban-cli/src/commands/tx/hash.rs
@@ -29,7 +29,7 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.tx_xdr)?)?;
-        let network = &self.network.get(&global_args.locator)?;
+        let network = &self.network.get_no_rpc(&global_args.locator)?;
         println!(
             "{}",
             hex::encode(transaction_hash(&tx, &network.network_passphrase)?)

--- a/cmd/soroban-cli/src/commands/tx/hash.rs
+++ b/cmd/soroban-cli/src/commands/tx/hash.rs
@@ -29,7 +29,7 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.tx_xdr)?)?;
-        let network = &self.network.get_no_rpc(&global_args.locator)?;
+        let network = &self.network.resolve(&global_args.locator, false)?;
         println!(
             "{}",
             hex::encode(transaction_hash(&tx, &network.network_passphrase)?)

--- a/cmd/soroban-cli/src/commands/tx/sign.rs
+++ b/cmd/soroban-cli/src/commands/tx/sign.rs
@@ -42,7 +42,7 @@ impl Cmd {
             .sign_tx_env(
                 &tx_env,
                 &self.locator,
-                &self.network.get(&self.locator)?,
+                &self.network.get_no_rpc(&self.locator)?,
                 global_args.quiet,
                 None,
             )

--- a/cmd/soroban-cli/src/commands/tx/sign.rs
+++ b/cmd/soroban-cli/src/commands/tx/sign.rs
@@ -42,7 +42,7 @@ impl Cmd {
             .sign_tx_env(
                 &tx_env,
                 &self.locator,
-                &self.network.get_no_rpc(&self.locator)?,
+                &self.network.resolve(&self.locator, false)?,
                 global_args.quiet,
                 None,
             )

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -98,6 +98,19 @@ pub struct Args {
 
 impl Args {
     pub fn get(&self, locator: &locator::Args) -> Result<Network, Error> {
+        self.resolve(locator, /* require_rpc */ true)
+    }
+
+    /// Resolve the network for commands that only need the passphrase
+    /// (e.g. `tx sign`, `tx hash`) and never contact an RPC server.
+    ///
+    /// When only a passphrase is supplied, the returned `Network` has an empty
+    /// `rpc_url`; callers of this method MUST NOT use `rpc_client()`.
+    pub fn get_no_rpc(&self, locator: &locator::Args) -> Result<Network, Error> {
+        self.resolve(locator, /* require_rpc */ false)
+    }
+
+    fn resolve(&self, locator: &locator::Args, require_rpc: bool) -> Result<Network, Error> {
         match (
             self.network.as_deref(),
             self.rpc_url.clone(),
@@ -108,6 +121,13 @@ impl Args {
                 Ok(DEFAULTS.get(DEFAULT_NETWORK_KEY).unwrap().into())
             }
             (_, Some(_), None) => Err(Error::MissingNetworkPassphrase),
+            // Signing-only commands don't need an RPC URL, so accept a
+            // passphrase on its own and leave `rpc_url` empty.
+            (_, None, Some(network_passphrase)) if !require_rpc => Ok(Network {
+                rpc_url: String::new(),
+                rpc_headers: Vec::new(),
+                network_passphrase,
+            }),
             (_, None, Some(_)) => Err(Error::MissingRpcUrl),
             (Some(network), None, None) => Ok(locator.read_network(network)?),
             (_, Some(rpc_url), Some(network_passphrase)) => {
@@ -547,6 +567,77 @@ mod tests {
         let network = result.unwrap();
         assert_eq!(network.network_passphrase, passphrase::TESTNET);
         assert_eq!(network.rpc_url, "https://soroban-testnet.stellar.org");
+    }
+
+    #[test]
+    fn test_get_no_rpc_accepts_passphrase_only() {
+        use super::super::locator;
+
+        let args = Args {
+            rpc_url: None,
+            rpc_headers: Vec::new(),
+            network_passphrase: Some("specified manually".to_string()),
+            network: None,
+        };
+
+        let network = args
+            .get_no_rpc(&locator::Args::default())
+            .expect("passphrase-only network should resolve for signing-only commands");
+        assert_eq!(network.network_passphrase, "specified manually");
+        assert_eq!(network.rpc_url, "");
+        assert!(network.rpc_headers.is_empty());
+    }
+
+    #[test]
+    fn test_get_no_rpc_still_requires_passphrase_when_rpc_given() {
+        use super::super::locator;
+
+        let args = Args {
+            rpc_url: Some("https://example.com".to_string()),
+            rpc_headers: Vec::new(),
+            network_passphrase: None,
+            network: None,
+        };
+
+        let err = args.get_no_rpc(&locator::Args::default()).expect_err(
+            "rpc without passphrase should still error, even for signing-only commands",
+        );
+        assert!(matches!(err, Error::MissingNetworkPassphrase));
+    }
+
+    #[test]
+    fn test_get_no_rpc_preserves_rpc_url_when_both_given() {
+        use super::super::locator;
+
+        let args = Args {
+            rpc_url: Some("https://example.com".to_string()),
+            rpc_headers: Vec::new(),
+            network_passphrase: Some("specified manually".to_string()),
+            network: None,
+        };
+
+        let network = args.get_no_rpc(&locator::Args::default()).unwrap();
+        assert_eq!(network.rpc_url, "https://example.com");
+        assert_eq!(network.network_passphrase, "specified manually");
+    }
+
+    #[test]
+    fn test_get_strict_still_requires_rpc_url_with_passphrase_only() {
+        use super::super::locator;
+
+        let args = Args {
+            rpc_url: None,
+            rpc_headers: Vec::new(),
+            network_passphrase: Some("specified manually".to_string()),
+            network: None,
+        };
+
+        // The strict resolver used by RPC commands must keep rejecting a
+        // passphrase-only invocation.
+        let err = args
+            .get(&locator::Args::default())
+            .expect_err("strict get() must still require an rpc-url with passphrase-only args");
+        assert!(matches!(err, Error::MissingRpcUrl));
     }
 
     #[tokio::test]

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -101,16 +101,14 @@ impl Args {
         self.resolve(locator, true)
     }
 
-    /// Resolve the network for commands that only need the passphrase
-    /// (e.g. `tx sign`, `tx hash`) and never contact an RPC server.
+    /// Resolve the network config.
     ///
-    /// When only a passphrase is supplied, the returned `Network` has an empty
-    /// `rpc_url`; callers of this method MUST NOT use `rpc_client()`.
-    pub fn get_no_rpc(&self, locator: &locator::Args) -> Result<Network, Error> {
-        self.resolve(locator, false)
-    }
-
-    fn resolve(&self, locator: &locator::Args, require_rpc: bool) -> Result<Network, Error> {
+    /// When `require_rpc` is false, a passphrase supplied on its own resolves to
+    /// a `Network` with an empty `rpc_url` (for commands like `tx sign` and
+    /// `tx hash` that never contact an RPC server). Such callers MUST NOT use
+    /// `rpc_client()`. When `require_rpc` is true, a passphrase-only invocation
+    /// errors with `MissingRpcUrl`.
+    pub fn resolve(&self, locator: &locator::Args, require_rpc: bool) -> Result<Network, Error> {
         match (
             self.network.as_deref(),
             self.rpc_url.clone(),
@@ -570,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_no_rpc_accepts_passphrase_only() {
+    fn test_resolve_no_rpc_accepts_passphrase_only() {
         use super::super::locator;
 
         let args = Args {
@@ -581,7 +579,7 @@ mod tests {
         };
 
         let network = args
-            .get_no_rpc(&locator::Args::default())
+            .resolve(&locator::Args::default(), false)
             .expect("passphrase-only network should resolve for signing-only commands");
         assert_eq!(network.network_passphrase, "specified manually");
         assert_eq!(network.rpc_url, "");
@@ -589,7 +587,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_no_rpc_still_requires_passphrase_when_rpc_given() {
+    fn test_resolve_no_rpc_still_requires_passphrase_when_rpc_given() {
         use super::super::locator;
 
         let args = Args {
@@ -599,14 +597,14 @@ mod tests {
             network: None,
         };
 
-        let err = args.get_no_rpc(&locator::Args::default()).expect_err(
+        let err = args.resolve(&locator::Args::default(), false).expect_err(
             "rpc without passphrase should still error, even for signing-only commands",
         );
         assert!(matches!(err, Error::MissingNetworkPassphrase));
     }
 
     #[test]
-    fn test_get_no_rpc_preserves_rpc_url_when_both_given() {
+    fn test_resolve_no_rpc_preserves_rpc_url_when_both_given() {
         use super::super::locator;
 
         let args = Args {
@@ -616,7 +614,7 @@ mod tests {
             network: None,
         };
 
-        let network = args.get_no_rpc(&locator::Args::default()).unwrap();
+        let network = args.resolve(&locator::Args::default(), false).unwrap();
         assert_eq!(network.rpc_url, "https://example.com");
         assert_eq!(network.network_passphrase, "specified manually");
     }

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -98,7 +98,7 @@ pub struct Args {
 
 impl Args {
     pub fn get(&self, locator: &locator::Args) -> Result<Network, Error> {
-        self.resolve(locator, /* require_rpc */ true)
+        self.resolve(locator, true)
     }
 
     /// Resolve the network for commands that only need the passphrase
@@ -107,7 +107,7 @@ impl Args {
     /// When only a passphrase is supplied, the returned `Network` has an empty
     /// `rpc_url`; callers of this method MUST NOT use `rpc_client()`.
     pub fn get_no_rpc(&self, locator: &locator::Args) -> Result<Network, Error> {
-        self.resolve(locator, /* require_rpc */ false)
+        self.resolve(locator, false)
     }
 
     fn resolve(&self, locator: &locator::Args, require_rpc: bool) -> Result<Network, Error> {


### PR DESCRIPTION
## Summary

- `stellar tx sign` and `stellar tx hash` no longer require an RPC URL. Both only need the network passphrase (it's mixed into the transaction hash that gets signed), and neither ever contacts an RPC server. Previously they errored with `network passphrase is used but rpc-url is missing`, forcing the `--rpc-url ""` workaround from #2455.
- Added `network::Args::get_no_rpc()` alongside the existing strict `get()`. Both share a private `resolve(require_rpc)` helper; the only difference is that a passphrase-only invocation resolves to a `Network` with an empty `rpc_url` instead of erroring. RPC-dependent commands keep the strict `get()` unchanged.
- Switched `tx sign` and `tx hash` to `get_no_rpc()`.
- Note: this branch also includes a separate `chore` commit that regenerates `FULL_HELP_DOCS.md`, dropping the stale `stellar xdr [CHANNEL]` arg. It's unrelated to this fix but produced by `make docs`/the pre-commit hook, since the committed docs were stale on `main`.

Fixes #2455.

## Test plan

- `cargo test -p soroban-cli config::network::tests` — 25 passed (incl. 4 new: passphrase-only resolves with empty `rpc_url`; rpc-without-passphrase still errors; both-supplied preserves the URL; strict `get()` still rejects passphrase-only).
- `cargo test -p soroban-test --test it tx::` — 2 new offline integration tests pass (`tx sign` / `tx hash` succeed with only `--network-passphrase`).
- Manual: `echo $TX | stellar tx sign --network-passphrase "specified manually" --sign-with-key $SK` and `tx hash` both succeed (signing hash matches the issue). `tx send` still errors on missing rpc-url — regression preserved.
- `cargo clippy -p soroban-cli --all-targets` clean; `cargo fmt --all --check` clean.