### PR TITLE
Update Soroban dependencies to 27.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4305,7 +4305,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4342,7 +4342,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5371,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d769030e3b2c27873e9be4931decbbe79787b943d5b30e31f8c395eae83144b8"
+checksum = "b77bc93d930032c487cb1506b6ed166b2af49db76d52678ec4887ac621ecce01"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5474,9 +5474,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa50d998c0baafcc6078cb94f5228040c7719b1608c15debc3fc78365dc22f5"
+checksum = "6b22e9981cdd444f3aa6734bc58d76195bf7eca3ccf1dd432b875af5d02da068"
 dependencies = [
  "arbitrary",
  "crate-git-revision 0.0.6",
@@ -5493,9 +5493,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde1064f5e92dbcc8018ecc8e92728bf5bbff0236abaf792c6858367a6853415"
+checksum = "2b6072f99ca6bf8e8d5b04e05d083dac785e5357d9c0f36a6658f819c2fd7d67"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -5503,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47762a1b75b9ccd07558f28e1a0289ca6adec56810c581cde5cf16e329e00b9"
+checksum = "2c06afd7c75ce150ce53e4d77a77645b18e3fb61856a0ddc42bfcecdc39fa3b9"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5540,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04b813a9e32456b37875fc41cdb05912a9e947000b9414b7985bffe07a889a"
+checksum = "647811bdd28a3ec40296987f6635781e5e1141c8f5affbbd53ba12b6295b7bb6"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5559,9 +5559,9 @@ version = "27.0.0"
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2272e9ee6f44cae1f3fe38b16f83e37ae6b55d002ecd7cbd45e02fde277c5a0"
+checksum = "27ea48b5d5e22c0cbaa370f813111016c9f5a8a6632edb0684c72be6531c4d3a"
 dependencies = [
  "serde",
  "serde_json",
@@ -5573,9 +5573,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4cf66a6ec501ca3bb6018e36d3293ffbcd9b83651d8ae5afa03a4c8dd02fd1"
+checksum = "6cfa78af0110f0830d3af9db0361b6cdb50507846cedb8725189318134218b80"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5597,9 +5597,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ecdb16404a2a973c88193ccbfe519aa44b02cd2ff838dd61ce49117a2537c"
+checksum = "3db611bd0acfe5fd348ffdcef16c84090c6ab051f3e325b5ac049a73044a7ee6"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -5617,9 +5617,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85665c21947b7e9fff81a8e81c866e2e774040039856f75af9cb06ec75191c8"
+checksum = "8061fe31998fe9fba8fcd7175b3e3ca914a6f6e3bf829fe91fdf7f930b1251d9"
 dependencies = [
  "base64 0.22.1",
  "sha2 0.10.9",
@@ -5630,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb924883f555ca020951e861025d153657481e0a88dddec9f853e2aad76ddc9"
+checksum = "2180cddacf3023a439827cb35c0e391ec413b1328173fe7c8c2743fc67b3af9e"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5729,18 +5729,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6be88fe99c858b5d79411a0a4b51b0f5fafca1b82b5fcb651bada1e2f52d190"
+checksum = "bc52c6f247f1c3383b9fa8f8ab6bf3c6c7b36e893a2fff585bc819cbc89ec193"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407dbf1edb3935637eb348945a9a756696a5dda1d4084735fbdeb5c8177bcc03"
+checksum = "7417a2ae69b4a6fc52f986c3d501b3bd442ba976a0991f042f81f7ee593e1b30"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5789,9 +5789,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "27.0.0-rc.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697ec90d05795ccf631203555c775765916aca130c41521c403532d687444ad7"
+checksum = "e9943559865bce30221f21f2bdd45352c91c253ddf1002dba413a7a0ffc23945"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,26 +48,26 @@ version = "27.0.0"
 
 # Dependencies from the rs-stellar-env repo:
 [workspace.dependencies.soroban-env-host]
-version = "27.0.0"
+version = "27.0.1"
 
 # Dependencies from the rs-soroban-sdk repo:
 [workspace.dependencies.soroban-spec]
-version = "27.0.0-rc.1"
+version = "27.0.2"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "27.0.0-rc.1"
+version = "27.0.2"
 
 [workspace.dependencies.soroban-sdk]
-version = "27.0.0-rc.1"
+version = "27.0.2"
 
 [workspace.dependencies.soroban-token-sdk]
-version = "27.0.0-rc.1"
+version = "27.0.2"
 
 [workspace.dependencies.stellar-asset-spec]
-version = "27.0.0-rc.1"
+version = "27.0.2"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "27.0.0-rc.1"
+version = "27.0.2"
 
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]

--- a/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
+++ b/cmd/soroban-cli/src/utils/contract-workspace-template/Cargo.toml.removeextension
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "26"
+soroban-sdk = "27"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What

Bumps the Soroban workspace dependencies to `27.0.2` (`soroban-spec`, `soroban-spec-rust`, `soroban-sdk`, `soroban-token-sdk`, `stellar-asset-spec`, `soroban-ledger-snapshot`) and `soroban-env-host` to `27.0.1`, with the matching `Cargo.lock` updates.

### Why

Keeps the CLI aligned with the latest published Soroban SDK and env-host releases, moving several dependencies off the `27.0.0-rc.1` pre-release pins onto stable versions.

### Known limitations

N/A