### PR TITLE
Add depth limit to xdr encoding and decoding

### DIFF
--- a/cmd/crates/soroban-spec-tools/src/contract.rs
+++ b/cmd/crates/soroban-spec-tools/src/contract.rs
@@ -114,7 +114,12 @@ impl Spec {
         let spec = self
             .spec
             .iter()
-            .map(|e| Ok(format!("\"{}\"", e.to_xdr_base64(Limits::none())?)))
+            .map(|e| {
+                Ok(format!(
+                    "\"{}\"",
+                    e.to_xdr_base64(Limits::depth(SPEC_XDR_DEPTH_LIMIT))?
+                ))
+            })
             .collect::<Result<Vec<_>, Error>>()?
             .join(",\n");
         Ok(format!("[{spec}]"))

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -15,6 +15,11 @@ use types::{Entry, ErrorEnumCase};
 
 use soroban_spec::read::{from_wasm, FromWasmError};
 
+/// Depth limit when encoding and decoding XDR.
+///
+/// 500 matches `soroban-env-host`'s `DEFAULT_XDR_RW_LIMITS`.
+const XDR_DEPTH_LIMIT: u32 = 500;
+
 pub mod boilerplate;
 mod types;
 
@@ -86,7 +91,12 @@ fn generate_class(
         .join(",\n        ");
     let spec = spec
         .iter()
-        .map(|s| format!("\"{}\"", s.to_xdr_base64(Limits::none()).unwrap()))
+        .map(|s| {
+            format!(
+                "\"{}\"",
+                s.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT)).unwrap()
+            )
+        })
         .join(",\n        ");
     format!(
         r#"export interface Client {{{method_types}

--- a/cmd/crates/stellar-ledger/src/lib.rs
+++ b/cmd/crates/stellar-ledger/src/lib.rs
@@ -22,6 +22,11 @@ mod signer;
 
 pub mod emulator_test_support;
 
+/// Depth limit when encoding and decoding XDR.
+///
+/// 500 matches `soroban-env-host`'s `DEFAULT_XDR_RW_LIMITS`.
+const XDR_DEPTH_LIMIT: u32 = 500;
+
 // this is from https://github.com/LedgerHQ/ledger-live/blob/36cfbf3fa3300fd99bcee2ab72e1fd8f280e6280/libs/ledgerjs/packages/hw-app-str/src/Str.ts#L181
 const APDU_MAX_SIZE: u8 = 150;
 const HD_PATH_ELEMENTS_COUNT: u8 = 3;
@@ -161,7 +166,8 @@ where
             network_id,
             tagged_transaction,
         };
-        let mut signature_payload_as_bytes = signature_payload.to_xdr(Limits::none())?;
+        let mut signature_payload_as_bytes =
+            signature_payload.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?;
 
         let mut hd_path_to_bytes = hd_path.into().to_vec()?;
 

--- a/cmd/soroban-cli/src/assembled.rs
+++ b/cmd/soroban-cli/src/assembled.rs
@@ -10,6 +10,8 @@ use soroban_rpc::{
     AuthMode, Error, LogEvents, LogResources, ResourceConfig, SimulateTransactionResponse,
 };
 
+use crate::utils::XDR_DEPTH_LIMIT;
+
 pub async fn simulate_and_assemble_transaction(
     client: &soroban_rpc::Client,
     tx: &Transaction,
@@ -24,7 +26,7 @@ pub async fn simulate_and_assemble_transaction(
 
     tracing::trace!(
         "Simulation transaction envelope: {}",
-        envelope.to_xdr_base64(Limits::none())?
+        envelope.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?
     );
 
     // Whether an explicit record mode was requested. In record mode the RPC re-records auth
@@ -94,7 +96,7 @@ impl Assembled {
             network_id: Hash(Sha256::digest(network_passphrase).into()),
             tagged_transaction: TransactionSignaturePayloadTaggedTransaction::Tx(self.txn.clone()),
         };
-        Ok(Sha256::digest(signature_payload.to_xdr(Limits::none())?).into())
+        Ok(Sha256::digest(signature_payload.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?).into())
     }
 
     /// Returns a reference to the original transaction.
@@ -263,7 +265,12 @@ fn assemble(
                     VecM::try_from(
                         r.auth
                             .iter()
-                            .map(|v| SorobanAuthorizationEntry::from_xdr_base64(v, Limits::none()))
+                            .map(|v| {
+                                SorobanAuthorizationEntry::from_xdr_base64(
+                                    v,
+                                    Limits::depth(XDR_DEPTH_LIMIT),
+                                )
+                            })
                             .collect::<Result<Vec<_>, _>>()?,
                     )
                 })
@@ -372,10 +379,16 @@ mod tests {
             min_resource_fee: 115,
             latest_ledger: 3,
             results: vec![SimulateHostFunctionResultRaw {
-                auth: vec![fn_auth.to_xdr_base64(Limits::none()).unwrap()],
-                xdr: ScVal::U32(0).to_xdr_base64(Limits::none()).unwrap(),
+                auth: vec![fn_auth
+                    .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                    .unwrap()],
+                xdr: ScVal::U32(0)
+                    .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                    .unwrap(),
             }],
-            transaction_data: transaction_data().to_xdr_base64(Limits::none()).unwrap(),
+            transaction_data: transaction_data()
+                .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                .unwrap(),
             ..Default::default()
         }
     }
@@ -534,7 +547,9 @@ mod tests {
             &txn,
             SimulateTransactionResponse {
                 min_resource_fee: 115,
-                transaction_data: transaction_data().to_xdr_base64(Limits::none()).unwrap(),
+                transaction_data: transaction_data()
+                    .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                    .unwrap(),
                 latest_ledger: 3,
                 ..Default::default()
             },
@@ -556,7 +571,9 @@ mod tests {
             &txn,
             SimulateTransactionResponse {
                 min_resource_fee: 115,
-                transaction_data: transaction_data().to_xdr_base64(Limits::none()).unwrap(),
+                transaction_data: transaction_data()
+                    .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                    .unwrap(),
                 latest_ledger: 3,
                 ..Default::default()
             },

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -19,6 +19,7 @@ use stellar_xdr::{Limited, Limits, ScMetaEntry, ScMetaV0, StringM, WriteXdr};
 
 #[cfg(feature = "additional-libs")]
 use crate::commands::contract::optimize;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{global, version},
     print::Print,
@@ -511,7 +512,7 @@ impl Cmd {
         }
 
         let mut buffer = Vec::new();
-        let mut writer = Limited::new(Cursor::new(&mut buffer), Limits::none());
+        let mut writer = Limited::new(Cursor::new(&mut buffer), Limits::depth(XDR_DEPTH_LIMIT));
         for entry in new_meta {
             entry.write_xdr(&mut writer)?;
         }
@@ -823,9 +824,12 @@ pub fn filter_and_dedup_spec(
 ) -> Result<Vec<u8>, Error> {
     let mut seen = HashSet::new();
     let mut filtered_xdr = Vec::new();
-    let mut writer = Limited::new(Cursor::new(&mut filtered_xdr), Limits::none());
+    let mut writer = Limited::new(
+        Cursor::new(&mut filtered_xdr),
+        Limits::depth(XDR_DEPTH_LIMIT),
+    );
     for entry in soroban_spec::shaking::filter(entries, markers) {
-        let entry_xdr = entry.to_xdr(Limits::none())?;
+        let entry_xdr = entry.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?;
         if seen.insert(entry_xdr) {
             entry.write_xdr(&mut writer)?;
         }

--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 
 use crate::config::address::AliasName;
+use crate::utils::XDR_DEPTH_LIMIT;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -108,7 +109,9 @@ impl Cmd {
             .await?
             .to_envelope();
         match res {
-            TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
+            TxnEnvelopeResult::TxnEnvelope(tx) => {
+                println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
+            }
             TxnEnvelopeResult::Res(contract) => {
                 let network = self.config.get_network()?;
 

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -19,6 +19,7 @@ use crate::xdr::{
 };
 
 use crate::commands::tx::fetch;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{
         contract::{self, arg_parsing, build, id::wasm::get_contract_id, upload},
@@ -256,7 +257,7 @@ impl Cmd {
 
         match res {
             TxnEnvelopeResult::TxnEnvelope(tx) => {
-                println!("{}", tx.to_xdr_base64(Limits::none())?);
+                println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
             }
             TxnEnvelopeResult::Res(contract) => {
                 let network = cmd.config.get_network()?;

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -17,6 +17,7 @@ use crate::{
 use clap::Parser;
 
 use crate::commands::tx::fetch;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{
         global,
@@ -135,7 +136,9 @@ impl Cmd {
             .await?
             .to_envelope();
         match res {
-            TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
+            TxnEnvelopeResult::TxnEnvelope(tx) => {
+                println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
+            }
             TxnEnvelopeResult::Res(ttl_ledger) => {
                 if self.ttl_ledger_only {
                     println!("{ttl_ledger}");

--- a/cmd/soroban-cli/src/commands/contract/id/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/id/wasm.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use sha2::{Digest, Sha256};
 
 use crate::config;
+use crate::utils::XDR_DEPTH_LIMIT;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -68,7 +69,7 @@ pub fn get_contract_id(
         network_id,
         contract_id_preimage,
     });
-    let preimage_xdr = preimage.to_xdr(Limits::none())?;
+    let preimage_xdr = preimage.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?;
     Ok(stellar_strkey::Contract(
         Sha256::digest(preimage_xdr).into(),
     ))

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -17,6 +17,7 @@ use crate::log::extract_events;
 use crate::print::Print;
 use crate::tx::sim_sign_and_send_tx;
 use crate::utils::deprecate_message;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     assembled::simulate_and_assemble_transaction,
     commands::{
@@ -187,7 +188,9 @@ impl Cmd {
         }
 
         match res {
-            TxnEnvelopeResult::TxnEnvelope(tx) => println!("{}", tx.to_xdr_base64(Limits::none())?),
+            TxnEnvelopeResult::TxnEnvelope(tx) => {
+                println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
+            }
             TxnEnvelopeResult::Res(output) => {
                 println!("{output}");
             }

--- a/cmd/soroban-cli/src/commands/contract/read.rs
+++ b/cmd/soroban-cli/src/commands/contract/read.rs
@@ -9,6 +9,7 @@ use crate::xdr::{
 };
 use clap::{Parser, ValueEnum};
 
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     config::{self, locator},
     key,
@@ -167,12 +168,12 @@ impl Cmd {
                         })?,
                 ],
                 Output::Xdr => [
-                    key.to_xdr_base64(Limits::none())?,
-                    val.to_xdr_base64(Limits::none())?,
-                    last_modified_ledger.to_xdr_base64(Limits::none())?,
+                    key.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?,
+                    val.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?,
+                    last_modified_ledger.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?,
                     live_until_ledger_seq
                         .unwrap_or_default()
-                        .to_xdr_base64(Limits::none())?,
+                        .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?,
                 ],
             };
             out.write_record(output)

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use stellar_strkey::DecodeError;
 
 use crate::commands::tx::fetch;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{
         contract::extend,
@@ -132,7 +133,7 @@ impl Cmd {
             .to_envelope();
         let expiration_ledger_seq = match res {
             TxnEnvelopeResult::TxnEnvelope(tx) => {
-                println!("{}", tx.to_xdr_base64(Limits::none())?);
+                println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
                 return Ok(());
             }
             TxnEnvelopeResult::Res(res) => res,

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -26,7 +26,8 @@ use crate::{
         builder::{self, TxExt},
         sim_sign_and_send_tx,
     },
-    utils, wasm,
+    utils::{self, XDR_DEPTH_LIMIT},
+    wasm,
 };
 
 const CONTRACT_META_SDK_KEY: &str = "rssdkver";
@@ -159,7 +160,7 @@ impl Cmd {
 
             match res {
                 TxnEnvelopeResult::TxnEnvelope(tx) => {
-                    println!("{}", tx.to_xdr_base64(Limits::none())?);
+                    println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
                 }
                 TxnEnvelopeResult::Res(hash) => println!("{}", hex::encode(hash)),
             }
@@ -279,8 +280,10 @@ impl Cmd {
             // go ahead if the contract has a V0 extension.
             if let Some(entries) = contract_data.entries {
                 if let Some(entry_result) = entries.first() {
-                    let entry: LedgerEntryData =
-                        LedgerEntryData::from_xdr_base64(&entry_result.xdr, Limits::none())?;
+                    let entry: LedgerEntryData = LedgerEntryData::from_xdr_base64(
+                        &entry_result.xdr,
+                        Limits::depth(XDR_DEPTH_LIMIT),
+                    )?;
 
                     match &entry {
                         LedgerEntryData::ContractCode(code) => {

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -10,6 +10,7 @@ use crate::{
     config::{self, locator, network},
     get_spec::get_remote_contract_spec,
     rpc,
+    utils::XDR_DEPTH_LIMIT,
 };
 
 #[derive(Parser, Debug, Clone)]
@@ -331,7 +332,7 @@ impl Cmd {
         let topics: Vec<ScVal> = event
             .topic
             .iter()
-            .filter_map(|t| ScVal::from_xdr_base64(t, Limits::none()).ok())
+            .filter_map(|t| ScVal::from_xdr_base64(t, Limits::depth(XDR_DEPTH_LIMIT)).ok())
             .collect();
 
         if topics.len() != event.topic.len() {
@@ -339,7 +340,7 @@ impl Cmd {
         }
 
         // Decode value from base64 XDR
-        let data = ScVal::from_xdr_base64(&event.value, Limits::none()).ok()?;
+        let data = ScVal::from_xdr_base64(&event.value, Limits::depth(XDR_DEPTH_LIMIT)).ok()?;
 
         spec.decode_event(&event.contract_id, &topics, &data)
             .inspect_err(|e| tracing::debug!("Failed to decode event {}: {e}", event.id))
@@ -488,7 +489,7 @@ impl Cmd {
                 if segment == "*" || segment == "**" {
                     topic_filter.push(segment.to_owned());
                 } else {
-                    match xdr::ScVal::from_xdr_base64(segment, Limits::none()) {
+                    match xdr::ScVal::from_xdr_base64(segment, Limits::depth(XDR_DEPTH_LIMIT)) {
                         Ok(_s) => {
                             topic_filter.push(segment.to_owned());
                         }

--- a/cmd/soroban-cli/src/commands/ledger/entry/fetch/contract_data.rs
+++ b/cmd/soroban-cli/src/commands/ledger/entry/fetch/contract_data.rs
@@ -2,6 +2,7 @@ use super::args::Args;
 use crate::{
     commands::contract::Durability,
     config::{self, locator},
+    utils::XDR_DEPTH_LIMIT,
     xdr::{
         self, ContractDataDurability, ContractId, Hash, LedgerKey, LedgerKeyContractData, Limits,
         ReadXdr, ScAddress, ScVal,
@@ -90,7 +91,7 @@ impl Cmd {
             for key in keys {
                 let key = LedgerKey::ContractData(LedgerKeyContractData {
                     contract: contract_address_arg.clone(),
-                    key: ScVal::from_xdr_base64(key, Limits::none())?,
+                    key: ScVal::from_xdr_base64(key, Limits::depth(XDR_DEPTH_LIMIT))?,
                     durability: ContractDataDurability::Persistent,
                 });
 

--- a/cmd/soroban-cli/src/commands/network/settings.rs
+++ b/cmd/soroban-cli/src/commands/network/settings.rs
@@ -1,5 +1,6 @@
 use crate::config::network;
 use crate::output::{Format, Output};
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{commands::global, config};
 use semver::Version;
 use stellar_xdr::{
@@ -110,7 +111,10 @@ impl Cmd {
         };
         match self.output {
             // Xdr is a distinct raw rendering, handled outside the JSON path.
-            OutputFormat::Xdr => println!("{}", config_upgrade_set.to_xdr_base64(Limits::none())?),
+            OutputFormat::Xdr => println!(
+                "{}",
+                config_upgrade_set.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?
+            ),
             OutputFormat::Json | OutputFormat::JsonFormatted => {
                 output.json_value(&config_upgrade_set)?;
             }

--- a/cmd/soroban-cli/src/commands/snapshot/create.rs
+++ b/cmd/soroban-cli/src/commands/snapshot/create.rs
@@ -24,6 +24,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
 use tokio_util::io::StreamReader;
 use url::Url;
 
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{config::data, global, HEADING_ARCHIVE},
     config::{self, locator, network::passphrase},
@@ -316,7 +317,7 @@ impl Cmd {
                 // Stream the bucket entries from the bucket, identifying
                 // entries that match the filters, and including only the
                 // entries that match in the snapshot.
-                let limited = &mut Limited::new(file, Limits::none());
+                let limited = &mut Limited::new(file, Limits::depth(XDR_DEPTH_LIMIT));
                 let entries = Frame::<BucketEntry>::read_xdr_iter(limited);
                 let mut count_saved = 0;
                 for entry in entries {
@@ -667,7 +668,7 @@ async fn get_ledger_metadata_from_archive(
 
     // Now read the cached file
     let file = std::fs::File::open(&cache_path).map_err(Error::ReadOpeningCachedBucket)?;
-    let limited = &mut Limited::new(file, Limits::none());
+    let limited = &mut Limited::new(file, Limits::depth(XDR_DEPTH_LIMIT));
 
     // Find the specific ledger header entry we need
     let entries = Frame::<LedgerHeaderHistoryEntry>::read_xdr_iter(limited);

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -1,3 +1,4 @@
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{global, txn_result::TxnEnvelopeResult, HEADING_TRANSACTION},
     config::{
@@ -94,7 +95,7 @@ impl Args {
     ) -> Result<(), Error> {
         let res = self.handle(op, global_args).await?;
         if let TxnEnvelopeResult::TxnEnvelope(tx) = res {
-            println!("{}", tx.to_xdr_base64(Limits::none())?);
+            println!("{}", tx.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?);
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/tx/edit.rs
+++ b/cmd/soroban-cli/src/commands/tx/edit.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 
 use serde_json::json;
 
-use crate::{commands::global, print::Print};
+use crate::{commands::global, print::Print, utils::XDR_DEPTH_LIMIT};
 
 fn schema_url() -> String {
     let ver = stellar_xdr::VERSION.pkg;
@@ -150,7 +150,7 @@ fn xdr_to_json<T>(xdr_string: &str) -> Result<String, Error>
 where
     T: stellar_xdr::ReadXdr + serde::Serialize,
 {
-    let tx = T::from_xdr_base64(xdr_string, stellar_xdr::Limits::none())?;
+    let tx = T::from_xdr_base64(xdr_string, stellar_xdr::Limits::depth(XDR_DEPTH_LIMIT))?;
     let mut schema: serde_json::Value = serde_json::to_value(tx)?;
     schema["$schema"] = json!(schema_url());
     let json = serde_json::to_string_pretty(&schema)?;
@@ -173,10 +173,10 @@ where
     let value: T = serde_json::from_str(json_string.as_str())?;
     let mut data = Vec::new();
     let cursor = Cursor::new(&mut data);
-    let mut limit = stellar_xdr::Limited::new(cursor, stellar_xdr::Limits::none());
+    let mut limit = stellar_xdr::Limited::new(cursor, stellar_xdr::Limits::depth(XDR_DEPTH_LIMIT));
     value.write_xdr(&mut limit)?;
 
-    Ok(value.to_xdr_base64(stellar_xdr::Limits::none())?)
+    Ok(value.to_xdr_base64(stellar_xdr::Limits::depth(XDR_DEPTH_LIMIT))?)
 }
 
 fn default_json() -> String {

--- a/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/envelope.rs
@@ -5,6 +5,7 @@ use crate::{
 use clap::Parser;
 
 use super::args;
+use crate::utils::XDR_DEPTH_LIMIT;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -36,7 +37,9 @@ impl Cmd {
                     println!("{}", serde_json::to_string(&envelope)?);
                 }
                 args::OutputFormat::Xdr => {
-                    let envelope_xdr = envelope.to_xdr_base64(Limits::none()).unwrap();
+                    let envelope_xdr = envelope
+                        .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                        .unwrap();
                     println!("{envelope_xdr}");
                 }
                 args::OutputFormat::JsonFormatted => {

--- a/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/meta.rs
@@ -5,6 +5,7 @@ use crate::{
 use clap::Parser;
 
 use super::args;
+use crate::utils::XDR_DEPTH_LIMIT;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -36,7 +37,7 @@ impl Cmd {
                     println!("{}", serde_json::to_string(&meta)?);
                 }
                 args::OutputFormat::Xdr => {
-                    let meta_xdr = meta.to_xdr_base64(Limits::none()).unwrap();
+                    let meta_xdr = meta.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT)).unwrap();
                     println!("{meta_xdr}");
                 }
                 args::OutputFormat::JsonFormatted => {

--- a/cmd/soroban-cli/src/commands/tx/fetch/result.rs
+++ b/cmd/soroban-cli/src/commands/tx/fetch/result.rs
@@ -1,4 +1,5 @@
 use super::args;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::global,
     xdr::{self, Limits, WriteXdr},
@@ -35,7 +36,9 @@ impl Cmd {
                     println!("{}", serde_json::to_string(&result)?);
                 }
                 args::OutputFormat::Xdr => {
-                    let result_xdr = result.to_xdr_base64(Limits::none()).unwrap();
+                    let result_xdr = result
+                        .to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))
+                        .unwrap();
                     println!("{result_xdr}");
                 }
                 args::OutputFormat::JsonFormatted => {

--- a/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
+++ b/cmd/soroban-cli/src/commands/tx/op/add/mod.rs
@@ -1,4 +1,5 @@
 use super::super::{global, help, xdr::tx_envelope_from_input};
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::xdr::{OperationBody, WriteXdr};
 
 pub(crate) use super::super::new;
@@ -249,7 +250,10 @@ impl Cmd {
                 cmd.args.source(),
             ),
         }?;
-        println!("{}", res.to_xdr_base64(crate::xdr::Limits::none())?);
+        println!(
+            "{}",
+            res.to_xdr_base64(crate::xdr::Limits::depth(XDR_DEPTH_LIMIT))?
+        );
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/sign.rs
+++ b/cmd/soroban-cli/src/commands/tx/sign.rs
@@ -1,3 +1,4 @@
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::global,
     config::{locator, network, sign_with},
@@ -47,7 +48,10 @@ impl Cmd {
                 None,
             )
             .await?;
-        println!("{}", tx_env_signed.to_xdr_base64(Limits::none())?);
+        println!(
+            "{}",
+            tx_env_signed.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?
+        );
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/tx/simulate.rs
+++ b/cmd/soroban-cli/src/commands/tx/simulate.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::ffi::OsString;
 
 use crate::commands::{config, global};
+use crate::utils::XDR_DEPTH_LIMIT;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -45,7 +46,10 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let res = self.execute(global_args, &self.config).await?;
         let tx_env: TransactionEnvelope = res.transaction().clone().into();
-        println!("{}", tx_env.to_xdr_base64(xdr::Limits::none())?);
+        println!(
+            "{}",
+            tx_env.to_xdr_base64(xdr::Limits::depth(XDR_DEPTH_LIMIT))?
+        );
         Ok(())
     }
 

--- a/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
+++ b/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
@@ -1,5 +1,6 @@
 use stellar_xdr::MuxedAccount;
 
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     commands::{
         global,
@@ -37,7 +38,7 @@ impl Cmd {
     pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
         let mut tx = tx_envelope_from_input(&None)?;
         self.update_tx_env(&mut tx, global_args).await?;
-        println!("{}", tx.to_xdr_base64(xdr::Limits::none())?);
+        println!("{}", tx.to_xdr_base64(xdr::Limits::depth(XDR_DEPTH_LIMIT))?);
         Ok(())
     }
 

--- a/cmd/soroban-cli/src/commands/tx/xdr.rs
+++ b/cmd/soroban-cli/src/commands/tx/xdr.rs
@@ -1,3 +1,4 @@
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::xdr::{
     Limits, Operation, ReadXdr, Transaction, TransactionEnvelope, TransactionV1Envelope,
 };
@@ -37,7 +38,7 @@ pub fn tx_envelope_from_input(input: &Option<OsString>) -> Result<TransactionEnv
         &mut stdin()
     };
 
-    let mut lim = Limited::new(SkipWhitespace::new(read), Limits::none());
+    let mut lim = Limited::new(SkipWhitespace::new(read), Limits::depth(XDR_DEPTH_LIMIT));
     Ok(TransactionEnvelope::read_xdr_base64_to_end(&mut lim)?)
 }
 

--- a/cmd/soroban-cli/src/config/data.rs
+++ b/cmd/soroban-cli/src/config/data.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use url::Url;
 
 use crate::utils::url::redact_url;
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::xdr::{self, WriteXdr};
 
 #[derive(thiserror::Error, Debug)]
@@ -80,7 +81,7 @@ pub fn write_spec(hash: &str, spec_entries: &[xdr::ScSpecEntry]) -> Result<(), E
     tracing::trace!("writing spec to {:?}", file);
     let mut contents: Vec<u8> = Vec::new();
     for entry in spec_entries {
-        contents.extend(entry.to_xdr(xdr::Limits::none())?);
+        contents.extend(entry.to_xdr(xdr::Limits::depth(XDR_DEPTH_LIMIT))?);
     }
     crate::config::locator::write_hardened_file(&file, &contents)?;
     Ok(())
@@ -202,7 +203,7 @@ impl TryFrom<GetTransactionResponse> for Action {
 }
 
 fn to_xdr(data: &impl WriteXdr) -> Result<String, xdr::Error> {
-    data.to_xdr_base64(xdr::Limits::none())
+    data.to_xdr_base64(xdr::Limits::depth(XDR_DEPTH_LIMIT))
 }
 
 #[cfg(test)]

--- a/cmd/soroban-cli/src/key.rs
+++ b/cmd/soroban-cli/src/key.rs
@@ -5,6 +5,7 @@ use crate::xdr::{
 use crate::{
     commands::contract::Durability,
     config::{alias, locator, network::Network},
+    utils::XDR_DEPTH_LIMIT,
     wasm,
 };
 use std::path::PathBuf;
@@ -82,7 +83,7 @@ impl Args {
                 .collect::<Result<Vec<_>, Error>>()?
         } else if let Some(keys) = &self.key_xdr {
             keys.iter()
-                .map(|s| Ok(ScVal::from_xdr_base64(s, Limits::none())?))
+                .map(|s| Ok(ScVal::from_xdr_base64(s, Limits::depth(XDR_DEPTH_LIMIT))?))
                 .collect::<Result<Vec<_>, Error>>()?
         } else if let Some(wasm) = &self.wasm {
             return Ok(vec![crate::wasm::Args { wasm: wasm.clone() }.try_into()?]);

--- a/cmd/soroban-cli/src/log/event.rs
+++ b/cmd/soroban-cli/src/log/event.rs
@@ -2,6 +2,7 @@ use soroban_spec_tools::event::DecodedEvent;
 use soroban_spec_tools::{sanitize, Spec};
 use tracing::debug;
 
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{print::Print, xdr};
 use xdr::{
     ContractEvent, ContractEventBody, ContractEventType, ContractEventV0, DiagnosticEvent, WriteXdr,
@@ -39,7 +40,9 @@ fn format_decoded_event(decoded: &DecodedEvent, status: &str) -> String {
 pub fn all(events: &[DiagnosticEvent]) {
     for (index, event) in events.iter().enumerate() {
         let json = serde_json::to_string(event).unwrap();
-        let xdr = event.to_xdr_base64(xdr::Limits::none()).unwrap();
+        let xdr = event
+            .to_xdr_base64(xdr::Limits::depth(XDR_DEPTH_LIMIT))
+            .unwrap();
         print_event(&xdr, &json, index);
     }
 }

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 use ed25519_dalek::{ed25519::signature::Signer as _, Signature as Ed25519Signature};
 use sha2::{Digest, Sha256};
 
+use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{config::network::Network, print::Print, utils::transaction_hash};
 use std::io::{self, BufRead, IsTerminal};
 
@@ -283,7 +284,7 @@ async fn sign_soroban_authorization_entry(
             signature_expiration_ledger,
         })
     }
-    .to_xdr(Limits::none())?;
+    .to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?;
 
     let payload = Sha256::digest(preimage);
     let p: [u8; 32] = payload.as_slice().try_into()?;
@@ -440,7 +441,7 @@ impl Lab {
         network: &Network,
         printer: &Print,
     ) -> Result<DecoratedSignature, Error> {
-        let xdr = tx_env.to_xdr_base64(Limits::none())?;
+        let xdr = tx_env.to_xdr_base64(Limits::depth(XDR_DEPTH_LIMIT))?;
 
         let mut url = url::Url::parse(Self::URL)?;
         url.query_pairs_mut()
@@ -858,7 +859,7 @@ mod tests {
                 invocation: body.auth[0].root_invocation.clone(),
             },
         )
-        .to_xdr(Limits::none())
+        .to_xdr(Limits::depth(XDR_DEPTH_LIMIT))
         .unwrap();
         let payload: [u8; 32] = Sha256::digest(preimage).into();
 

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -15,6 +15,11 @@ pub use soroban_spec_tools::contract as contract_spec;
 
 use crate::config::network::Network;
 
+/// Depth limit when encoding and decoding XDR.
+///
+/// 500 matches `soroban-env-host`'s `DEFAULT_XDR_RW_LIMITS`.
+pub(crate) const XDR_DEPTH_LIMIT: u32 = 500;
+
 /// # Errors
 ///
 /// Might return an error
@@ -52,7 +57,7 @@ pub fn transaction_hash(
         network_id: Hash(Sha256::digest(network_passphrase).into()),
         tagged_transaction: TransactionSignaturePayloadTaggedTransaction::Tx(tx.clone()),
     };
-    Ok(Sha256::digest(signature_payload.to_xdr(Limits::none())?).into())
+    Ok(Sha256::digest(signature_payload.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?).into())
 }
 
 /// # Errors
@@ -68,7 +73,7 @@ pub fn fee_bump_transaction_hash(
             fee_bump_tx.clone(),
         ),
     };
-    Ok(Sha256::digest(signature_payload.to_xdr(Limits::none())?).into())
+    Ok(Sha256::digest(signature_payload.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?).into())
 }
 
 static EXPLORERS: phf::Map<&'static str, &'static str> = phf_map! {
@@ -197,7 +202,7 @@ pub fn contract_id_hash_from_asset(
         contract_id_preimage: ContractIdPreimage::Asset(asset.clone()),
     });
     let preimage_xdr = preimage
-        .to_xdr(Limits::none())
+        .to_xdr(Limits::depth(XDR_DEPTH_LIMIT))
         .expect("HashIdPreimage should not fail encoding to xdr");
     stellar_strkey::Contract(Sha256::digest(preimage_xdr).into())
 }
@@ -359,6 +364,7 @@ pub mod args {
 }
 
 pub mod rpc {
+    use super::XDR_DEPTH_LIMIT;
     use crate::xdr;
     use soroban_rpc::{Client, Error};
     use stellar_xdr::{Hash, LedgerEntryData, LedgerKey, Limits, ReadXdr};
@@ -374,8 +380,10 @@ pub mod rpc {
             ));
         }
         let contract_data_entry = &entries[0];
-        let code = match LedgerEntryData::from_xdr_base64(&contract_data_entry.xdr, Limits::none())?
-        {
+        let code = match LedgerEntryData::from_xdr_base64(
+            &contract_data_entry.xdr,
+            Limits::depth(XDR_DEPTH_LIMIT),
+        )? {
             LedgerEntryData::ContractCode(xdr::ContractCodeEntry { code, .. }) => Vec::from(code),
             scval => return Err(Error::UnexpectedContractCodeDataType(scval)),
         };


### PR DESCRIPTION
### What

Adds a depth limit to all XDR encoding and decoding sites.

### Why

This also prevents stack overflow crashes if intentionally deep XDR structs are encountered.

### Known limitations

None
