### PR TITLE
Add CPU and memory limits to container start

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1709,6 +1709,8 @@ By default, when starting a testnet container, without any optional arguments, i
   - `docker`: Docker, or any Docker-compatible CLI
   - `apple-container`: Apple's `container` CLI (macOS 26+, Apple silicon)
 
+- `--cpus <CPUS>` — Limit the number of CPUs available to the container, e.g. `2`. A whole number: Apple's `container` engine does not accept fractional CPUs
+- `--memory <MEMORY>` — Limit the memory available to the container, e.g. `2g` or `512m`
 - `--name <NAME>` — Optional argument to specify the container name
 - `-l`, `--limits <LIMITS>` — Optional argument to specify the limits for the local network only
 - `-p`, `--ports-mapping <PORTS_MAPPING>` — Argument to specify the `HOST_PORT:CONTAINER_PORT` mapping

--- a/cmd/crates/soroban-test/tests/it/container.rs
+++ b/cmd/crates/soroban-test/tests/it/container.rs
@@ -125,6 +125,21 @@ fn start_defaults_to_docker_and_passes_expected_args() {
 }
 
 #[test]
+fn start_passes_cpu_and_memory_limits_to_run() {
+    let s = EngineSandbox::new();
+    s.install_engine("docker");
+
+    s.cmd("ok")
+        .args(["start", "local", "--cpus", "2", "--memory", "2g"])
+        .assert()
+        .success();
+
+    let run = line_for(&s.invocations(), " run ");
+    assert!(run.contains("--cpus 2"), "run line: {run}");
+    assert!(run.contains("--memory 2g"), "run line: {run}");
+}
+
+#[test]
 fn start_passes_docker_host_as_h_flag() {
     let s = EngineSandbox::new();
     s.install_engine("docker");

--- a/cmd/soroban-cli/src/commands/container/shared.rs
+++ b/cmd/soroban-cli/src/commands/container/shared.rs
@@ -238,6 +238,45 @@ impl Args {
     }
 }
 
+/// Resource limits for commands that *run* a container (e.g. `container start`).
+/// Kept separate from [`Args`] so commands like `stop`/`logs`, which only act on
+/// an existing container, don't advertise flags they ignore. Both `--cpus` and
+/// `--memory` are accepted verbatim by docker and Apple's `container` on `run`,
+/// so the values pass through unparsed.
+#[derive(Debug, clap::Parser, Clone, Default)]
+pub struct RunArgs {
+    /// Limit the number of CPUs available to the container, e.g. `2`. A whole
+    /// number: Apple's `container` engine does not accept fractional CPUs.
+    #[arg(long)]
+    pub cpus: Option<u32>,
+
+    /// Limit the memory available to the container, e.g. `2g` or `512m`.
+    #[arg(long)]
+    pub memory: Option<String>,
+}
+
+impl RunArgs {
+    /// The resource-limit flags as `run` argv tokens (`--cpus <n>`,
+    /// `--memory <size>`); empty when no limit is set.
+    pub(crate) fn flags(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(cpus) = &self.cpus {
+            out.push("--cpus".to_string());
+            out.push(cpus.to_string());
+        }
+        if let Some(memory) = &self.memory {
+            out.push("--memory".to_string());
+            out.push(memory.clone());
+        }
+        out
+    }
+
+    /// Append the resource-limit flags to a `run` command. A no-op when unset.
+    pub(crate) fn apply(&self, cmd: &mut Command) {
+        cmd.args(self.flags());
+    }
+}
+
 #[derive(ValueEnum, Debug, Copy, Clone, PartialEq)]
 pub enum Network {
     Local,
@@ -446,5 +485,26 @@ mod test {
             r#"Error: internalError: "failed to stop container" (cause: "notFound: "container with ID stellar-local not found"")"#
         ));
         assert!(!apple.is_container_not_found("some unrelated failure"));
+    }
+
+    #[test]
+    fn run_args_flags_emit_only_set_limits() {
+        assert!(RunArgs::default().flags().is_empty());
+        assert_eq!(
+            RunArgs {
+                cpus: Some(1),
+                memory: None,
+            }
+            .flags(),
+            ["--cpus", "1"]
+        );
+        assert_eq!(
+            RunArgs {
+                cpus: Some(2),
+                memory: Some("2g".to_string()),
+            }
+            .flags(),
+            ["--cpus", "2", "--memory", "2g"]
+        );
     }
 }

--- a/cmd/soroban-cli/src/commands/container/start.rs
+++ b/cmd/soroban-cli/src/commands/container/start.rs
@@ -11,7 +11,7 @@ use crate::{
     print,
 };
 
-use super::shared::{Args, Name};
+use super::shared::{Args, Name, RunArgs};
 
 const DEFAULT_PORT_MAPPING: &str = "8000:8000";
 const DOCKER_IMAGE: &str = "docker.io/stellar/quickstart";
@@ -32,6 +32,9 @@ pub enum Error {
 pub struct Cmd {
     #[command(flatten)]
     pub container_args: Args,
+
+    #[command(flatten)]
+    pub run_args: RunArgs,
 
     /// Network to start. Default is `local`
     pub network: Option<Network>,
@@ -90,6 +93,7 @@ impl Runner {
             .args
             .container_args
             .run_command(&container_name, &self.args.ports_mapping);
+        self.args.run_args.apply(&mut cmd);
         cmd.arg(&image);
         // Each element of `get_container_args` is passed as a single argv token (some elements,
         // such as "--enable rpc,horizon,lab", intentionally contain spaces).


### PR DESCRIPTION
### What

Adds `--cpus` and `--memory` flags to `stellar container start`, applied as resource limits on the container `run` command.

They live in a new `shared::RunArgs` group kept separate from the connection `Args`, so commands that only act on an existing container (`stop`, `logs`) don't advertise flags they'd ignore. Both values pass through unparsed, which docker and Apple's `container` both accept on `run`.

### Why

Lets users cap the CPU and memory a local network container consumes, rather than letting it use the host's full resources.

### Known limitations

`--cpus`/`--memory` are forwarded verbatim to the selected engine; the CLI does not validate the values, so an engine-specific parse error surfaces from the engine itself.