### PR TITLE
Error instead of panicking when source account sequence number is at i64::MAX

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/asset.rs
@@ -29,6 +29,8 @@ use crate::utils::XDR_DEPTH_LIMIT;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
     #[error("error parsing int: {0}")]
     ParseIntError(#[from] ParseIntError),
 
@@ -176,7 +178,7 @@ impl Cmd {
         let tx = build_wrap_token_tx(
             asset,
             &contract_id,
-            sequence + 1,
+            crate::utils::next_sequence_number(sequence)?,
             config.get_inclusion_fee()?,
             network_passphrase,
             source_account,

--- a/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy/wasm.rs
@@ -85,6 +85,8 @@ pub struct Cmd {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
+    #[error(transparent)]
     Install(#[from] upload::Error),
 
     #[error("error parsing int: {0}")]
@@ -432,7 +434,7 @@ impl Cmd {
         let sequence: i64 = account_details.seq_num.into();
         let txn = Box::new(build_create_contract_tx(
             wasm_hash,
-            sequence + 1,
+            crate::utils::next_sequence_number(sequence)?,
             config.get_inclusion_fee()?,
             source_account,
             contract_id_preimage,

--- a/cmd/soroban-cli/src/commands/contract/extend.rs
+++ b/cmd/soroban-cli/src/commands/contract/extend.rs
@@ -70,6 +70,8 @@ impl Pwd for Cmd {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
     #[error("parsing key {key}: {error}")]
     CannotParseKey {
         key: String,
@@ -215,7 +217,7 @@ impl Cmd {
         let tx = Box::new(Transaction {
             source_account,
             fee: config.get_inclusion_fee()?,
-            seq_num: SequenceNumber(sequence + 1),
+            seq_num: SequenceNumber(crate::utils::next_sequence_number(sequence)?),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![Operation {

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -96,6 +96,8 @@ impl Pwd for Cmd {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
     #[error("cannot add contract to ledger entries: {0}")]
     CannotAddContractToLedgerEntries(xdr::Error),
 
@@ -248,8 +250,12 @@ impl Cmd {
         let AccountId(PublicKey::PublicKeyTypeEd25519(account_id)) =
             account_details.account_id.clone();
 
-        let tx =
-            build_invoke_contract_tx(host_function_params.clone(), sequence + 1, 100, account_id)?;
+        let tx = build_invoke_contract_tx(
+            host_function_params.clone(),
+            crate::utils::next_sequence_number(sequence)?,
+            100,
+            account_id,
+        )?;
         Ok(simulate_and_assemble_transaction(
             rpc_client,
             &tx,
@@ -385,7 +391,7 @@ impl Cmd {
 
         let tx = Box::new(build_invoke_contract_tx(
             host_function_params.clone(),
-            sequence + 1,
+            crate::utils::next_sequence_number(sequence)?,
             config.get_inclusion_fee()?,
             account_id,
         )?);

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -69,6 +69,8 @@ impl Pwd for Cmd {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
     #[error("parsing key {key}: {error}")]
     CannotParseKey {
         key: String,
@@ -181,7 +183,7 @@ impl Cmd {
         let tx = Box::new(Transaction {
             source_account,
             fee: config.get_inclusion_fee()?,
-            seq_num: SequenceNumber(sequence + 1),
+            seq_num: SequenceNumber(crate::utils::next_sequence_number(sequence)?),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![Operation {

--- a/cmd/soroban-cli/src/commands/contract/upload.rs
+++ b/cmd/soroban-cli/src/commands/contract/upload.rs
@@ -67,6 +67,8 @@ pub struct Cmd {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
     #[error("error parsing int: {0}")]
     ParseIntError(#[from] ParseIntError),
 
@@ -258,7 +260,7 @@ impl Cmd {
 
         let (tx_without_preflight, hash) = build_install_contract_code_tx(
             &contract,
-            sequence + 1,
+            crate::utils::next_sequence_number(sequence)?,
             config.get_inclusion_fee()?,
             &source_account,
         )?;

--- a/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
+++ b/cmd/soroban-cli/src/commands/tx/update/sequence_number/next.rs
@@ -32,6 +32,8 @@ pub enum Error {
     Config(#[from] config::Error),
     #[error(transparent)]
     Network(#[from] config::network::Error),
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
 }
 
 impl Cmd {
@@ -51,7 +53,7 @@ impl Cmd {
             TransactionEnvelope::Tx(transaction_v1_envelope) => {
                 let tx_source_acct = &transaction_v1_envelope.tx.source_account;
                 let current_seq_num = self.current_seq_num(tx_source_acct).await?;
-                let next_seq_num = current_seq_num + 1;
+                let next_seq_num = crate::utils::next_sequence_number(current_seq_num)?;
                 transaction_v1_envelope.tx.seq_num = SequenceNumber(next_seq_num);
             }
             TransactionEnvelope::TxV0(_) | TransactionEnvelope::TxFeeBump(_) => {

--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -50,6 +50,8 @@ pub enum Error {
     StellarStrkey(#[from] stellar_strkey::DecodeError),
     #[error(transparent)]
     Address(#[from] address::Error),
+    #[error(transparent)]
+    SequenceNumberOverflow(#[from] crate::utils::SequenceNumberOverflow),
 }
 
 #[derive(Debug, clap::Args, Clone, Default)]
@@ -194,13 +196,12 @@ impl Args {
     ) -> Result<SequenceNumber, Error> {
         let network = self.get_network()?;
         let client = network.rpc_client()?;
-        Ok((client
+        let seq_num = client
             .get_account(&account.into().to_string())
             .await?
             .seq_num
-            .0
-            + 1)
-        .into())
+            .0;
+        Ok(crate::utils::next_sequence_number(seq_num)?.into())
     }
 
     pub fn hd_path(&self) -> Option<u32> {

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -20,6 +20,26 @@ use crate::config::network::Network;
 /// 500 matches `soroban-env-host`'s `DEFAULT_XDR_RW_LIMITS`.
 pub(crate) const XDR_DEPTH_LIMIT: u32 = 500;
 
+/// A transaction's sequence number must be exactly one greater than the source
+/// account's current sequence number, which any account can raise to
+/// `i64::MAX` with a single `bump_sequence` operation. Incrementing past that
+/// point must surface as an error instead of an integer-overflow panic.
+#[derive(thiserror::Error, Debug)]
+#[error("account sequence number is at the maximum value ({0}); no further transactions can be submitted from this account")]
+pub struct SequenceNumberOverflow(pub i64);
+
+/// Returns the sequence number for the next transaction of an account
+/// currently at `current`, erroring if the account is at `i64::MAX`.
+///
+/// # Errors
+///
+/// Returns [`SequenceNumberOverflow`] when `current` is `i64::MAX`.
+pub fn next_sequence_number(current: i64) -> Result<i64, SequenceNumberOverflow> {
+    current
+        .checked_add(1)
+        .ok_or(SequenceNumberOverflow(current))
+}
+
 /// # Errors
 ///
 /// Might return an error
@@ -461,6 +481,20 @@ fn verify_wasm_hash(code: &[u8], expected_hash: &Hash) -> Result<(), soroban_rpc
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_next_sequence_number() {
+        assert_eq!(next_sequence_number(0).unwrap(), 1);
+        assert_eq!(next_sequence_number(41).unwrap(), 42);
+        assert_eq!(next_sequence_number(i64::MAX - 1).unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn test_next_sequence_number_at_max_errors_instead_of_overflowing() {
+        // Regression test for https://github.com/stellar/stellar-cli/issues/2417
+        let err = next_sequence_number(i64::MAX).unwrap_err();
+        assert_eq!(err.0, i64::MAX);
+    }
 
     #[test]
     fn test_contract_id_from_str() {

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -34,7 +34,7 @@ pub struct SequenceNumberOverflow(pub i64);
 /// # Errors
 ///
 /// Returns [`SequenceNumberOverflow`] when `current` is `i64::MAX`.
-pub fn next_sequence_number(current: i64) -> Result<i64, SequenceNumberOverflow> {
+pub(crate) fn next_sequence_number(current: i64) -> Result<i64, SequenceNumberOverflow> {
     current
         .checked_add(1)
         .ok_or(SequenceNumberOverflow(current))


### PR DESCRIPTION
Fixes #2417.

Any account can reach `i64::MAX` sequence with a single `bump_sequence` operation. After that, every command that builds a transaction for the account computed `sequence + 1`, which panics with `attempt to add with overflow` on debug builds and wraps to `i64::MIN` on release builds.

The issue reports the `tx new` path (`config::Args::next_sequence_number`), but the same unchecked increment exists at 8 more sites.

### Fix

Add `utils::next_sequence_number` (checked add with a descriptive error):

```
account sequence number is at the maximum value (9223372036854775807); no further transactions can be submitted from this account
```

and use it at every site that increments an account sequence number:

- `config::Args::next_sequence_number` (the issue's repro path)
- `contract invoke` (simulation and final tx build)
- `contract upload`
- `contract extend`
- `contract restore`
- `contract deploy` (wasm and asset)
- `tx update sequence-number next`

Not changed: `Assembled::bump_seq_num` — it has no in-repo callers and changing it would break its public `-> Self` signature; it can be handled separately if desired.

### Tests

- `test_next_sequence_number` — ordinary increments, including `i64::MAX - 1 → i64::MAX`.
- `test_next_sequence_number_at_max_errors_instead_of_overflowing` — `i64::MAX` yields the error instead of overflowing.
