### PR TITLE
Fix `contract extend` panic when extending a missing entry

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -1,3 +1,4 @@
+use predicates::prelude::PredicateBooleanExt;
 use soroban_cli::{
     commands::{
         contract::{self, fetch},
@@ -340,6 +341,28 @@ async fn contract_data_read() {
         .assert()
         .success()
         .stdout(predicates::str::starts_with("COUNTER,2"));
+}
+
+#[tokio::test]
+async fn extend_nonexistent_entry_errors_without_panic() {
+    // A well-formed but non-existent contract id makes the extend a no-op. The
+    // CLI must surface a clean error rather than panic with "index out of
+    // bounds" while inspecting the (empty) ledger entries. See issue #2599.
+    const NONEXISTENT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+    let sandbox = &TestEnv::new();
+
+    sandbox
+        .new_assert_cmd("contract")
+        .arg("extend")
+        .arg("--id")
+        .arg(NONEXISTENT_ID)
+        .arg("--ledgers-to-extend")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Ledger entry not found"))
+        .stderr(predicates::str::contains("index out of bounds").not())
+        .stderr(predicates::str::contains("panicked").not());
 }
 
 async fn invoke_with_seed(sandbox: &TestEnv, id: &str, seed_phrase: &str) {

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -288,7 +288,14 @@ impl Cmd {
         if changes.is_empty() {
             print.infoln("No changes detected, transaction was a no-op.");
             let entry = client.get_full_ledger_entries(&keys).await?;
-            let extension = entry.entries[0].live_until_ledger_seq.unwrap_or_default();
+            // A no-op extend against a non-existent entry returns no entries, so
+            // avoid indexing into an empty vec (which would panic).
+            let extension = entry
+                .entries
+                .first()
+                .ok_or(Error::LedgerEntryNotFound)?
+                .live_until_ledger_seq
+                .unwrap_or_default();
 
             return Ok(TxnResult::Res(extension));
         }


### PR DESCRIPTION
### What

Fixes a panic in `stellar contract extend`. When run against a well-formed but non-existent contract entry, the transaction goes through as a no-op and the CLI then crashes with `index out of bounds: the len is 0 but the index is 0`. It now exits cleanly with a "Ledger entry not found" error instead.

### Why

On a no-op extend the code fetched the ledger entries and unconditionally indexed `entry.entries[0]`. For a non-existent entry that vec is empty, so the index panicked. This replaces the raw index with `.first().ok_or(Error::LedgerEntryNotFound)?`, reusing the existing error variant already returned for the analogous no-op cases in the same function. Fixes #2599.

### Known limitations

N/A