### PR TITLE
Centralize asset/token resolution behind a single resolver

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/token/balance.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/balance.rs
@@ -109,3 +109,37 @@ async fn balance_fails_when_sac_not_deployed() {
         "expected an error message, got: {stdout}"
     );
 }
+
+#[tokio::test]
+async fn balance_fails_when_contract_not_found() {
+    let sandbox = &TestEnv::new();
+    // A well-formed contract id that resolves to a plain contract (not a SAC)
+    // and was never deployed → the missing-contract branch, distinct from the
+    // SAC deploy pointer above.
+    let id = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4";
+
+    // In JSON mode the error carries a machine-readable `type` discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "balance",
+            "--id",
+            id,
+            "--account",
+            "test",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "contract_not_found",
+        "expected a typed error, got: {stdout}"
+    );
+    assert!(
+        value["error"]["message"].as_str().is_some(),
+        "expected an error message, got: {stdout}"
+    );
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/transfer.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/transfer.rs
@@ -140,6 +140,36 @@ async fn transfer_fails_when_sac_not_deployed() {
 }
 
 #[tokio::test]
+async fn transfer_fails_when_contract_not_found() {
+    let sandbox = &TestEnv::new();
+    let recipient = new_account(sandbox, "recipient");
+    // A well-formed contract id that resolves to a plain contract (not a SAC)
+    // and was never deployed → the missing-contract branch, distinct from the
+    // SAC deploy pointer above.
+    let id = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4";
+
+    // In JSON mode the error carries a machine-readable `type` discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "transfer", "--id", id, "--to", &recipient, "--amount", "1", "--from", "test",
+            "--output", "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "contract_not_found",
+        "expected a typed error, got: {stdout}"
+    );
+    assert!(
+        value["error"]["message"].as_str().is_some(),
+        "expected an error message, got: {stdout}"
+    );
+}
+
+#[tokio::test]
 async fn transfer_fails_when_recipient_trustline_missing() {
     let sandbox = &TestEnv::new();
     let test = test_address(sandbox);

--- a/cmd/soroban-cli/src/commands/contract/alias/ls.rs
+++ b/cmd/soroban-cli/src/commands/contract/alias/ls.rs
@@ -101,7 +101,9 @@ impl Cmd {
         }
 
         for (network_passphrase, list) in &mut map {
-            if let Some(contract) = alias::resolve_reserved(alias::NATIVE, network_passphrase) {
+            if let Some(contract) =
+                alias::resolve_reserved(alias::NATIVE, &self.config_locator, network_passphrase)
+            {
                 list.push(AliasEntry {
                     alias: alias::NATIVE.to_string(),
                     contract: format!("{contract}"),

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -53,9 +53,6 @@ pub enum Error {
     Builder(#[from] builder::Error),
 
     #[error(transparent)]
-    Asset(#[from] builder::asset::Error),
-
-    #[error(transparent)]
     Locator(#[from] locator::Error),
 
     #[error(transparent)]

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -19,10 +19,9 @@ use crate::{
         txn_result::{TxnEnvelopeResult, TxnResult},
         HEADING_TRANSACTION,
     },
-    config::{self, data, network},
+    config::{self, data, network, token::UnresolvedToken},
     rpc::Error as SorobanRpcError,
     tx::builder,
-    utils::contract_id_hash_from_asset,
 };
 
 use crate::config::address::AliasName;
@@ -58,6 +57,9 @@ pub enum Error {
 
     #[error(transparent)]
     Locator(#[from] locator::Error),
+
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
 
     #[error(transparent)]
     Fee(#[from] fetch::fee::Error),
@@ -144,11 +146,19 @@ impl Cmd {
         quiet: bool,
         no_cache: bool,
     ) -> Result<TxnResult<stellar_strkey::Contract>, Error> {
-        // Parse asset
         let print = Print::new(quiet);
-        let asset = self.asset.resolve(&config.locator)?;
 
         let network = config.get_network()?;
+        // Resolve the asset up front, before any RPC, so an invalid asset or
+        // unresolvable issuer alias fails fast instead of after network calls.
+        let token = UnresolvedToken::Asset(self.asset.clone())
+            .resolve(&config.locator, &network.network_passphrase)?;
+        let contract_id = token.contract_id;
+        let asset = token
+            .asset()
+            .expect("an asset reference resolves to a SAC")
+            .clone();
+
         let client = network.rpc_client()?;
         client
             .verify_network_passphrase(Some(&network.network_passphrase))
@@ -163,7 +173,6 @@ impl Cmd {
             .await?;
         let sequence: i64 = account_details.seq_num.into();
         let network_passphrase = &network.network_passphrase;
-        let contract_id = contract_id_hash_from_asset(&asset, network_passphrase);
         let tx = build_wrap_token_tx(
             asset,
             &contract_id,

--- a/cmd/soroban-cli/src/commands/contract/id/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/asset.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 use crate::config;
+use crate::config::token::UnresolvedToken;
 
 use crate::tx::builder;
-use crate::utils::contract_id_hash_from_asset;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -23,6 +23,8 @@ pub enum Error {
     Xdr(#[from] crate::xdr::Error),
     #[error(transparent)]
     Asset(#[from] builder::asset::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
 }
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
@@ -32,10 +34,8 @@ impl Cmd {
 
     pub fn contract_address(&self) -> Result<stellar_strkey::Contract, Error> {
         let network = self.config.get_network()?;
-        let contract_id = contract_id_hash_from_asset(
-            &self.asset.resolve(&self.config.locator)?,
-            &network.network_passphrase,
-        );
-        Ok(stellar_strkey::Contract(contract_id.0))
+        let token = UnresolvedToken::Asset(self.asset.clone())
+            .resolve(&self.config.locator, &network.network_passphrase)?;
+        Ok(token.contract_id)
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/id/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/asset.rs
@@ -22,8 +22,6 @@ pub enum Error {
     #[error(transparent)]
     Xdr(#[from] crate::xdr::Error),
     #[error(transparent)]
-    Asset(#[from] builder::asset::Error),
-    #[error(transparent)]
     Token(#[from] config::token::Error),
 }
 impl Cmd {

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -1,13 +1,5 @@
-use std::str::FromStr;
-
 use crate::{
-    commands::contract::invoke,
-    config::{alias::UnresolvedContract, locator},
-    get_spec,
-    output::Format,
-    rpc,
-    tx::builder,
-    utils::contract_id_hash_from_asset,
+    commands::contract::invoke, config::token::ResolvedToken, get_spec, output::Format, rpc,
 };
 
 /// Output format shared by the `stellar token` subcommands.
@@ -32,27 +24,8 @@ impl From<OutputFormat> for Format {
     }
 }
 
-/// A `stellar token` target, resolved from the `--id` value.
-///
-/// The shape of the value decides how it is interpreted:
-/// * `native` or `CODE:ISSUER` → a Stellar Asset Contract (SAC), resolved from
-///   the classic asset.
-/// * anything else → a contract, either a `C…` strkey or a saved alias.
-#[derive(Clone, Debug)]
-pub enum TokenTarget {
-    /// A SEP-41 contract addressed directly by id or alias.
-    Contract(UnresolvedContract),
-    /// A Stellar Asset Contract addressed by its underlying classic asset.
-    Asset(builder::Asset),
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error(transparent)]
-    Locator(#[from] locator::Error),
-    #[error(transparent)]
-    Asset(#[from] builder::asset::Error),
-
     #[error(
         "the Stellar Asset Contract {0} is not deployed on this network.\n\
          Deploy it first with `stellar contract asset deploy --asset <ASSET>`, then retry."
@@ -68,111 +41,30 @@ impl Error {
     #[must_use]
     pub fn error_type(&self) -> &'static str {
         match self {
-            Error::Locator(_) => "config",
-            Error::Asset(_) => "invalid_asset",
             Error::SacNotDeployed(_) => "sac_not_deployed",
             Error::ContractNotFound(_) => "contract_not_found",
         }
     }
 }
 
-impl FromStr for TokenTarget {
-    type Err = builder::asset::Error;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        // `native` and the `CODE:ISSUER` shape are both classic assets, resolved
-        // to their Stellar Asset Contract — so a missing SAC reports
-        // `sac_not_deployed`, not `contract_not_found`. Everything else is a
-        // contract id or a saved alias.
-        if value == "native" || value.contains(':') {
-            Ok(TokenTarget::Asset(value.parse()?))
-        } else {
-            // `UnresolvedContract::from_str` is infallible.
-            Ok(TokenTarget::Contract(value.parse().unwrap()))
-        }
+/// If `err` is a "contract not found" failure raised while fetching the contract
+/// spec, translate it into a token-aware error keyed off what `token` resolved
+/// to: a missing SAC (pointing at `contract asset deploy`), or a missing
+/// contract for a direct id/alias. Returns `None` for any other failure so the
+/// caller can surface the underlying invoke error unchanged.
+#[must_use]
+pub fn not_deployed_error(token: &ResolvedToken, err: &invoke::Error) -> Option<Error> {
+    let invoke::Error::GetSpecError(get_spec::Error::Rpc(rpc::Error::NotFound(kind, _))) = err
+    else {
+        return None;
+    };
+    if kind != "Contract" {
+        return None;
     }
-}
-
-impl TokenTarget {
-    /// Resolve this target to a concrete contract id for the given network.
-    pub fn resolve_contract_id(
-        &self,
-        locator: &locator::Args,
-        network_passphrase: &str,
-    ) -> Result<stellar_strkey::Contract, Error> {
-        match self {
-            TokenTarget::Contract(contract) => {
-                Ok(contract.resolve_contract_id(locator, network_passphrase)?)
-            }
-            TokenTarget::Asset(asset) => {
-                let asset = asset.resolve(locator)?;
-                Ok(contract_id_hash_from_asset(&asset, network_passphrase))
-            }
-        }
-    }
-
-    /// If `err` is a "contract not found" failure raised while fetching the
-    /// contract spec, translate it into a token-aware error: a missing SAC for
-    /// an asset target (pointing at `contract asset deploy`), or a missing
-    /// contract for a direct id/alias. Returns `None` for any other failure so
-    /// the caller can surface the underlying invoke error unchanged.
-    #[must_use]
-    pub fn not_deployed_error(
-        &self,
-        err: &invoke::Error,
-        contract_id: &stellar_strkey::Contract,
-    ) -> Option<Error> {
-        let invoke::Error::GetSpecError(get_spec::Error::Rpc(rpc::Error::NotFound(kind, _))) = err
-        else {
-            return None;
-        };
-        if kind != "Contract" {
-            return None;
-        }
-        Some(if matches!(self, TokenTarget::Asset(_)) {
-            Error::SacNotDeployed(format!("{contract_id}"))
-        } else {
-            Error::ContractNotFound(format!("{contract_id}"))
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // A valid contract strkey borrowed from the CLI's own help text.
-    const CONTRACT: &str = "CCR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OTE2";
-
-    #[test]
-    fn native_parses_as_asset() {
-        assert!(matches!(
-            "native".parse::<TokenTarget>().unwrap(),
-            TokenTarget::Asset(builder::Asset::Native)
-        ));
-    }
-
-    #[test]
-    fn code_issuer_parses_as_asset() {
-        assert!(matches!(
-            "USDC:issuer".parse::<TokenTarget>().unwrap(),
-            TokenTarget::Asset(builder::Asset::Asset(..))
-        ));
-    }
-
-    #[test]
-    fn contract_strkey_parses_as_resolved_contract() {
-        assert!(matches!(
-            CONTRACT.parse::<TokenTarget>().unwrap(),
-            TokenTarget::Contract(UnresolvedContract::Resolved(_))
-        ));
-    }
-
-    #[test]
-    fn bare_name_parses_as_contract_alias() {
-        assert!(matches!(
-            "alice".parse::<TokenTarget>().unwrap(),
-            TokenTarget::Contract(UnresolvedContract::Alias(_))
-        ));
-    }
+    let contract_id = token.contract_id;
+    Some(if token.is_sac() {
+        Error::SacNotDeployed(format!("{contract_id}"))
+    } else {
+        Error::ContractNotFound(format!("{contract_id}"))
+    })
 }

--- a/cmd/soroban-cli/src/commands/token/balance.rs
+++ b/cmd/soroban-cli/src/commands/token/balance.rs
@@ -6,9 +6,13 @@ use crate::{
     commands::{
         contract::invoke,
         global,
-        token::args::{self, OutputFormat, TokenTarget},
+        token::args::{self, OutputFormat},
     },
-    config::{self, locator, network, sign_with, UnresolvedContract, UnresolvedScAddress},
+    config::{
+        self, locator, network, sign_with,
+        token::{ResolvedToken, UnresolvedToken},
+        UnresolvedContract, UnresolvedScAddress,
+    },
     fixed_point::FixedPoint,
     output::Output,
 };
@@ -19,7 +23,7 @@ pub struct Cmd {
     /// The token to query: a contract id or alias, `native`, or a classic asset
     /// as `CODE:ISSUER`.
     #[arg(long = "id")]
-    pub id: TokenTarget,
+    pub id: UnresolvedToken,
 
     /// Account or contract whose balance to read.
     #[arg(long)]
@@ -50,6 +54,8 @@ pub enum Error {
     #[error(transparent)]
     Args(#[from] args::Error),
     #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
     ScAddress(#[from] config::sc_address::Error),
     #[error(transparent)]
     Invoke(#[from] invoke::Error),
@@ -68,6 +74,7 @@ impl Error {
             Error::Config(_) => "config",
             Error::Network(_) => "network",
             Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
             Error::ScAddress(_) => "invalid_address",
             Error::Invoke(_) => "invoke",
             Error::Serde(_) | Error::ParseResult { .. } => "internal",
@@ -108,9 +115,9 @@ impl Cmd {
         let config = self.config();
         let network = config.get_network()?;
 
-        let contract_id = self
+        let token = self
             .id
-            .resolve_contract_id(&config.locator, &network.network_passphrase)?;
+            .resolve(&config.locator, &network.network_passphrase)?;
         let account = self
             .account
             .clone()
@@ -122,7 +129,7 @@ impl Cmd {
                 &config,
                 quiet,
                 global_args.no_cache,
-                contract_id,
+                &token,
                 vec![
                     OsString::from("balance"),
                     OsString::from("--id"),
@@ -141,7 +148,7 @@ impl Cmd {
                     &config,
                     quiet,
                     global_args.no_cache,
-                    contract_id,
+                    &token,
                     vec![OsString::from("decimals")],
                     "decimals",
                 )
@@ -163,11 +170,11 @@ impl Cmd {
         config: &config::Args,
         quiet: bool,
         no_cache: bool,
-        contract_id: stellar_strkey::Contract,
+        token: &ResolvedToken,
         slop: Vec<OsString>,
     ) -> Result<String, Error> {
         let invoke_cmd = invoke::Cmd {
-            contract_id: UnresolvedContract::Resolved(contract_id),
+            contract_id: UnresolvedContract::Resolved(token.contract_id),
             slop,
             config: config.clone(),
             send: invoke::Send::No,
@@ -177,11 +184,7 @@ impl Cmd {
         let receipt = invoke_cmd
             .execute_with_receipt(config, quiet, no_cache)
             .await
-            .map_err(|e| {
-                self.id
-                    .not_deployed_error(&e, &contract_id)
-                    .map_or(Error::Invoke(e), Error::Args)
-            })?
+            .map_err(|e| args::not_deployed_error(token, &e).map_or(Error::Invoke(e), Error::Args))?
             .into_result();
 
         Ok(receipt.map(|r| r.output).unwrap_or_default())
@@ -194,13 +197,11 @@ impl Cmd {
         config: &config::Args,
         quiet: bool,
         no_cache: bool,
-        contract_id: stellar_strkey::Contract,
+        token: &ResolvedToken,
         slop: Vec<OsString>,
         what: &'static str,
     ) -> Result<T, Error> {
-        let out = self
-            .read(config, quiet, no_cache, contract_id, slop)
-            .await?;
+        let out = self.read(config, quiet, no_cache, token, slop).await?;
         // A 128-bit balance comes back JSON-encoded as a quoted string (it can't
         // fit a JSON number), while `decimals` (u32) comes back bare; strip any
         // surrounding quotes so both parse straight into `T`.

--- a/cmd/soroban-cli/src/commands/token/transfer.rs
+++ b/cmd/soroban-cli/src/commands/token/transfer.rs
@@ -6,11 +6,11 @@ use crate::{
     commands::{
         contract::invoke,
         global,
-        token::args::{self, OutputFormat, TokenTarget},
+        token::args::{self, OutputFormat},
     },
     config::{
-        self, locator, network, sign_with, UnresolvedContract, UnresolvedMuxedAccount,
-        UnresolvedScAddress,
+        self, locator, network, sign_with, token::UnresolvedToken, UnresolvedContract,
+        UnresolvedMuxedAccount, UnresolvedScAddress,
     },
     output::Output,
 };
@@ -21,7 +21,7 @@ pub struct Cmd {
     /// The token to transfer from: a contract id or alias, `native`, or a
     /// classic asset as `CODE:ISSUER`.
     #[arg(long = "id")]
-    pub id: TokenTarget,
+    pub id: UnresolvedToken,
 
     /// Account to transfer tokens from. Signs and authorizes the transfer, so it
     /// must be an identity or secret key you control.
@@ -61,6 +61,8 @@ pub enum Error {
     #[error(transparent)]
     Args(#[from] args::Error),
     #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
     ScAddress(#[from] config::sc_address::Error),
     #[error(transparent)]
     Invoke(#[from] invoke::Error),
@@ -95,6 +97,7 @@ impl Error {
             Error::Config(_) => "config",
             Error::Network(_) => "network",
             Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
             Error::ScAddress(_) => "invalid_address",
             Error::Invoke(_) => "invoke",
             Error::Serde(_) => "internal",
@@ -138,9 +141,9 @@ impl Cmd {
         let config = self.config();
         let network = config.get_network()?;
 
-        let contract_id = self
+        let token = self
             .id
-            .resolve_contract_id(&config.locator, &network.network_passphrase)?;
+            .resolve(&config.locator, &network.network_passphrase)?;
 
         // SEP-41 `transfer(from, to, amount)`: `from` is the source account
         // (which also signs and authorizes), `to` is the destination.
@@ -172,7 +175,7 @@ impl Cmd {
         .collect();
 
         let invoke_cmd = invoke::Cmd {
-            contract_id: UnresolvedContract::Resolved(contract_id),
+            contract_id: UnresolvedContract::Resolved(token.contract_id),
             slop,
             config: config.clone(),
             // A transfer always intends to submit. Force `Send::Yes` so a token
@@ -186,9 +189,7 @@ impl Cmd {
             .execute_with_receipt(&config, quiet, global_args.no_cache)
             .await
             .map_err(|e| {
-                self.id
-                    .not_deployed_error(&e, &contract_id)
-                    .map_or(Error::Invoke(e), Error::Args)
+                args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args)
             })?
             .into_result();
 

--- a/cmd/soroban-cli/src/config/alias.rs
+++ b/cmd/soroban-cli/src/config/alias.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use stellar_strkey::Contract;
 
 use super::locator;
-use crate::utils::contract_id_hash_from_asset;
-use crate::xdr::Asset;
+use crate::config::token::UnresolvedToken;
+use crate::tx::builder;
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct Data {
@@ -29,15 +29,24 @@ pub fn is_reserved(alias: &str) -> bool {
 /// truth for what the reserved alias points to, so resolution stays consistent
 /// across `get_contract_id`, `alias show`, and `alias ls`.
 #[must_use]
-pub fn resolve_reserved(alias: &str, network_passphrase: &str) -> Option<Contract> {
-    if is_reserved(alias) {
-        Some(contract_id_hash_from_asset(
-            &Asset::Native,
-            network_passphrase,
-        ))
-    } else {
-        None
+pub fn resolve_reserved(
+    alias: &str,
+    locator: &locator::Args,
+    network_passphrase: &str,
+) -> Option<Contract> {
+    if !is_reserved(alias) {
+        return None;
     }
+
+    // The reserved alias points at the native asset's Stellar Asset Contract.
+    // Route it through the shared token resolver so its id stays identical to
+    // every other `native` resolution. `locator` is unused for native (there is
+    // no issuer alias to look up) but is threaded through for signature parity
+    // with the resolver; native therefore can never fail to resolve.
+    let resolved = UnresolvedToken::Asset(builder::Asset::Native)
+        .resolve(locator, network_passphrase)
+        .expect("the reserved native alias always resolves to its SAC");
+    Some(resolved.contract_id)
 }
 
 /// Errors if `alias` is a reserved, built-in alias. Call this before doing any

--- a/cmd/soroban-cli/src/config/locator.rs
+++ b/cmd/soroban-cli/src/config/locator.rs
@@ -540,7 +540,7 @@ impl Args {
         // refuse to silently override it: resolving to the built-in anyway
         // would misdirect the command to the wrong contract. The stored file
         // can still be removed with `contract alias remove <name>`.
-        if let Some(reserved) = alias::resolve_reserved(alias, network_passphrase) {
+        if let Some(reserved) = alias::resolve_reserved(alias, self, network_passphrase) {
             if let Some(stored) = self.get_stored_contract_id(alias, network_passphrase)? {
                 if stored != reserved {
                     return Err(Error::ShadowedReservedAlias {

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -23,6 +23,7 @@ pub mod network;
 pub mod sc_address;
 pub mod secret;
 pub mod sign_with;
+pub mod token;
 pub mod upgrade_check;
 pub mod utils;
 

--- a/cmd/soroban-cli/src/config/token.rs
+++ b/cmd/soroban-cli/src/config/token.rs
@@ -1,0 +1,212 @@
+use std::str::FromStr;
+
+use crate::{
+    config::{alias::UnresolvedContract, locator},
+    tx::builder,
+    utils::contract_id_hash_from_asset,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Locator(#[from] locator::Error),
+    #[error(transparent)]
+    Asset(#[from] builder::asset::Error),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Locator(_) => "config",
+            Error::Asset(_) => "invalid_asset",
+        }
+    }
+}
+
+/// What a token reference resolved to.
+#[derive(Clone, Debug)]
+pub enum TokenKind {
+    /// A Stellar Asset Contract (SAC) wrapping this classic asset.
+    Sac(crate::xdr::Asset),
+    /// A plain SEP-41 contract addressed by id or alias.
+    Contract,
+}
+
+/// A token reference resolved to a concrete contract id, together with what it
+/// turned out to be. This is the single answer to both "what contract id?" and
+/// "is this a SAC, and for which asset?", so SAC-awareness (deploy hints,
+/// `sac_not_deployed` vs `contract_not_found` errors) stays consistent
+/// everywhere.
+#[derive(Clone, Debug)]
+pub struct ResolvedToken {
+    pub contract_id: stellar_strkey::Contract,
+    pub kind: TokenKind,
+}
+
+impl ResolvedToken {
+    /// Returns `true` if this token is a Stellar Asset Contract.
+    #[must_use]
+    pub fn is_sac(&self) -> bool {
+        matches!(self.kind, TokenKind::Sac(_))
+    }
+
+    /// The classic asset backing this token, or `None` for a plain contract.
+    #[must_use]
+    pub fn asset(&self) -> Option<&crate::xdr::Asset> {
+        match &self.kind {
+            TokenKind::Sac(asset) => Some(asset),
+            TokenKind::Contract => None,
+        }
+    }
+}
+
+/// An unresolved token reference parsed from a user-supplied string.
+///
+/// The shape of the value decides how it is interpreted:
+/// * `native` or `CODE:ISSUER` → a Stellar Asset Contract (SAC), resolved from
+///   the classic asset.
+/// * anything else → a contract, either a `C…` strkey or a saved alias.
+#[derive(Clone, Debug)]
+pub enum UnresolvedToken {
+    /// A Stellar Asset Contract addressed by its underlying classic asset.
+    Asset(builder::Asset),
+    /// A SEP-41 contract addressed directly by id or alias.
+    Contract(UnresolvedContract),
+}
+
+impl FromStr for UnresolvedToken {
+    type Err = builder::asset::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // `native` and the `CODE:ISSUER` shape are both classic assets, resolved
+        // to their Stellar Asset Contract — so a missing SAC reports
+        // `sac_not_deployed`, not `contract_not_found`. Everything else is a
+        // contract id or a saved alias.
+        if value == "native" || value.contains(':') {
+            Ok(UnresolvedToken::Asset(value.parse()?))
+        } else {
+            // `UnresolvedContract::from_str` is infallible.
+            Ok(UnresolvedToken::Contract(value.parse().unwrap()))
+        }
+    }
+}
+
+impl UnresolvedToken {
+    /// Resolve this reference to a concrete contract id and classify it as a SAC
+    /// (with its asset) or a plain contract.
+    pub fn resolve(
+        &self,
+        locator: &locator::Args,
+        network_passphrase: &str,
+    ) -> Result<ResolvedToken, Error> {
+        match self {
+            UnresolvedToken::Asset(asset) => {
+                let asset = asset.resolve(locator)?;
+                let contract_id = contract_id_hash_from_asset(&asset, network_passphrase);
+                Ok(ResolvedToken {
+                    contract_id,
+                    kind: TokenKind::Sac(asset),
+                })
+            }
+            UnresolvedToken::Contract(contract) => {
+                let contract_id = contract.resolve_contract_id(locator, network_passphrase)?;
+                Ok(ResolvedToken {
+                    contract_id,
+                    kind: TokenKind::Contract,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A valid contract strkey borrowed from the CLI's own help text.
+    const CONTRACT: &str = "CCR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OTE2";
+    const NETWORK: &str = "Test Network";
+
+    #[test]
+    fn native_parses_as_asset() {
+        assert!(matches!(
+            "native".parse::<UnresolvedToken>().unwrap(),
+            UnresolvedToken::Asset(builder::Asset::Native)
+        ));
+    }
+
+    #[test]
+    fn code_issuer_parses_as_asset() {
+        assert!(matches!(
+            "USDC:issuer".parse::<UnresolvedToken>().unwrap(),
+            UnresolvedToken::Asset(builder::Asset::Asset(..))
+        ));
+    }
+
+    #[test]
+    fn contract_strkey_parses_as_resolved_contract() {
+        assert!(matches!(
+            CONTRACT.parse::<UnresolvedToken>().unwrap(),
+            UnresolvedToken::Contract(UnresolvedContract::Resolved(_))
+        ));
+    }
+
+    #[test]
+    fn bare_name_parses_as_contract_alias() {
+        assert!(matches!(
+            "alice".parse::<UnresolvedToken>().unwrap(),
+            UnresolvedToken::Contract(UnresolvedContract::Alias(_))
+        ));
+    }
+
+    #[test]
+    fn native_resolves_to_sac() {
+        let locator = locator::Args::default();
+        let resolved = "native"
+            .parse::<UnresolvedToken>()
+            .unwrap()
+            .resolve(&locator, NETWORK)
+            .unwrap();
+
+        assert!(resolved.is_sac());
+        assert!(matches!(resolved.asset(), Some(crate::xdr::Asset::Native)));
+        assert_eq!(
+            resolved.contract_id,
+            contract_id_hash_from_asset(&crate::xdr::Asset::Native, NETWORK)
+        );
+    }
+
+    #[test]
+    fn code_issuer_resolves_to_sac() {
+        let locator = locator::Args::default();
+        // A `CODE:ISSUER` reference with a concrete G… issuer needs no alias
+        // lookup, so it resolves without a populated locator.
+        let resolved = "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+            .parse::<UnresolvedToken>()
+            .unwrap()
+            .resolve(&locator, NETWORK)
+            .unwrap();
+
+        assert!(resolved.is_sac());
+        assert!(matches!(
+            resolved.asset(),
+            Some(crate::xdr::Asset::CreditAlphanum4(_))
+        ));
+    }
+
+    #[test]
+    fn contract_strkey_resolves_to_contract() {
+        let locator = locator::Args::default();
+        let resolved = CONTRACT
+            .parse::<UnresolvedToken>()
+            .unwrap()
+            .resolve(&locator, NETWORK)
+            .unwrap();
+
+        assert!(!resolved.is_sac());
+        assert!(resolved.asset().is_none());
+        assert_eq!(resolved.contract_id, CONTRACT.parse().unwrap());
+    }
+}


### PR DESCRIPTION
### What

Introduces a single token resolver in a new `config::token` module and migrates the scattered asset/token → contract-id derivations onto it, resolving #2652.

- `UnresolvedToken` — a token reference parsed from a user string (`native`/`CODE:ISSUER` → asset; `C…` strkey or alias → contract).
- `ResolvedToken { contract_id, kind }` where `TokenKind` is `Sac(xdr::Asset)` or `Contract` — the single answer to both "what contract id?" and "is this a SAC, and for which asset?". Helpers: `is_sac()` / `asset()`.

Migrated call sites:
- `commands::token::args` — dropped the old `TokenTarget`; `not_deployed_error` is now keyed off `ResolvedToken::kind`, keeping the `sac_not_deployed` vs `contract_not_found` split. `args::Error` now carries only the two token-aware variants it actually produces.
- `commands::token::{balance,transfer}` — `--id` is now `UnresolvedToken`; both resolve once and thread the `ResolvedToken` through.
- `commands::contract::{id,deploy}::asset` — derive the id (and, for deploy, the wrap-tx asset) via the resolver. Deploy resolves up front, before any RPC, so an invalid asset fails fast.
- `config::alias::resolve_reserved` — the reserved `native` alias now resolves through the shared resolver.

`utils::contract_id_hash_from_asset` remains the low-level primitive the resolver builds on.

### Why

Resolving a token/asset reference to a contract id — and knowing whether it's a Stellar Asset Contract and for which asset — was spread across several overlapping places, with no single type answering both questions. This surfaced in #2651, where `native` had to be special-cased as a SAC. The resolver makes SAC-awareness consistent everywhere (errors, deploy, id).

### Known limitations

`snapshot::create` is intentionally left unmigrated: that site parses the asset to extract the **issuer** for account search, not to derive a contract id, so `ResolvedToken`'s shape doesn't fit.