### PR TITLE
Make `latest` the default quickstart image tag

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1692,7 +1692,7 @@ Start a container running a Stellar node, RPC, API, and friendbot (faucet).
 
 By default, when starting a testnet container, without any optional arguments, it will run the equivalent of the following docker command:
 
-`docker run --rm -p 8000:8000 --name stellar stellar/quickstart:testing --testnet --enable rpc,horizon`
+`docker run --rm -p 8000:8000 --name stellar stellar/quickstart:latest --testnet --enable rpc,horizon`
 
 **Usage:** `stellar container start [OPTIONS] [NETWORK]`
 

--- a/cmd/crates/soroban-test/tests/it/container.rs
+++ b/cmd/crates/soroban-test/tests/it/container.rs
@@ -115,13 +115,42 @@ fn start_defaults_to_docker_and_passes_expected_args() {
 
     let log = s.invocations();
     // Pulled and ran via docker (not the apple `image pull` form).
-    assert!(line_for(&log, "pull").starts_with("docker pull "));
+    let pull = line_for(&log, "pull");
+    assert!(pull.starts_with("docker pull "));
+    // Local defaults to the published `latest` tag, not the unpublished `testing` tag.
+    assert!(
+        pull.contains("docker.io/stellar/quickstart:latest"),
+        "pull line: {pull}"
+    );
     let run = line_for(&log, " run ");
     assert!(run.starts_with("docker "), "expected docker binary: {run}");
+    assert!(
+        run.contains("docker.io/stellar/quickstart:latest"),
+        "run line: {run}"
+    );
     assert!(run.contains("--name stellar-local"), "run line: {run}");
     assert!(run.contains("-p 8000:8000"), "run line: {run}");
     // No host override unless requested.
     assert!(!run.contains("-H "), "unexpected -H: {run}");
+}
+
+#[test]
+fn start_testnet_defaults_to_latest_image_tag() {
+    let s = EngineSandbox::new();
+    s.install_engine("docker");
+
+    s.cmd("ok").args(["start", "testnet"]).assert().success();
+
+    let log = s.invocations();
+    // Testnet, like local, now defaults to the published `latest` tag.
+    assert!(
+        line_for(&log, "pull").contains("docker.io/stellar/quickstart:latest"),
+        "pull line: {log}"
+    );
+    assert!(
+        line_for(&log, " run ").contains("docker.io/stellar/quickstart:latest"),
+        "run line: {log}"
+    );
 }
 
 #[test]

--- a/cmd/soroban-cli/src/commands/container/mod.rs
+++ b/cmd/soroban-cli/src/commands/container/mod.rs
@@ -22,7 +22,7 @@ pub enum Cmd {
     ///
     /// By default, when starting a testnet container, without any optional arguments, it will run the equivalent of the following docker command:
     ///
-    /// `docker run --rm -p 8000:8000 --name stellar stellar/quickstart:testing --testnet --enable rpc,horizon`
+    /// `docker run --rm -p 8000:8000 --name stellar stellar/quickstart:latest --testnet --enable rpc,horizon`
     Start(start::Cmd),
     /// Stop a network container started with `stellar container start`.
     Stop(stop::Cmd),

--- a/cmd/soroban-cli/src/commands/container/start.rs
+++ b/cmd/soroban-cli/src/commands/container/start.rs
@@ -165,11 +165,10 @@ impl Runner {
     }
 
     fn get_image_name(&self) -> String {
-        // this can be overriden with the `-t` flag
         let mut image_tag = match &self.network {
-            Network::Pubnet => "latest",
             Network::Futurenet => "future",
-            _ => "testing", // default to testing for local and testnet
+            // pubnet, local, and testnet all default to latest
+            _ => "latest",
         };
 
         if let Some(image_override) = &self.args.image_tag_override {


### PR DESCRIPTION
### What

Change the default quickstart container image tag for local and testnet networks from `testing` to `latest` in `stellar container start`.

### Why

Now that we've stopped publishing public core `testing` images ([pipelines#1074](https://github.com/stellar/pipelines/pull/1074)) and only stable builds go to testnet, the `testing` tag is no longer meaningful as a distinct default.