### PR TITLE
Add `stellar container use` to set the default engine

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1660,6 +1660,8 @@ Start local networks in containers
 - `logs` — Get logs from a running network container
 - `start` — Start a container running a Stellar node, RPC, API, and friendbot (faucet)
 - `stop` — Stop a network container started with `stellar container start`
+- `use` — Set the default container engine used by `stellar container` commands
+- `unset` — Unset the default container engine defined previously with `container use <engine>`
 
 ## `stellar container logs`
 
@@ -1738,6 +1740,34 @@ Stop a network container started with `stellar container start`
   Possible values:
   - `docker`: Docker, or any Docker-compatible CLI
   - `apple-container`: Apple's `container` CLI (macOS 26+, Apple silicon)
+
+## `stellar container use`
+
+Set the default container engine used by `stellar container` commands
+
+**Usage:** `stellar container use [OPTIONS] <ENGINE>`
+
+###### **Arguments:**
+
+- `<ENGINE>` — Container engine to use by default
+
+  Possible values:
+  - `docker`: Docker, or any Docker-compatible CLI
+  - `apple-container`: Apple's `container` CLI (macOS 26+, Apple silicon)
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+## `stellar container unset`
+
+Unset the default container engine defined previously with `container use <engine>`
+
+**Usage:** `stellar container unset [OPTIONS]`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
 
 ## `stellar config`
 

--- a/cmd/crates/soroban-test/tests/it/container.rs
+++ b/cmd/crates/soroban-test/tests/it/container.rs
@@ -267,6 +267,68 @@ fn warns_and_drops_docker_host_for_apple_engine() {
 }
 
 #[test]
+fn use_persists_default_engine_for_later_commands() {
+    let s = EngineSandbox::new();
+    s.install_engine("docker");
+    s.install_engine("container");
+
+    s.cmd("ok")
+        .args(["use", "apple-container"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "default container engine is set to `apple-container`",
+        ));
+
+    // A later command with no `--engine` flag and no env override honors the
+    // stored default (config -> STELLAR_CONTAINER_ENGINE -> resolution).
+    s.cmd("ok").args(["start", "local"]).assert().success();
+    assert!(line_for(&s.invocations(), " run ").starts_with("container "));
+}
+
+#[test]
+fn unset_reverts_to_docker_default() {
+    let s = EngineSandbox::new();
+    s.install_engine("docker");
+    s.install_engine("container");
+
+    s.cmd("ok")
+        .args(["use", "apple-container"])
+        .assert()
+        .success();
+    s.cmd("ok")
+        .args(["unset"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "default container engine has been unset",
+        ));
+
+    // With the default cleared and no flag/env, we fall back to docker.
+    s.cmd("ok").args(["start", "local"]).assert().success();
+    assert!(line_for(&s.invocations(), " run ").starts_with("docker "));
+}
+
+#[test]
+fn explicit_engine_overrides_stored_default() {
+    let s = EngineSandbox::new();
+    s.install_engine("docker");
+    s.install_engine("container");
+
+    s.cmd("ok")
+        .args(["use", "apple-container"])
+        .assert()
+        .success();
+
+    // The flag wins over the stored default.
+    s.cmd("ok")
+        .args(["stop", "local", "--engine", "docker"])
+        .assert()
+        .success();
+    assert!(line_for(&s.invocations(), " stop ").starts_with("docker "));
+}
+
+#[test]
 fn errors_when_engine_binary_is_missing() {
     // No engine installed on the isolated PATH.
     let s = EngineSandbox::new();

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -122,6 +122,7 @@ fn set_env_from_config() {
     set_env_value_from_config("STELLAR_ACCOUNT", config.defaults.identity);
     set_env_value_from_config("STELLAR_NETWORK", config.defaults.network);
     set_env_value_from_config("STELLAR_INCLUSION_FEE", config.defaults.inclusion_fee);
+    set_env_value_from_config("STELLAR_CONTAINER_ENGINE", config.defaults.container_engine);
 }
 
 // Resolve the effective JSON output `Format` for the top-level error handler

--- a/cmd/soroban-cli/src/commands/container/mod.rs
+++ b/cmd/soroban-cli/src/commands/container/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod logs;
 pub(crate) mod shared;
 pub(crate) mod start;
 pub(crate) mod stop;
+pub(crate) mod unset;
+pub(crate) mod use_engine;
 
 // TODO: remove once `network start` is removed
 pub type StartCmd = start::Cmd;
@@ -24,6 +26,10 @@ pub enum Cmd {
     Start(start::Cmd),
     /// Stop a network container started with `stellar container start`.
     Stop(stop::Cmd),
+    /// Set the default container engine used by `stellar container` commands.
+    Use(use_engine::Cmd),
+    /// Unset the default container engine defined previously with `container use <engine>`.
+    Unset(unset::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -36,6 +42,12 @@ pub enum Error {
 
     #[error(transparent)]
     Stop(#[from] stop::Error),
+
+    #[error(transparent)]
+    Use(#[from] use_engine::Error),
+
+    #[error(transparent)]
+    Unset(#[from] unset::Error),
 }
 
 impl Cmd {
@@ -44,6 +56,8 @@ impl Cmd {
             Cmd::Logs(cmd) => cmd.run(global_args).await?,
             Cmd::Start(cmd) => cmd.run(global_args).await?,
             Cmd::Stop(cmd) => cmd.run(global_args).await?,
+            Cmd::Use(cmd) => cmd.run(global_args)?,
+            Cmd::Unset(cmd) => cmd.run(global_args)?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/container/unset.rs
+++ b/cmd/soroban-cli/src/commands/container/unset.rs
@@ -1,0 +1,26 @@
+use crate::{commands::global, config::locator, print::Print};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] locator::Error),
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+}
+
+impl Cmd {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = Print::new(global_args.quiet);
+
+        self.config_locator.unset_default_container_engine()?;
+
+        print.infoln("The default container engine has been unset".to_string());
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/container/use_engine.rs
+++ b/cmd/soroban-cli/src/commands/container/use_engine.rs
@@ -1,0 +1,41 @@
+use crate::{commands::global, config::locator, print::Print};
+
+use super::shared::Engine;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] locator::Error),
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// Container engine to use by default.
+    pub engine: Engine,
+
+    #[command(flatten)]
+    pub config_locator: locator::Args,
+}
+
+impl Cmd {
+    pub fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let print = Print::new(global_args.quiet);
+
+        if std::env::var("STELLAR_CONTAINER_ENGINE").is_ok()
+            && std::env::var("STELLAR_CONTAINER_ENGINE_SOURCE").is_err()
+        {
+            print.warnln("Environment variable STELLAR_CONTAINER_ENGINE is set, which will override this default engine.");
+        }
+
+        self.config_locator
+            .write_default_container_engine(&self.engine.to_string())?;
+
+        print.infoln(format!(
+            "The default container engine is set to `{}`",
+            self.engine
+        ));
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -236,6 +236,18 @@ impl Args {
             .save_to(&path)
     }
 
+    pub fn write_default_container_engine(&self, engine: &str) -> Result<(), Error> {
+        let path = self.global_config_path()?.join("config.toml");
+        Config::load(&path)?
+            .set_container_engine(engine)
+            .save_to(&path)
+    }
+
+    pub fn unset_default_container_engine(&self) -> Result<(), Error> {
+        let path = self.global_config_path()?.join("config.toml");
+        Config::load(&path)?.unset_container_engine().save_to(&path)
+    }
+
     pub fn unset_default_identity(&self) -> Result<(), Error> {
         let path = self.global_config_path()?.join("config.toml");
         Config::load(&path)?.unset_identity().save_to(&path)

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -237,6 +237,7 @@ pub struct Defaults {
     pub network: Option<String>,
     pub identity: Option<String>,
     pub inclusion_fee: Option<u32>,
+    pub container_engine: Option<String>,
 }
 
 impl Config {
@@ -274,6 +275,12 @@ impl Config {
     }
 
     #[must_use]
+    pub fn set_container_engine(mut self, s: &str) -> Self {
+        self.defaults.container_engine = Some(s.to_string());
+        self
+    }
+
+    #[must_use]
     pub fn unset_identity(mut self) -> Self {
         self.defaults.identity = None;
         self
@@ -288,6 +295,12 @@ impl Config {
     #[must_use]
     pub fn unset_inclusion_fee(mut self) -> Self {
         self.defaults.inclusion_fee = None;
+        self
+    }
+
+    #[must_use]
+    pub fn unset_container_engine(mut self) -> Self {
+        self.defaults.container_engine = None;
         self
     }
 


### PR DESCRIPTION
### What

Adds two subcommands for managing a persistent default container engine:

- `stellar container use <engine>` — writes the chosen engine (`docker` or `apple-container`) to the global `config.toml` under `defaults.container_engine`.
- `stellar container unset` — removes that persisted default.

On startup the persisted default is loaded into `STELLAR_CONTAINER_ENGINE` via `set_env_from_config`, so it feeds the existing engine resolution without a new code path. An explicit `--engine` flag or an already-set `STELLAR_CONTAINER_ENGINE` still takes precedence, and `container use` warns when the env var is set since it would override the value being saved.

Config plumbing: a `container_engine` field on `Defaults`, `set_container_engine`/`unset_container_engine` on `Config`, and `write_default_container_engine`/`unset_default_container_engine` on the locator.

### Why

Builds on the `--engine` flag (base branch) so users no longer have to pass `--engine` on every `stellar container` invocation. Setting the engine once persists it across commands, matching how other `stellar` defaults (network, identity) already work.

### Known limitations

N/A