### PR TITLE
Use latest quickstart image for RPC tests

### DIFF
--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: stellar/quickstart@main
         with:
-          tag: nightly
+          tag: latest
           protocol_version: 27
       - uses: actions/checkout@v7
       - uses: stellar/actions/rust-cache@main


### PR DESCRIPTION
### What

Remove the explicit `tag: nightly` override in the RPC Tests workflow so it uses the `latest` quickstart image (the action default established in #2649).

### Why

The nightly quickstart's captive-core emits newer XDR-JSON — notably `ContractEvent`'s discriminant as `type` — that the CLI's pinned `stellar-xdr` 27.0.0 (via `stellar-rpc-client` 27.0.0) cannot parse, so `ledger fetch` integration tests fail with ``missing field `type_` ``. The `latest` released image matches the CLI's protocol-27 XDR, so the tests pass again.

### Known limitations

CI no longer exercises upcoming-protocol nightly builds. That coverage can be restored once `stellar-rpc-client` ships a release depending on `stellar-xdr` >= 28.0.0, which reads both `type` and `type_`.