### PR TITLE
Add `stellar token balance` command

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1897,6 +1897,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 ###### **Subcommands:**
 
 - `transfer` — Transfer tokens from one account to another
+- `balance` — Read the token balance of an account or contract
 
 ## `stellar token transfer`
 
@@ -1937,6 +1938,37 @@ Transfer tokens from one account to another
 - `--sign-with-lab` — Sign with https://lab.stellar.org
 - `--sign-with-ledger` — Sign with a ledger wallet
 - `--auto-sign` — Sign without prompting for approval. Only applies to signatures that require user approval, like non-root Soroban auth entries
+
+## `stellar token balance`
+
+Read the token balance of an account or contract
+
+**Usage:** `stellar token balance [OPTIONS] --id <ID> --account <ACCOUNT>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
+- `--account <ACCOUNT>` — Account or contract whose balance to read
+- `--decimal` — Format the balance as a decimal using the token's `decimals`, instead of the raw smallest unit (stroops for a Stellar Asset Contract)
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON receipt
+  - `json-formatted`: Formatted (multiline) JSON receipt
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar tx`
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/balance.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/balance.rs
@@ -1,0 +1,111 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{
+    token::{add_trustline, deploy_sac, issuer_pays},
+    util::{new_account, test_address},
+};
+
+/// Run `stellar token balance ... --output json` and return the parsed value.
+fn balance_json(sandbox: &TestEnv, id: &str, account: &str, decimal: bool) -> Value {
+    let mut args = vec![
+        "balance",
+        "--id",
+        id,
+        "--account",
+        account,
+        "--output",
+        "json",
+    ];
+    if decimal {
+        args.push("--decimal");
+    }
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(args)
+        .assert()
+        .success()
+        .stdout_as_str();
+    serde_json::from_str(&stdout).unwrap()
+}
+
+#[tokio::test]
+async fn balance_returns_stroops_and_optional_decimal() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // Give `test` a known balance: 12_300_000 stroops == 1.23 units (7 decimals).
+    add_trustline(sandbox, "test", &asset);
+    issuer_pays(sandbox, "issuer", &test, &asset, 12_300_000);
+    deploy_sac(sandbox, &asset, "issuer");
+
+    // Default: raw stroops, as a string.
+    let raw = balance_json(sandbox, &asset, "test", false);
+    assert_eq!(raw["balance"], "12300000", "raw balance, got: {raw}");
+    assert!(
+        raw.get("decimals").is_none(),
+        "no decimals without --decimal"
+    );
+
+    // `--decimal`: decimal-aware value plus the token's decimals.
+    let dec = balance_json(sandbox, &asset, "test", true);
+    assert_eq!(dec["balance"], "1.23", "decimal balance, got: {dec}");
+    assert_eq!(dec["decimals"], 7, "decimals, got: {dec}");
+}
+
+#[tokio::test]
+async fn balance_zero_for_account_without_holdings() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // A holder with a trustline but no issuance holds a zero balance.
+    let holder = new_account(sandbox, "holder");
+    add_trustline(sandbox, "holder", &asset);
+    deploy_sac(sandbox, &asset, "issuer");
+
+    let raw = balance_json(sandbox, &asset, &holder, false);
+    assert_eq!(raw["balance"], "0", "expected zero balance, got: {raw}");
+}
+
+#[tokio::test]
+async fn balance_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed for this asset → structured deploy-pointer error.
+    sandbox
+        .new_assert_cmd("token")
+        .args(["balance", "--id", &asset, "--account", "test"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("contract asset deploy"));
+
+    // In JSON mode the error carries a machine-readable `type` discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "balance",
+            "--id",
+            &asset,
+            "--account",
+            "test",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+    assert!(
+        value["error"]["message"].as_str().is_some(),
+        "expected an error message, got: {stdout}"
+    );
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,3 +1,4 @@
+pub mod balance;
 pub mod transfer;
 
 use soroban_test::{AssertExt, TestEnv};

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -100,7 +100,7 @@ pub async fn main() {
         // failure, the JSON body is just a parseable representation of it.
         if let Some(format) = json_error_format(&root.cmd) {
             let output = crate::output::Output::new(format, root.global_args.quiet);
-            let _ = output.json_value(&crate::output::error_json(&e));
+            let _ = output.json_value(&crate::output::error_json(&e, error_type(&e)));
             std::process::exit(1);
         }
         printer.errorln(format!("error: {e}"));
@@ -143,10 +143,21 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Network(network::Cmd::Info(cmd)) => cmd.output.into(),
         commands::Cmd::Network(network::Cmd::Settings(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Transfer(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Balance(cmd)) => cmd.output.into(),
         _ => return None,
     };
 
     matches!(format, Format::Json | Format::JsonFormatted).then_some(format)
+}
+
+// Machine-readable `type` discriminator for the JSON error envelope. Commands
+// that classify their failures provide a specific slug (e.g. `sac_not_deployed`);
+// everything else falls back to `unknown`.
+fn error_type(err: &commands::Error) -> &'static str {
+    match err {
+        commands::Error::Token(e) => e.error_type(),
+        _ => "unknown",
+    }
 }
 
 fn config_dir_from_raw_args() -> Option<PathBuf> {

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -1,8 +1,11 @@
 use std::str::FromStr;
 
 use crate::{
+    commands::contract::invoke,
     config::{alias::UnresolvedContract, locator},
+    get_spec,
     output::Format,
+    rpc,
     tx::builder,
     utils::contract_id_hash_from_asset,
 };
@@ -50,6 +53,28 @@ pub enum Error {
     Locator(#[from] locator::Error),
     #[error(transparent)]
     Asset(#[from] builder::asset::Error),
+
+    #[error(
+        "the Stellar Asset Contract {0} is not deployed on this network.\n\
+         Deploy it first with `stellar contract asset deploy --asset <ASSET>`, then retry."
+    )]
+    SacNotDeployed(String),
+
+    #[error("contract {0} was not found on this network")]
+    ContractNotFound(String),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Locator(_) => "config",
+            Error::Asset(_) => "invalid_asset",
+            Error::SacNotDeployed(_) => "sac_not_deployed",
+            Error::ContractNotFound(_) => "contract_not_found",
+        }
+    }
 }
 
 impl FromStr for TokenTarget {
@@ -84,6 +109,31 @@ impl TokenTarget {
                 Ok(contract_id_hash_from_asset(&asset, network_passphrase))
             }
         }
+    }
+
+    /// If `err` is a "contract not found" failure raised while fetching the
+    /// contract spec, translate it into a token-aware error: a missing SAC for
+    /// an asset target (pointing at `contract asset deploy`), or a missing
+    /// contract for a direct id/alias. Returns `None` for any other failure so
+    /// the caller can surface the underlying invoke error unchanged.
+    #[must_use]
+    pub fn not_deployed_error(
+        &self,
+        err: &invoke::Error,
+        contract_id: &stellar_strkey::Contract,
+    ) -> Option<Error> {
+        let invoke::Error::GetSpecError(get_spec::Error::Rpc(rpc::Error::NotFound(kind, _))) = err
+        else {
+            return None;
+        };
+        if kind != "Contract" {
+            return None;
+        }
+        Some(if matches!(self, TokenTarget::Asset(_)) {
+            Error::SacNotDeployed(format!("{contract_id}"))
+        } else {
+            Error::ContractNotFound(format!("{contract_id}"))
+        })
     }
 }
 

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -35,10 +35,9 @@ impl From<OutputFormat> for Format {
 /// A `stellar token` target, resolved from the `--id` value.
 ///
 /// The shape of the value decides how it is interpreted:
-/// * `CODE:ISSUER` → a Stellar Asset Contract (SAC), resolved from the asset.
-/// * anything else → a contract, either a `C…` strkey or a saved alias. This
-///   includes `native`, which resolves through the built-in reserved alias to
-///   the native-asset SAC.
+/// * `native` or `CODE:ISSUER` → a Stellar Asset Contract (SAC), resolved from
+///   the classic asset.
+/// * anything else → a contract, either a `C…` strkey or a saved alias.
 #[derive(Clone, Debug)]
 pub enum TokenTarget {
     /// A SEP-41 contract addressed directly by id or alias.
@@ -81,10 +80,11 @@ impl FromStr for TokenTarget {
     type Err = builder::asset::Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        // `CODE:ISSUER` is the classic-asset shape, resolved to a SAC.
-        // Everything else is a contract id or alias — including `native`, which
-        // resolves through the built-in reserved alias to the native-asset SAC.
-        if value.contains(':') {
+        // `native` and the `CODE:ISSUER` shape are both classic assets, resolved
+        // to their Stellar Asset Contract — so a missing SAC reports
+        // `sac_not_deployed`, not `contract_not_found`. Everything else is a
+        // contract id or a saved alias.
+        if value == "native" || value.contains(':') {
             Ok(TokenTarget::Asset(value.parse()?))
         } else {
             // `UnresolvedContract::from_str` is infallible.
@@ -145,10 +145,10 @@ mod tests {
     const CONTRACT: &str = "CCR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OTE2";
 
     #[test]
-    fn native_parses_as_contract_alias() {
+    fn native_parses_as_asset() {
         assert!(matches!(
             "native".parse::<TokenTarget>().unwrap(),
-            TokenTarget::Contract(UnresolvedContract::Alias(_))
+            TokenTarget::Asset(builder::Asset::Native)
         ));
     }
 

--- a/cmd/soroban-cli/src/commands/token/balance.rs
+++ b/cmd/soroban-cli/src/commands/token/balance.rs
@@ -9,8 +9,8 @@ use crate::{
         token::args::{self, OutputFormat, TokenTarget},
     },
     config::{self, locator, network, sign_with, UnresolvedContract, UnresolvedScAddress},
+    fixed_point::FixedPoint,
     output::Output,
-    print,
 };
 
 #[derive(Debug, Parser, Clone)]
@@ -58,9 +58,6 @@ pub enum Error {
 
     #[error("could not parse {what} from the contract: {value:?}")]
     ParseResult { what: &'static str, value: String },
-
-    #[error("token reports {0} decimals, which is too large to format as a decimal")]
-    UnsupportedDecimals(u32),
 }
 
 impl Error {
@@ -74,7 +71,6 @@ impl Error {
             Error::ScAddress(_) => "invalid_address",
             Error::Invoke(_) => "invoke",
             Error::Serde(_) | Error::ParseResult { .. } => "internal",
-            Error::UnsupportedDecimals(_) => "unsupported_decimals",
         }
     }
 }
@@ -150,14 +146,7 @@ impl Cmd {
                     "decimals",
                 )
                 .await?;
-            // `format_number` computes `10.pow(decimals)`, which overflows i128
-            // once decimals exceeds 38. The value comes from the contract, so
-            // reject an implausible scale rather than panic (debug) or wrap
-            // silently (release). Real SACs use 7.
-            if decimals > 38 {
-                return Err(Error::UnsupportedDecimals(decimals));
-            }
-            (print::format_number(raw, decimals), Some(decimals))
+            (FixedPoint::new(raw, decimals).to_string(), Some(decimals))
         } else {
             (raw.to_string(), None)
         };

--- a/cmd/soroban-cli/src/commands/token/balance.rs
+++ b/cmd/soroban-cli/src/commands/token/balance.rs
@@ -1,0 +1,223 @@
+use std::ffi::OsString;
+
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat, TokenTarget},
+    },
+    config::{self, locator, network, sign_with, UnresolvedContract, UnresolvedScAddress},
+    output::Output,
+    print,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to query: a contract id or alias, `native`, or a classic asset
+    /// as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: TokenTarget,
+
+    /// Account or contract whose balance to read.
+    #[arg(long)]
+    pub account: UnresolvedScAddress,
+
+    /// Format the balance as a decimal using the token's `decimals`, instead of
+    /// the raw smallest unit (stroops for a Stellar Asset Contract).
+    #[arg(long)]
+    pub decimal: bool,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    ScAddress(#[from] config::sc_address::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    #[error("could not parse {what} from the contract: {value:?}")]
+    ParseResult { what: &'static str, value: String },
+
+    #[error("token reports {0} decimals, which is too large to format as a decimal")]
+    UnsupportedDecimals(u32),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::ScAddress(_) => "invalid_address",
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) | Error::ParseResult { .. } => "internal",
+            Error::UnsupportedDecimals(_) => "unsupported_decimals",
+        }
+    }
+}
+
+/// The machine-readable result of a balance query.
+#[derive(Debug, serde::Serialize)]
+struct BalanceResult {
+    /// The balance, in the requested representation: raw smallest units by
+    /// default, or a decimal string when `--decimal` is set.
+    balance: String,
+    /// The token's `decimals`, present only when `--decimal` was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    decimals: Option<u32>,
+}
+
+impl Cmd {
+    /// A read-only config: balance is resolved by simulation, so no source
+    /// account, signing options, or fees are needed.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: config::UnresolvedMuxedAccount::default(),
+            locator: self.locator.clone(),
+            sign_with: sign_with::Args::default(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // Read-only calls still log through the invoke pipeline's Print; keep it
+        // quiet in JSON mode so stdout stays pure JSON.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let contract_id = self
+            .id
+            .resolve_contract_id(&config.locator, &network.network_passphrase)?;
+        let account = self
+            .account
+            .clone()
+            .resolve(&config.locator, &network.network_passphrase, None)?
+            .to_string();
+
+        let raw: i128 = self
+            .read_parsed(
+                &config,
+                quiet,
+                global_args.no_cache,
+                contract_id,
+                vec![
+                    OsString::from("balance"),
+                    OsString::from("--id"),
+                    OsString::from(&account),
+                ],
+                "balance",
+            )
+            .await?;
+
+        let (balance, decimals) = if self.decimal {
+            // Deliberately a second, separate simulation: `decimals` isn't
+            // returned by `balance`, so `--decimal` costs one extra read-only
+            // RPC round-trip on top of the balance query.
+            let decimals: u32 = self
+                .read_parsed(
+                    &config,
+                    quiet,
+                    global_args.no_cache,
+                    contract_id,
+                    vec![OsString::from("decimals")],
+                    "decimals",
+                )
+                .await?;
+            // `format_number` computes `10.pow(decimals)`, which overflows i128
+            // once decimals exceeds 38. The value comes from the contract, so
+            // reject an implausible scale rather than panic (debug) or wrap
+            // silently (release). Real SACs use 7.
+            if decimals > 38 {
+                return Err(Error::UnsupportedDecimals(decimals));
+            }
+            (print::format_number(raw, decimals), Some(decimals))
+        } else {
+            (raw.to_string(), None)
+        };
+
+        output.readable(|_| println!("{balance}"));
+        output.json_value(&BalanceResult { balance, decimals })?;
+
+        Ok(())
+    }
+
+    /// Invoke a read-only token function and return its decoded output string.
+    async fn read(
+        &self,
+        config: &config::Args,
+        quiet: bool,
+        no_cache: bool,
+        contract_id: stellar_strkey::Contract,
+        slop: Vec<OsString>,
+    ) -> Result<String, Error> {
+        let invoke_cmd = invoke::Cmd {
+            contract_id: UnresolvedContract::Resolved(contract_id),
+            slop,
+            config: config.clone(),
+            send: invoke::Send::No,
+            ..Default::default()
+        };
+
+        let receipt = invoke_cmd
+            .execute_with_receipt(config, quiet, no_cache)
+            .await
+            .map_err(|e| {
+                self.id
+                    .not_deployed_error(&e, &contract_id)
+                    .map_or(Error::Invoke(e), Error::Args)
+            })?
+            .into_result();
+
+        Ok(receipt.map(|r| r.output).unwrap_or_default())
+    }
+
+    /// Invoke a read-only token function, then parse its decoded output as `T`.
+    /// `what` labels the value in a `ParseResult` error if parsing fails.
+    async fn read_parsed<T: std::str::FromStr>(
+        &self,
+        config: &config::Args,
+        quiet: bool,
+        no_cache: bool,
+        contract_id: stellar_strkey::Contract,
+        slop: Vec<OsString>,
+        what: &'static str,
+    ) -> Result<T, Error> {
+        let out = self
+            .read(config, quiet, no_cache, contract_id, slop)
+            .await?;
+        // A 128-bit balance comes back JSON-encoded as a quoted string (it can't
+        // fit a JSON number), while `decimals` (u32) comes back bare; strip any
+        // surrounding quotes so both parse straight into `T`.
+        out.trim()
+            .trim_matches('"')
+            .parse()
+            .map_err(|_| Error::ParseResult { what, value: out })
+    }
+}

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod balance;
 pub mod transfer;
 
 use crate::commands::global;
@@ -7,18 +8,35 @@ use crate::commands::global;
 pub enum Cmd {
     /// Transfer tokens from one account to another
     Transfer(transfer::Cmd),
+
+    /// Read the token balance of an account or contract
+    Balance(balance::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
     Transfer(#[from] transfer::Error),
+    #[error(transparent)]
+    Balance(#[from] balance::Error),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Transfer(e) => e.error_type(),
+            Error::Balance(e) => e.error_type(),
+        }
+    }
 }
 
 impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         match self {
             Cmd::Transfer(cmd) => cmd.run(global_args).await?,
+            Cmd::Balance(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/token/transfer.rs
+++ b/cmd/soroban-cli/src/commands/token/transfer.rs
@@ -68,15 +68,6 @@ pub enum Error {
     Serde(#[from] serde_json::Error),
 
     #[error(
-        "the Stellar Asset Contract {0} is not deployed on this network.\n\
-         Deploy it first with `stellar contract asset deploy --asset <ASSET>`, then retry."
-    )]
-    SacNotDeployed(String),
-
-    #[error("contract {0} was not found on this network")]
-    ContractNotFound(String),
-
-    #[error(
         "muxed (M…) source accounts are not yet supported for `token transfer`; \
          use the underlying G… account as `--from` instead"
     )]
@@ -94,6 +85,22 @@ fn parse_nonneg_i128(value: &str) -> Result<i128, String> {
         return Err(format!("amount must not be negative: {value}"));
     }
     Ok(amount)
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::ScAddress(_) => "invalid_address",
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+            Error::MuxedSourceNotSupported => "unsupported",
+        }
+    }
 }
 
 /// The machine-readable receipt of a token transfer.
@@ -178,7 +185,11 @@ impl Cmd {
         let receipt = invoke_cmd
             .execute_with_receipt(&config, quiet, global_args.no_cache)
             .await
-            .map_err(|e| self.map_invoke_error(e, &contract_id))?
+            .map_err(|e| {
+                self.id
+                    .not_deployed_error(&e, &contract_id)
+                    .map_or(Error::Invoke(e), Error::Args)
+            })?
             .into_result();
 
         // `transfer` always writes, so the invocation is submitted rather than
@@ -209,32 +220,5 @@ impl Cmd {
         })?;
 
         Ok(())
-    }
-
-    /// Translate a raw invocation failure into a token-aware error where we can
-    /// recognize it. A missing contract instance surfaces as a
-    /// `Contract not found` RPC error while fetching the spec; for an asset
-    /// target that means the SAC has not been deployed yet, so we point the user
-    /// at `contract asset deploy`. Other failures pass through unchanged.
-    fn map_invoke_error(
-        &self,
-        err: invoke::Error,
-        contract_id: &stellar_strkey::Contract,
-    ) -> Error {
-        use crate::{get_spec, rpc};
-
-        if let invoke::Error::GetSpecError(get_spec::Error::Rpc(rpc::Error::NotFound(kind, _))) =
-            &err
-        {
-            if kind == "Contract" {
-                return if matches!(self.id, TokenTarget::Asset(_)) {
-                    Error::SacNotDeployed(format!("{contract_id}"))
-                } else {
-                    Error::ContractNotFound(format!("{contract_id}"))
-                };
-            }
-        }
-
-        Error::Invoke(err)
     }
 }

--- a/cmd/soroban-cli/src/fixed_point.rs
+++ b/cmd/soroban-cli/src/fixed_point.rs
@@ -1,0 +1,106 @@
+use std::fmt::{self, Display};
+
+/// A fixed-point number: a raw integer `value` interpreted as scaled by
+/// `10^decimals` (e.g. a token balance in its smallest unit alongside the
+/// token's `decimals`).
+///
+/// Formatting inserts the decimal point by manipulating the digit string
+/// directly, so it never computes `10.pow(decimals)`. That means it cannot
+/// overflow regardless of how large `decimals` is — important because
+/// `decimals` is often contract-controlled and unbounded.
+#[derive(Clone, Copy, Debug)]
+pub struct FixedPoint {
+    value: i128,
+    decimals: u32,
+}
+
+impl FixedPoint {
+    #[must_use]
+    pub fn new(value: i128, decimals: u32) -> Self {
+        Self { value, decimals }
+    }
+}
+
+impl Display for FixedPoint {
+    /// Renders the value as a decimal string with trailing zeros trimmed
+    /// (e.g. `12345000` at 7 decimals → `1.2345`, `10000000` → `1`).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.decimals == 0 {
+            return write!(f, "{}", self.value);
+        }
+
+        let decimals = self.decimals as usize;
+        // `unsigned_abs` yields the magnitude as a u128, which is safe even for
+        // `i128::MIN` (whose absolute value doesn't fit in an i128).
+        let digits = self.value.unsigned_abs().to_string();
+        // Left-pad so there is at least one integer digit ahead of the
+        // `decimals` fractional digits.
+        let digits = if digits.len() <= decimals {
+            format!("{digits:0>width$}", width = decimals + 1)
+        } else {
+            digits
+        };
+
+        let point = digits.len() - decimals;
+        let integer_part = &digits[..point];
+        let fractional_part = digits[point..].trim_end_matches('0');
+        let sign = if self.value < 0 { "-" } else { "" };
+
+        if fractional_part.is_empty() {
+            write!(f, "{sign}{integer_part}")
+        } else {
+            write!(f, "{sign}{integer_part}.{fractional_part}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fmt(value: i128, decimals: u32) -> String {
+        FixedPoint::new(value, decimals).to_string()
+    }
+
+    #[test]
+    #[allow(clippy::unreadable_literal)]
+    fn formats_typical_values() {
+        assert_eq!(fmt(0, 7), "0");
+        assert_eq!(fmt(1234567, 7), "0.1234567");
+        assert_eq!(fmt(12345000, 7), "1.2345");
+        assert_eq!(fmt(10000000, 7), "1");
+        assert_eq!(fmt(123456789012345, 7), "12345678.9012345");
+        assert_eq!(fmt(1, 7), "0.0000001");
+        assert_eq!(fmt(12345, 0), "12345");
+        assert_eq!(fmt(12345, 1), "1234.5");
+    }
+
+    #[test]
+    #[allow(clippy::unreadable_literal)]
+    fn formats_negative_values() {
+        assert_eq!(fmt(-1234567, 7), "-0.1234567");
+        assert_eq!(fmt(-12345000, 7), "-1.2345");
+        assert_eq!(fmt(-10000000, 7), "-1");
+        assert_eq!(fmt(-5, 0), "-5");
+    }
+
+    #[test]
+    fn handles_i128_bounds_without_overflow() {
+        assert_eq!(
+            fmt(i128::MIN, 18),
+            "-170141183460469231731.687303715884105728"
+        );
+        assert_eq!(
+            fmt(i128::MAX, 18),
+            "170141183460469231731.687303715884105727"
+        );
+    }
+
+    #[test]
+    fn large_decimals_do_not_overflow() {
+        // `10.pow(decimals)` would overflow i128 for decimals >= 39 (and panic
+        // with a zero divisor for >= 128); string placement handles any scale.
+        assert_eq!(fmt(1, 39), "0.000000000000000000000000000000000000001");
+        assert_eq!(fmt(123, 255).chars().take(2).collect::<String>(), "0.");
+    }
+}

--- a/cmd/soroban-cli/src/lib.rs
+++ b/cmd/soroban-cli/src/lib.rs
@@ -17,6 +17,7 @@ pub mod color;
 pub mod commands;
 pub mod config;
 mod env_vars;
+pub mod fixed_point;
 pub mod get_spec;
 pub mod key;
 pub mod log;

--- a/cmd/soroban-cli/src/output.rs
+++ b/cmd/soroban-cli/src/output.rs
@@ -18,27 +18,33 @@ use serde::Serialize;
 
 use crate::print::Print;
 
-/// Build the canonical JSON error envelope for an error: `{ "error": { … } }`.
+/// Build the canonical JSON error envelope for an error:
+/// `{ "error": { "type": …, "message": … } }`.
 ///
-/// The inner object is always present and always has at least a `message`
-/// string, so every command renders errors with the same shape. When the error
-/// chain contains a JSON-RPC [`ErrorObject`](jsonrpsee_types::ErrorObjectOwned)
-/// (whose own `Display` is just its debug representation), its structured
-/// `{ code, message, data? }` form is used; every other error falls back to its
-/// `Display` as the `message`.
+/// The inner object always carries a machine-readable `type` discriminator (so
+/// consumers can branch on the kind of failure without parsing the message) and
+/// at least a `message` string. When the error chain contains a JSON-RPC
+/// [`ErrorObject`](jsonrpsee_types::ErrorObjectOwned) (whose own `Display` is
+/// just its debug representation), its structured `{ code, message, data? }`
+/// form is merged in; every other error falls back to its `Display` as the
+/// `message`.
+///
+/// `error_type` is the caller-supplied discriminator (e.g. `"sac_not_deployed"`,
+/// or `"unknown"` when the error has no more specific type).
 #[must_use]
-pub fn error_json(err: &(dyn std::error::Error + 'static)) -> serde_json::Value {
+pub fn error_json(err: &(dyn std::error::Error + 'static), error_type: &str) -> serde_json::Value {
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
     while let Some(source) = current {
         if let Some(object) = source.downcast_ref::<jsonrpsee_types::ErrorObjectOwned>() {
-            if let Ok(value) = serde_json::to_value(object) {
-                return serde_json::json!({ "error": value });
+            if let Ok(serde_json::Value::Object(mut map)) = serde_json::to_value(object) {
+                map.insert("type".to_string(), serde_json::json!(error_type));
+                return serde_json::json!({ "error": map });
             }
         }
         current = source.source();
     }
 
-    serde_json::json!({ "error": { "message": err.to_string() } })
+    serde_json::json!({ "error": { "type": error_type, "message": err.to_string() } })
 }
 
 /// The format a command should render its output in.
@@ -184,8 +190,17 @@ mod tests {
     fn error_json_uses_structured_rpc_error_object() {
         let obj = jsonrpsee_types::ErrorObject::owned(-32603, "DB is empty", None::<()>);
         assert_eq!(
-            error_json(&obj),
-            serde_json::json!({ "error": { "code": -32603, "message": "DB is empty" } }),
+            error_json(&obj, "unknown"),
+            serde_json::json!({ "error": { "type": "unknown", "code": -32603, "message": "DB is empty" } }),
+        );
+    }
+
+    #[test]
+    fn error_json_includes_specific_type() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "no sac");
+        assert_eq!(
+            error_json(&err, "sac_not_deployed"),
+            serde_json::json!({ "error": { "type": "sac_not_deployed", "message": "no sac" } }),
         );
     }
 
@@ -206,8 +221,8 @@ mod tests {
 
         let obj = jsonrpsee_types::ErrorObject::owned(-32000, "boom", None::<()>);
         assert_eq!(
-            error_json(&Wrapper(obj)),
-            serde_json::json!({ "error": { "code": -32000, "message": "boom" } }),
+            error_json(&Wrapper(obj), "unknown"),
+            serde_json::json!({ "error": { "type": "unknown", "code": -32000, "message": "boom" } }),
         );
     }
 
@@ -215,8 +230,8 @@ mod tests {
     fn error_json_falls_back_to_message_for_other_errors() {
         let err = std::io::Error::new(std::io::ErrorKind::NotFound, "nope");
         assert_eq!(
-            error_json(&err),
-            serde_json::json!({ "error": { "message": "nope" } }),
+            error_json(&err, "unknown"),
+            serde_json::json!({ "error": { "type": "unknown", "message": "nope" } }),
         );
     }
 }

--- a/cmd/soroban-cli/src/print.rs
+++ b/cmd/soroban-cli/src/print.rs
@@ -109,26 +109,9 @@ macro_rules! create_print_functions {
 ///
 /// If `n` cannot be represented as an i128 value, returns "Err(number out of bounds)".
 pub fn format_number<T: TryInto<i128>>(n: T, decimals: u32) -> String {
-    let n: i128 = match n.try_into() {
-        Ok(value) => value,
-        Err(_) => return "Err(number out of bounds)".to_string(),
-    };
-    if decimals == 0 {
-        return n.to_string();
-    }
-    let divisor = 10i128.pow(decimals);
-    let integer_part = n / divisor;
-    let fractional_part = (n % divisor).abs();
-    // Pad with leading zeros to match decimals width, then trim trailing zeros
-    let frac_str = format!("{:0width$}", fractional_part, width = decimals as usize);
-    let frac_trimmed = frac_str.trim_end_matches('0');
-
-    if frac_trimmed.is_empty() {
-        format!("{integer_part}")
-    } else {
-        // If integer_part is 0, we still want to show the sign for negative numbers (e.g. -0.5)
-        let sign = if n < 0 && integer_part == 0 { "-" } else { "" };
-        format!("{sign}{integer_part}.{frac_trimmed}")
+    match n.try_into() {
+        Ok(value) => crate::fixed_point::FixedPoint::new(value, decimals).to_string(),
+        Err(_) => "Err(number out of bounds)".to_string(),
     }
 }
 


### PR DESCRIPTION
### What

Add a `stellar token balance` command that reads the token balance of an account or contract. The token can be specified as a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`. By default the balance is returned in the token's raw smallest unit (stroops for a Stellar Asset Contract); `--decimal` formats it using the token's `decimals`. Output is available as text (default) or JSON via `--output`.

```console
$ $stellar token balance --id native --account fnando --output=json
{"balance":"100000000000"}

$ $stellar token balance --id native --account fnando
100000000000

$ $stellar token balance --id usdc --account fnando --network testnet
2000000

$ $stellar token balance --id USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --account fnando --network testnet
2000000

$ $stellar token balance --id USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --account fnando --network testnet --decimal
0.2

$ http https://horizon-testnet.stellar.org/accounts/$($stellar keys address fnando) | jq '.balances | first | {asset_code, asset_issuer, balance}'
{
  "asset_code": "USDC",
  "asset_issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
  "balance": "0.2000000"
}
```

### Why

Reading a token balance previously required a manual `stellar contract invoke ... -- balance` call and hand-decoding the result. This adds a first-class, read-only command that resolves the token (including classic assets and `native`) and returns a clean value, with token-aware errors when a Stellar Asset Contract isn't deployed yet.

### Known limitations

N/A