### PR TITLE
Escape control characters in more terminal output

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
+++ b/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
@@ -383,7 +383,7 @@ pub fn build_custom_cmd(name: &str, spec: &Spec) -> Result<clap::Command, Error>
             .conflicts_with(name);
 
         if let Some(value_name) = spec.arg_value_name(type_, 0) {
-            let value_name: &'static str = Box::leak(value_name.into_boxed_str());
+            let value_name: &'static str = Box::leak(sanitize(&value_name).into_boxed_str());
             arg = arg.value_name(value_name);
         }
 
@@ -928,6 +928,56 @@ mod tests {
                 element_type: Box::new(ScSpecTypeDef::U32),
             }
         ))));
+    }
+
+    // A UDT struct field name is attacker-influenceable contract-spec data and
+    // is embedded into the clap `value_name` shown in `--help`, so control and
+    // escape sequences must not survive to the terminal.
+    #[test]
+    fn build_custom_cmd_strips_control_bytes_from_value_name() {
+        use soroban_spec_tools::test_utils::assert_no_control_chars;
+        use stellar_xdr::{
+            ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeUdt,
+            ScSpecUdtStructFieldV0, ScSpecUdtStructV0, ScSymbol,
+        };
+
+        let strukt = ScSpecEntry::UdtStructV0(ScSpecUdtStructV0 {
+            doc: "".try_into().unwrap(),
+            lib: "".try_into().unwrap(),
+            name: "S".try_into().unwrap(),
+            fields: vec![ScSpecUdtStructFieldV0 {
+                doc: "".try_into().unwrap(),
+                name: "\x1b[2Jevil".try_into().unwrap(),
+                type_: ScSpecTypeDef::U32,
+            }]
+            .try_into()
+            .unwrap(),
+        });
+        let func = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "".try_into().unwrap(),
+            name: ScSymbol("f".try_into().unwrap()),
+            inputs: vec![ScSpecFunctionInputV0 {
+                doc: "".try_into().unwrap(),
+                name: "s".try_into().unwrap(),
+                type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                    name: "S".try_into().unwrap(),
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            outputs: vec![].try_into().unwrap(),
+        });
+
+        let spec = Spec(Some(vec![strukt, func]));
+
+        let cmd = build_custom_cmd("f", &spec).unwrap();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id() == "s")
+            .expect("arg `s` should be registered");
+        for value_name in arg.get_value_names().unwrap_or_default() {
+            assert_no_control_chars(value_name.as_str());
+        }
     }
 
     #[test]

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -359,7 +359,7 @@ fn get_contract_meta_sdk_version(wasm_spec: &soroban_spec_tools::contract::Spec)
     if let Some(rs_sdk_version_entry) = &rs_sdk_version_option {
         match rs_sdk_version_entry {
             ScMetaEntry::ScMetaV0(ScMetaV0 { val, .. }) => {
-                return Some(val.to_utf8_string_lossy());
+                return Some(soroban_spec_tools::sanitize(&val.to_utf8_string_lossy()));
             }
         }
     }
@@ -410,5 +410,32 @@ mod tests {
         );
 
         assert!(result.is_ok());
+    }
+
+    fn spec_with_sdk_meta(version: &str) -> soroban_spec_tools::contract::Spec {
+        let meta = ScMetaEntry::ScMetaV0(ScMetaV0 {
+            key: CONTRACT_META_SDK_KEY.try_into().unwrap(),
+            val: version.try_into().unwrap(),
+        });
+        soroban_spec_tools::contract::Spec {
+            env_meta_base64: None,
+            env_meta: vec![],
+            meta_base64: Some(String::new()),
+            meta: vec![meta],
+            spec_base64: None,
+            spec: vec![],
+        }
+    }
+
+    // The SDK version comes from attacker-influenceable contract metadata and is
+    // rendered into an error message / warning line on the terminal, so control
+    // and escape sequences must not survive.
+    #[test]
+    fn sdk_version_strips_control_bytes() {
+        let spec = spec_with_sdk_meta("0.9.0-rc\x1b[2Jhax");
+        let version = get_contract_meta_sdk_version(&spec).expect("sdk version present");
+        soroban_spec_tools::test_utils::assert_no_control_chars(&version);
+        // "rc" detection (used to gate the release-candidate check) still works.
+        assert!(version.contains("rc"));
     }
 }

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -377,8 +377,8 @@ impl Cmd {
         writeln!(
             stdout,
             " {} [{}]:",
-            event.id,
-            event.event_type.to_uppercase()
+            sanitize(&event.id),
+            sanitize(&event.event_type.to_uppercase())
         )?;
 
         // Ledger info
@@ -388,14 +388,15 @@ impl Cmd {
         writeln!(
             stdout,
             "{} (closed at {})",
-            event.ledger, event.ledger_closed_at
+            event.ledger,
+            sanitize(&event.ledger_closed_at)
         )?;
 
         // Contract
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_dimmed(true))?;
         write!(stdout, "  Contract: ")?;
         stdout.reset()?;
-        writeln!(stdout, "{}", decoded.contract_id)?;
+        writeln!(stdout, "{}", sanitize(&decoded.contract_id))?;
 
         // Event name with prefix topics
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_dimmed(true))?;
@@ -527,11 +528,11 @@ mod tests {
 
     fn evil_event() -> rpc::Event {
         rpc::Event {
-            event_type: "contract".into(),
+            event_type: "contract\x1b[31m".into(),
             ledger: 1,
-            ledger_closed_at: "2026-01-01T00:00:00Z".into(),
+            ledger_closed_at: "2026-01-01T00:00:00Z\x1b[2J".into(),
             contract_id: "CACA".into(),
-            id: "0000000001-0000000001".into(),
+            id: "0000000001-0000000001\x1b[H".into(),
             operation_index: None,
             transaction_index: None,
             tx_hash: None,
@@ -546,7 +547,7 @@ mod tests {
         let mut params = IndexMap::new();
         params.insert("amount\x1b[31m".to_string(), json!(1000));
         DecodedEvent {
-            contract_id: "CACA".to_string(),
+            contract_id: "CACA\x1b[0m".to_string(),
             event_name: "\x1b[2J\x1b[Htransfer".to_string(),
             prefix_topics: vec!["\x1b[31mEVIL".into(), "topic2".into()],
             params,


### PR DESCRIPTION
### What

Sanitizes three more attacker-influenceable strings before they reach the terminal, so control and ANSI escape sequences can no longer survive to a user's screen:

- **`contract` arg parsing** — UDT struct field names are embedded into the clap `value_name` shown in `--help`; the value name is now run through `sanitize()`.
- **`contract upload`** — the SDK version read from contract metadata (used in an error/warning line, including the release-candidate check) is now sanitized while still preserving `rc` detection.
- **`events`** — the event `id`, `event_type`, `ledger_closed_at`, and decoded `contract_id` are now sanitized before being written to stdout.

Each change comes with a test that feeds embedded escape sequences (e.g. `\x1b[2J`, `\x1b[H`) and asserts no control characters survive in the rendered output.

### Why

Contract spec/metadata and RPC event data are not trusted input. Rendering them verbatim lets a malicious contract inject terminal escape sequences (screen clears, cursor moves, color resets) into CLI output. This continues the terminal-output sanitization sweep started in recent commits, closing the remaining unescaped paths in `--help` value names, upload warnings, and event listings.

### Known limitations

N/A