### PR TITLE
Fix `contract restore` panic when restoring a missing entry

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -365,6 +365,26 @@ async fn extend_nonexistent_entry_errors_without_panic() {
         .stderr(predicates::str::contains("panicked").not());
 }
 
+#[tokio::test]
+async fn restore_nonexistent_entry_errors_without_panic() {
+    // A well-formed but non-existent contract id makes the restore a no-op.
+    // The CLI must surface a clean error rather than panic with "index out of
+    // bounds" while inspecting the (empty) ledger entries. See issue #2599.
+    const NONEXISTENT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+    let sandbox = &TestEnv::new();
+
+    sandbox
+        .new_assert_cmd("contract")
+        .arg("restore")
+        .arg("--id")
+        .arg(NONEXISTENT_ID)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Ledger entry not found"))
+        .stderr(predicates::str::contains("index out of bounds").not())
+        .stderr(predicates::str::contains("panicked").not());
+}
+
 async fn invoke_with_seed(sandbox: &TestEnv, id: &str, seed_phrase: &str) {
     invoke_with_source(sandbox, seed_phrase, id).await;
 }

--- a/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/hello_world.rs
@@ -367,9 +367,10 @@ async fn extend_nonexistent_entry_errors_without_panic() {
 
 #[tokio::test]
 async fn restore_nonexistent_entry_errors_without_panic() {
-    // A well-formed but non-existent contract id makes the restore a no-op.
-    // The CLI must surface a clean error rather than panic with "index out of
-    // bounds" while inspecting the (empty) ledger entries. See issue #2599.
+    // Restoring a well-formed but non-existent contract id fails at
+    // simulation with "Missing entry to restore". The CLI must surface that
+    // as a clean error and never panic with "index out of bounds" while
+    // inspecting empty ledger entries. See issue #2599.
     const NONEXISTENT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
     let sandbox = &TestEnv::new();
 
@@ -380,7 +381,7 @@ async fn restore_nonexistent_entry_errors_without_panic() {
         .arg(NONEXISTENT_ID)
         .assert()
         .failure()
-        .stderr(predicates::str::contains("Ledger entry not found"))
+        .stderr(predicates::str::contains("Missing entry to restore"))
         .stderr(predicates::str::contains("index out of bounds").not())
         .stderr(predicates::str::contains("panicked").not());
 }

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -262,7 +262,14 @@ impl Cmd {
         if changes.is_empty() {
             print.infoln("No changes detected, transaction was a no-op.");
             let entry = client.get_full_ledger_entries(&entry_keys).await?;
-            let extension = entry.entries[0].live_until_ledger_seq.unwrap_or_default();
+            // A no-op restore against a non-existent entry returns no entries, so
+            // avoid indexing into an empty vec (which would panic).
+            let extension = entry
+                .entries
+                .first()
+                .ok_or(Error::LedgerEntryNotFound)?
+                .live_until_ledger_seq
+                .unwrap_or_default();
 
             return Ok(TxnResult::Res(extension));
         }

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -262,8 +262,9 @@ impl Cmd {
         if changes.is_empty() {
             print.infoln("No changes detected, transaction was a no-op.");
             let entry = client.get_full_ledger_entries(&entry_keys).await?;
-            // A no-op restore against a non-existent entry returns no entries, so
-            // avoid indexing into an empty vec (which would panic).
+            // The fetch after a no-op can return no entries (e.g. the entry
+            // was evicted in the meantime), so avoid indexing into an empty
+            // vec (which would panic).
             let extension = entry
                 .entries
                 .first()


### PR DESCRIPTION
### What

Guard `stellar contract restore` against the same "index out of bounds" panic that #2657 fixed in `extend`: the no-op path unconditionally indexed `entry.entries[0]`, which panics if the post-transaction fetch returns no entries. It now errors with "Ledger entry not found" instead.

### Why

`restore` carried the identical unguarded indexing as `extend` (see #2599), so this applies the same `.first().ok_or(Error::LedgerEntryNotFound)?` fix. Unlike extend, restoring a non-existent entry fails cleanly at simulation ("Missing entry to restore") before reaching the no-op path, so this guard is defensive hardening for the narrower case where the fetch after a no-op comes back empty (e.g. the entry was evicted in the meantime). The regression test asserts the non-existent-entry case fails cleanly at simulation without panicking.

### Known limitations

The empty-fetch-after-no-op case itself isn't covered by an integration test since simulation catches the straightforward missing-entry scenario first.