### PR TITLE
Drop interop-breaking SDK wildcard re-export from generated TS clients

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_constructor/src/index.ts
@@ -21,7 +21,6 @@ import type {
   Timepoint,
   Duration,
 } from "@stellar/stellar-sdk/contract";
-export * from "@stellar/stellar-sdk";
 export * as contract from "@stellar/stellar-sdk/contract";
 export * as rpc from "@stellar/stellar-sdk/rpc";
 

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/index.ts
@@ -21,7 +21,6 @@ import type {
   Timepoint,
   Duration,
 } from "@stellar/stellar-sdk/contract";
-export * from "@stellar/stellar-sdk";
 export * as contract from "@stellar/stellar-sdk/contract";
 export * as rpc from "@stellar/stellar-sdk/rpc";
 

--- a/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
+++ b/cmd/crates/soroban-spec-typescript/src/boilerplate.rs
@@ -280,6 +280,29 @@ mod test {
     }
 
     #[test]
+    fn test_index_ts_has_no_interop_breaking_wildcard_reexport() {
+        // Regression for #2352: `export * from "@stellar/stellar-sdk"` re-exports
+        // a CommonJS module by star-flattening, which Rollup/Vite cannot interop,
+        // emitting "Unable to interop `export *` ... this may lose module exports".
+        // The namespace re-exports (contract/rpc) do not hit this and must stay.
+        let temp_dir = TempDir::new().unwrap();
+        let _project = init(temp_dir.path()).unwrap();
+        let index_ts = fs::read_to_string(temp_dir.path().join("src/index.ts")).unwrap();
+        assert!(
+            !index_ts.contains(r#"export * from "@stellar/stellar-sdk""#),
+            "generated index.ts still contains the interop-breaking wildcard re-export"
+        );
+        assert!(
+            index_ts.contains(r#"export * as contract from "@stellar/stellar-sdk/contract""#),
+            "namespace `contract` re-export should be preserved"
+        );
+        assert!(
+            index_ts.contains(r#"export * as rpc from "@stellar/stellar-sdk/rpc""#),
+            "namespace `rpc` re-export should be preserved"
+        );
+    }
+
+    #[test]
     fn test_init_rejects_invalid_contract_name() {
         let temp_dir = TempDir::new().unwrap();
         let p: Project = temp_dir.path().to_path_buf().try_into().unwrap();

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/index.ts
@@ -21,7 +21,6 @@ import type {
   Timepoint,
   Duration,
 } from "@stellar/stellar-sdk/contract";
-export * from "@stellar/stellar-sdk";
 export * as contract from "@stellar/stellar-sdk/contract";
 export * as rpc from "@stellar/stellar-sdk/rpc";
 


### PR DESCRIPTION
Fixes #2352

## What

Removes `export * from "@stellar/stellar-sdk"` from the generated TypeScript client's `src/index.ts` template, keeping the namespace re-exports (`export * as contract`, `export * as rpc`).

## Why

The SDK's root entrypoint is CommonJS. A flat `export *` over a CJS module cannot be statically resolved by Rollup/Vite, which emits `Unable to interop \`export *\` in ... this may lose module exports` and silently drops exports in consumer bundles. The namespace re-exports do not hit this path and are preserved.

## How

- Removed the flat wildcard re-export from `project_template/src/index.ts`
- Regenerated the two affected fixtures (`test_constructor`, `test_custom_types`)
- Added a regression test (`test_index_ts_has_no_interop_breaking_wildcard_reexport`) that runs `init` into a temp dir and asserts the generated `index.ts` no longer contains the flat re-export while keeping the namespace ones

## Testing

- New regression test fails on `main` (verified by re-adding the line) and passes with this change
- `cargo test -p soroban-spec-typescript`: 26 passed
- `cargo clippy -p soroban-spec-typescript --all-targets`: clean