### PR TITLE
test: cover Bool returned as SC_SPEC_TYPE_VAL (#2438)

### DIFF
--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -2511,6 +2511,23 @@ mod tests {
     }
 
     #[test]
+    fn test_xdr_to_json_bool_with_val_type() {
+        // Regression test for https://github.com/stellar/stellar-cli/issues/2438
+        // A contract fn returning `Val` (SC_SPEC_TYPE_VAL) whose runtime value is
+        // ScVal::Bool must render instead of panicking with "doesn't have a
+        // matching Val". Both booleans hit the same match arm; false is not special.
+        let spec = Spec(None);
+        assert_eq!(
+            spec.xdr_to_json(&ScVal::Bool(false), &ScType::Val).unwrap(),
+            Value::Bool(false)
+        );
+        assert_eq!(
+            spec.xdr_to_json(&ScVal::Bool(true), &ScType::Val).unwrap(),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
     fn test_xdr_to_json_map_with_val_type() {
         // ScVal::Map with ScType::Val should delegate to to_json, not sc_object_to_json.
         let spec = Spec(None);


### PR DESCRIPTION
### What
Adds a regression test locking the behavior reported in #2438: a contract function returning `Val` (`SC_SPEC_TYPE_VAL`) whose runtime value is `ScVal::Bool(false)` (or `true`) must render via `xdr_to_json` instead of panicking with "doesn't have a matching Val".

### Why this is test-only
The defect itself is **already fixed on `main`** by the generic-`Val` arm added in #2469 (`(val, ScType::Val) => to_json(val)`), which handles every `ScVal` variant. Existing regression coverage for that arm exercises `Bytes`, `Map` and `Vec` — but **not `Bool`**. This adds that missing case so a future refactor of the match can't silently reintroduce the panic.

Note: the `false` value in the original report is incidental — both `Bool(true)` and `Bool(false)` hit the same arm; the match discriminates on the variant, not the payload. #2438 can be closed as resolved by #2469 once this coverage lands.

### Tests
`cargo test -p soroban-spec-tools` and `cargo clippy -p soroban-spec-tools --all-targets` are green.