### PR TITLE
fix: structured error instead of panic on non-authorizer auth entry addresses

### DIFF
--- a/cmd/soroban-cli/src/config/address.rs
+++ b/cmd/soroban-cli/src/config/address.rs
@@ -85,8 +85,9 @@ impl UnresolvedMuxedAccount {
             // A literal public key has no secret on its own, but a stored
             // identity may hold the matching key. Scan identities by public key
             // so `G...` signs like its alias would; fall back to `CannotSign`
-            // when nothing matches. Muxed accounts (`M...`) aren't signable
-            // end-to-end yet (see the `todo!` in `sign_soroban_authorizations`),
+            // when nothing matches. Muxed accounts (`M...`) carry no secret of
+            // their own and are not valid authorizers (see
+            // `Error::UnsupportedAuthAddress` in `sign_soroban_authorizations`),
             // so they keep returning `CannotSign`.
             UnresolvedMuxedAccount::Resolved(muxed_account) => {
                 let xdr::MuxedAccount::Ed25519(xdr::Uint256(key)) = muxed_account else {

--- a/cmd/soroban-cli/src/config/address.rs
+++ b/cmd/soroban-cli/src/config/address.rs
@@ -85,10 +85,12 @@ impl UnresolvedMuxedAccount {
             // A literal public key has no secret on its own, but a stored
             // identity may hold the matching key. Scan identities by public key
             // so `G...` signs like its alias would; fall back to `CannotSign`
-            // when nothing matches. Muxed accounts (`M...`) carry no secret of
-            // their own and are not valid authorizers (see
-            // `Error::UnsupportedAuthAddress` in `sign_soroban_authorizations`),
-            // so they keep returning `CannotSign`.
+            // when nothing matches. Muxed accounts (`M...`) keep returning
+            // `CannotSign` because the CLI does not support signing via a
+            // muxed address end-to-end yet, so we deliberately do not unwrap
+            // the underlying ed25519 key here. (Soroban auth entries reject
+            // muxed authorizers under a separate rule — see
+            // `Error::UnsupportedAuthAddress` in `sign_soroban_authorizations`.)
             UnresolvedMuxedAccount::Resolved(muxed_account) => {
                 let xdr::MuxedAccount::Ed25519(xdr::Uint256(key)) = muxed_account else {
                     return Err(Error::CannotSign(muxed_account.clone()));

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -29,6 +29,8 @@ pub mod secure_store;
 pub enum Error {
     #[error("Contract addresses are not supported to sign auth entries {address}")]
     ContractAddressAreNotSupported { address: String },
+    #[error("{kind} addresses cannot authorize Soroban invocations: {address}")]
+    UnsupportedAuthAddress { kind: &'static str, address: String },
     #[error(transparent)]
     Ed25519(#[from] ed25519_dalek::SignatureError),
     #[error("Missing signing key for account {address}")]
@@ -130,9 +132,28 @@ pub async fn sign_soroban_authorizations(
         // See if we have a signer for this authorizationEntry
         // If not, then we Error
         let auth_address_bytes: &[u8; 32] = match address {
-            ScAddress::MuxedAccount(_) => todo!("muxed accounts are not supported"),
-            ScAddress::ClaimableBalance(_) => todo!("claimable balance not supported"),
-            ScAddress::LiquidityPool(_) => todo!("liquidity pool not supported"),
+            // Only account (G…) and contract addresses can authorize an
+            // invocation; the remaining ScAddress variants are values, not
+            // authorizers, so reject them with a structured error instead of
+            // panicking (#2534).
+            ScAddress::MuxedAccount(_) => {
+                return Err(Error::UnsupportedAuthAddress {
+                    kind: "Muxed (M…)",
+                    address: address.to_string(),
+                })
+            }
+            ScAddress::ClaimableBalance(_) => {
+                return Err(Error::UnsupportedAuthAddress {
+                    kind: "Claimable balance",
+                    address: address.to_string(),
+                })
+            }
+            ScAddress::LiquidityPool(_) => {
+                return Err(Error::UnsupportedAuthAddress {
+                    kind: "Liquidity pool",
+                    address: address.to_string(),
+                })
+            }
             ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(ref a)))) => a,
             ScAddress::Contract(stellar_xdr::ContractId(Hash(c))) => {
                 // This address is for a contract. This means we're using a custom
@@ -642,6 +663,66 @@ mod tests {
             signer_pk,
             "embedded public_key should match the signer"
         );
+    }
+
+    /// Regression for #2534: an auth entry whose credential address is not a
+    /// valid authorizer (muxed account, claimable balance, liquidity pool)
+    /// must yield a structured error, not the `todo!()` panic it used to hit.
+    async fn assert_unsupported_auth_address(address: ScAddress, expected_kind: &str) {
+        let signer = local_signer([1u8; 32]);
+        let source = MuxedAccount::Ed25519(Uint256([9u8; 32]));
+        let contract = [42u8; 32];
+
+        let entry = address_auth(address, invocation(contract, "hello"));
+        let host_fn = HostFunction::InvokeContract(invoke_args(contract, "hello"));
+        let tx = build_tx(source, host_fn, vec![entry]);
+
+        let res = sign_soroban_authorizations(
+            &tx,
+            &[signer],
+            EXPIRATION_LEDGER,
+            NETWORK,
+            false,
+            &Print::new(true),
+        )
+        .await;
+
+        match res {
+            Err(Error::UnsupportedAuthAddress { kind, .. }) => assert_eq!(kind, expected_kind),
+            other => panic!("expected UnsupportedAuthAddress error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_muxed_account_auth_address_errors_instead_of_panicking() {
+        assert_unsupported_auth_address(
+            ScAddress::MuxedAccount(xdr::MuxedEd25519Account {
+                id: 1,
+                ed25519: Uint256([7u8; 32]),
+            }),
+            "Muxed (M…)",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_claimable_balance_auth_address_errors_instead_of_panicking() {
+        assert_unsupported_auth_address(
+            ScAddress::ClaimableBalance(xdr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash(
+                [8u8; 32],
+            ))),
+            "Claimable balance",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_liquidity_pool_auth_address_errors_instead_of_panicking() {
+        assert_unsupported_auth_address(
+            ScAddress::LiquidityPool(xdr::PoolId(Hash([6u8; 32]))),
+            "Liquidity pool",
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/cmd/soroban-cli/src/signer/mod.rs
+++ b/cmd/soroban-cli/src/signer/mod.rs
@@ -673,6 +673,7 @@ mod tests {
         let source = MuxedAccount::Ed25519(Uint256([9u8; 32]));
         let contract = [42u8; 32];
 
+        let expected_address = address.to_string();
         let entry = address_auth(address, invocation(contract, "hello"));
         let host_fn = HostFunction::InvokeContract(invoke_args(contract, "hello"));
         let tx = build_tx(source, host_fn, vec![entry]);
@@ -688,7 +689,10 @@ mod tests {
         .await;
 
         match res {
-            Err(Error::UnsupportedAuthAddress { kind, .. }) => assert_eq!(kind, expected_kind),
+            Err(Error::UnsupportedAuthAddress { kind, address }) => {
+                assert_eq!(kind, expected_kind);
+                assert_eq!(address, expected_address);
+            }
             other => panic!("expected UnsupportedAuthAddress error, got: {other:?}"),
         }
     }


### PR DESCRIPTION
### What
`sign_soroban_authorizations` had three `todo!()` arms — muxed account, claimable balance, and liquidity pool credential addresses — so any transaction carrying such an auth entry crashed the CLI with a raw panic and backtrace. They now return a structured `Error::UnsupportedAuthAddress` naming the address kind and its strkey.

### Why
Part of #2534. Per the ruling in that issue's discussion, muxed accounts are not valid authorizers (confirmed there with dmkozh), so the actionable half of the issue is turning the panics into diagnosable errors — the error text says these addresses "cannot authorize", not "not yet supported". Also refreshes the `resolve_secret` comment in `config/address.rs` that pointed at the removed `todo!`.

Note: PR #2547 attempted this earlier but modifies `Dockerfile`/`entrypoint.sh`/`docker/README.md`, which were removed from main by #2616, and has been conflicting since May. This is a minimal replacement (2 files, no unrelated changes); happy to close in its favor if it gets rebased.

### Testing
Three new unit tests (`test_{muxed_account,claimable_balance,liquidity_pool}_auth_address_errors_instead_of_panicking`) build a transaction with an auth entry for each address kind and assert the structured error — the regression being guarded is "errors, does not panic". `cargo test -p soroban-cli --lib signer::`: 25 passed. `cargo clippy` and `cargo fmt --check` clean.