### PR TITLE
Centralize token resolution behind ResolvedToken

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -195,7 +195,7 @@ impl Cmd {
         }
         print.checkln("Deployed!");
 
-        Ok(TxnResult::Res(stellar_strkey::Contract(contract_id.0)))
+        Ok(TxnResult::Res(contract_id))
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/id/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/asset.rs
@@ -32,10 +32,10 @@ impl Cmd {
 
     pub fn contract_address(&self) -> Result<stellar_strkey::Contract, Error> {
         let network = self.config.get_network()?;
-        let contract_id = contract_id_hash_from_asset(
-            &self.asset.resolve(&self.config.locator)?,
+        let asset = self.asset.resolve(&self.config.locator)?;
+        Ok(contract_id_hash_from_asset(
+            &asset,
             &network.network_passphrase,
-        );
-        Ok(stellar_strkey::Contract(contract_id.0))
+        ))
     }
 }

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -8,6 +8,7 @@ use crate::{
     rpc,
     tx::builder,
     utils::contract_id_hash_from_asset,
+    xdr,
 };
 
 /// Output format shared by the `stellar token` subcommands.
@@ -44,6 +45,29 @@ pub enum TokenTarget {
     Contract(UnresolvedContract),
     /// A Stellar Asset Contract addressed by its underlying classic asset.
     Asset(builder::Asset),
+}
+
+/// The result of resolving a user-supplied token/asset reference to a contract.
+///
+/// It answers the two questions a caller needs at once: *which* contract id the
+/// reference points at, and *whether* that contract is a Stellar Asset Contract
+/// (and for which classic asset). The latter is what lets a missing contract be
+/// reported as `sac_not_deployed` (pointing at `contract asset deploy`) rather
+/// than a plain `contract_not_found`.
+#[derive(Clone, Debug)]
+pub struct ResolvedToken {
+    pub contract_id: stellar_strkey::Contract,
+    pub kind: TokenKind,
+}
+
+/// Whether a [`ResolvedToken`] is a Stellar Asset Contract (SAC) wrapping a
+/// classic asset, or a plain SEP-41 contract addressed directly.
+#[derive(Clone, Debug)]
+pub enum TokenKind {
+    /// A Stellar Asset Contract for the given classic asset.
+    Sac(xdr::Asset),
+    /// A contract addressed directly by id or alias.
+    Contract,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -94,20 +118,33 @@ impl FromStr for TokenTarget {
 }
 
 impl TokenTarget {
-    /// Resolve this target to a concrete contract id for the given network.
-    pub fn resolve_contract_id(
+    /// Resolve this target to a [`ResolvedToken`] for the given network.
+    pub fn resolve(
         &self,
         locator: &locator::Args,
         network_passphrase: &str,
-    ) -> Result<stellar_strkey::Contract, Error> {
+    ) -> Result<ResolvedToken, Error> {
         match self {
-            TokenTarget::Contract(contract) => {
-                Ok(contract.resolve_contract_id(locator, network_passphrase)?)
-            }
+            TokenTarget::Contract(contract) => Ok(ResolvedToken {
+                contract_id: contract.resolve_contract_id(locator, network_passphrase)?,
+                kind: TokenKind::Contract,
+            }),
             TokenTarget::Asset(asset) => {
                 let asset = asset.resolve(locator)?;
-                Ok(contract_id_hash_from_asset(&asset, network_passphrase))
+                Ok(ResolvedToken::sac(&asset, network_passphrase))
             }
+        }
+    }
+}
+
+impl ResolvedToken {
+    /// Resolve a classic `asset` to its Stellar Asset Contract on the network
+    /// identified by `network_passphrase`.
+    #[must_use]
+    pub fn sac(asset: &xdr::Asset, network_passphrase: &str) -> Self {
+        ResolvedToken {
+            contract_id: contract_id_hash_from_asset(asset, network_passphrase),
+            kind: TokenKind::Sac(asset.clone()),
         }
     }
 
@@ -117,11 +154,7 @@ impl TokenTarget {
     /// contract for a direct id/alias. Returns `None` for any other failure so
     /// the caller can surface the underlying invoke error unchanged.
     #[must_use]
-    pub fn not_deployed_error(
-        &self,
-        err: &invoke::Error,
-        contract_id: &stellar_strkey::Contract,
-    ) -> Option<Error> {
+    pub fn not_deployed_error(&self, err: &invoke::Error) -> Option<Error> {
         let invoke::Error::GetSpecError(get_spec::Error::Rpc(rpc::Error::NotFound(kind, _))) = err
         else {
             return None;
@@ -129,10 +162,10 @@ impl TokenTarget {
         if kind != "Contract" {
             return None;
         }
-        Some(if matches!(self, TokenTarget::Asset(_)) {
-            Error::SacNotDeployed(format!("{contract_id}"))
-        } else {
-            Error::ContractNotFound(format!("{contract_id}"))
+        let contract_id = &self.contract_id;
+        Some(match self.kind {
+            TokenKind::Sac(_) => Error::SacNotDeployed(format!("{contract_id}")),
+            TokenKind::Contract => Error::ContractNotFound(format!("{contract_id}")),
         })
     }
 }

--- a/cmd/soroban-cli/src/commands/token/balance.rs
+++ b/cmd/soroban-cli/src/commands/token/balance.rs
@@ -6,7 +6,7 @@ use crate::{
     commands::{
         contract::invoke,
         global,
-        token::args::{self, OutputFormat, TokenTarget},
+        token::args::{self, OutputFormat, ResolvedToken, TokenTarget},
     },
     config::{self, locator, network, sign_with, UnresolvedContract, UnresolvedScAddress},
     fixed_point::FixedPoint,
@@ -108,9 +108,9 @@ impl Cmd {
         let config = self.config();
         let network = config.get_network()?;
 
-        let contract_id = self
+        let resolved = self
             .id
-            .resolve_contract_id(&config.locator, &network.network_passphrase)?;
+            .resolve(&config.locator, &network.network_passphrase)?;
         let account = self
             .account
             .clone()
@@ -122,7 +122,7 @@ impl Cmd {
                 &config,
                 quiet,
                 global_args.no_cache,
-                contract_id,
+                &resolved,
                 vec![
                     OsString::from("balance"),
                     OsString::from("--id"),
@@ -141,7 +141,7 @@ impl Cmd {
                     &config,
                     quiet,
                     global_args.no_cache,
-                    contract_id,
+                    &resolved,
                     vec![OsString::from("decimals")],
                     "decimals",
                 )
@@ -163,11 +163,11 @@ impl Cmd {
         config: &config::Args,
         quiet: bool,
         no_cache: bool,
-        contract_id: stellar_strkey::Contract,
+        resolved: &ResolvedToken,
         slop: Vec<OsString>,
     ) -> Result<String, Error> {
         let invoke_cmd = invoke::Cmd {
-            contract_id: UnresolvedContract::Resolved(contract_id),
+            contract_id: UnresolvedContract::Resolved(resolved.contract_id),
             slop,
             config: config.clone(),
             send: invoke::Send::No,
@@ -178,8 +178,8 @@ impl Cmd {
             .execute_with_receipt(config, quiet, no_cache)
             .await
             .map_err(|e| {
-                self.id
-                    .not_deployed_error(&e, &contract_id)
+                resolved
+                    .not_deployed_error(&e)
                     .map_or(Error::Invoke(e), Error::Args)
             })?
             .into_result();
@@ -194,13 +194,11 @@ impl Cmd {
         config: &config::Args,
         quiet: bool,
         no_cache: bool,
-        contract_id: stellar_strkey::Contract,
+        resolved: &ResolvedToken,
         slop: Vec<OsString>,
         what: &'static str,
     ) -> Result<T, Error> {
-        let out = self
-            .read(config, quiet, no_cache, contract_id, slop)
-            .await?;
+        let out = self.read(config, quiet, no_cache, resolved, slop).await?;
         // A 128-bit balance comes back JSON-encoded as a quoted string (it can't
         // fit a JSON number), while `decimals` (u32) comes back bare; strip any
         // surrounding quotes so both parse straight into `T`.

--- a/cmd/soroban-cli/src/commands/token/transfer.rs
+++ b/cmd/soroban-cli/src/commands/token/transfer.rs
@@ -138,9 +138,9 @@ impl Cmd {
         let config = self.config();
         let network = config.get_network()?;
 
-        let contract_id = self
+        let resolved = self
             .id
-            .resolve_contract_id(&config.locator, &network.network_passphrase)?;
+            .resolve(&config.locator, &network.network_passphrase)?;
 
         // SEP-41 `transfer(from, to, amount)`: `from` is the source account
         // (which also signs and authorizes), `to` is the destination.
@@ -172,7 +172,7 @@ impl Cmd {
         .collect();
 
         let invoke_cmd = invoke::Cmd {
-            contract_id: UnresolvedContract::Resolved(contract_id),
+            contract_id: UnresolvedContract::Resolved(resolved.contract_id),
             slop,
             config: config.clone(),
             // A transfer always intends to submit. Force `Send::Yes` so a token
@@ -186,8 +186,8 @@ impl Cmd {
             .execute_with_receipt(&config, quiet, global_args.no_cache)
             .await
             .map_err(|e| {
-                self.id
-                    .not_deployed_error(&e, &contract_id)
+                resolved
+                    .not_deployed_error(&e)
                     .map_or(Error::Invoke(e), Error::Args)
             })?
             .into_result();


### PR DESCRIPTION
### What

Introduce a `ResolvedToken` type in the token command args that pairs a resolved contract id with its kind — a Stellar Asset Contract wrapping a classic asset, or a plain SEP-41 contract addressed directly — and have `TokenTarget::resolve` return it so the `token balance` and `token transfer` commands decide between a `sac_not_deployed` and a `contract_not_found` error from the resolved kind rather than re-deriving that distinction from the original input.

### Why

Closes #2652. Resolving a user-supplied token reference to a contract id and knowing whether it is a Stellar Asset Contract (and for which asset) were two separate steps: the id came out of the resolver while the SAC-versus-contract knowledge was re-derived at the error site by matching on the original `TokenTarget`. No single value answered both "which contract id?" and "is this a SAC, and which asset?" — the exact knowledge needed to produce a good `sac_not_deployed` versus `contract_not_found` error. Pairing the id with its kind removes that duplicated derivation and keeps the classification consistent.

### Known limitations

The bare asset-to-contract-id call sites that have no SAC-versus-contract error semantics — `contract asset id`, `contract asset deploy`, the reserved `native` alias in config, and snapshot creation — keep calling the low-level `contract_id_hash_from_asset` primitive directly, since routing them through the token command's resolver would invert the module layering (the token commands are layered on top of the contract invoke machinery) without buying anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsvKNysej3AxnnXdZKsW45)_