### PR TITLE
fix: warn when tx simulate discards existing signatures

### DIFF
--- a/cmd/soroban-cli/src/commands/tx/simulate.rs
+++ b/cmd/soroban-cli/src/commands/tx/simulate.rs
@@ -66,7 +66,14 @@ impl Cmd {
         // signature on the incoming envelope is invalid on the simulated
         // result. They were silently dropped before; say so, since the correct
         // order (simulate, then sign) is the actual fix on the user's side.
-        let discarded = super::xdr::signature_count(&tx_env);
+        // Warn only for v1 envelopes: v0 and fee-bump envelopes are rejected
+        // below by unwrap_envelope_v1 with their signatures intact, so nothing
+        // is discarded for them.
+        let discarded = if matches!(tx_env, TransactionEnvelope::Tx(_)) {
+            super::xdr::signature_count(&tx_env)
+        } else {
+            0
+        };
         if discarded > 0 {
             print.warnln(format!(
                 "Discarding {discarded} existing signature(s): simulation changes the \

--- a/cmd/soroban-cli/src/commands/tx/simulate.rs
+++ b/cmd/soroban-cli/src/commands/tx/simulate.rs
@@ -61,7 +61,20 @@ impl Cmd {
         let print = print::Print::new(global_args.quiet);
         let network = config.get_network()?;
         let client = network.rpc_client()?;
-        let tx = super::xdr::unwrap_envelope_v1(super::xdr::tx_envelope_from_input(&self.tx_xdr)?)?;
+        let tx_env = super::xdr::tx_envelope_from_input(&self.tx_xdr)?;
+        // Simulation rewrites the fee and Soroban transaction data, so any
+        // signature on the incoming envelope is invalid on the simulated
+        // result. They were silently dropped before; say so, since the correct
+        // order (simulate, then sign) is the actual fix on the user's side.
+        let discarded = super::xdr::signature_count(&tx_env);
+        if discarded > 0 {
+            print.warnln(format!(
+                "Discarding {discarded} existing signature(s): simulation changes the \
+                 transaction's fee and resources, which invalidates prior signatures. \
+                 Simulate first, then sign the result."
+            ));
+        }
+        let tx = super::xdr::unwrap_envelope_v1(tx_env)?;
         let resource_config = self
             .instruction_leeway
             .map(|instruction_leeway| soroban_rpc::ResourceConfig { instruction_leeway });

--- a/cmd/soroban-cli/src/commands/tx/xdr.rs
+++ b/cmd/soroban-cli/src/commands/tx/xdr.rs
@@ -76,6 +76,18 @@ impl<R: Read> Read for SkipWhitespace<R> {
     }
 }
 
+/// Number of signatures already attached to the envelope, across all envelope
+/// flavors. Callers that go on to discard the envelope's signatures (e.g. via
+/// [`unwrap_envelope_v1`]) can use this to say so instead of dropping them
+/// silently.
+pub fn signature_count(tx_env: &TransactionEnvelope) -> usize {
+    match tx_env {
+        TransactionEnvelope::TxV0(e) => e.signatures.len(),
+        TransactionEnvelope::Tx(e) => e.signatures.len(),
+        TransactionEnvelope::TxFeeBump(e) => e.signatures.len(),
+    }
+}
+
 pub fn unwrap_envelope_v1(tx_env: TransactionEnvelope) -> Result<Transaction, Error> {
     let TransactionEnvelope::Tx(TransactionV1Envelope { tx, .. }) = tx_env else {
         return Err(Error::OnlyTransactionV1Supported);
@@ -121,6 +133,49 @@ mod tests {
             self.pos += 1;
             Ok(n)
         }
+    }
+
+    fn minimal_tx() -> Transaction {
+        use crate::xdr::{
+            Memo, MuxedAccount, Preconditions, SequenceNumber, TransactionExt, Uint256,
+        };
+        Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0u8; 32])),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: Vec::new().try_into().unwrap(),
+            ext: TransactionExt::V0,
+        }
+    }
+
+    fn signatures(n: usize) -> crate::xdr::VecM<crate::xdr::DecoratedSignature, 20> {
+        use crate::xdr::{DecoratedSignature, Signature, SignatureHint};
+        vec![
+            DecoratedSignature {
+                hint: SignatureHint([0u8; 4]),
+                signature: Signature(vec![0u8; 64].try_into().unwrap()),
+            };
+            n
+        ]
+        .try_into()
+        .unwrap()
+    }
+
+    #[test]
+    fn signature_count_reports_attached_signatures() {
+        let unsigned = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx: minimal_tx(),
+            signatures: signatures(0),
+        });
+        assert_eq!(signature_count(&unsigned), 0);
+
+        let signed = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx: minimal_tx(),
+            signatures: signatures(2),
+        });
+        assert_eq!(signature_count(&signed), 2);
     }
 
     #[test]


### PR DESCRIPTION
### What
`tx simulate` silently dropped any signature already attached to the incoming envelope — `unwrap_envelope_v1` destructures it and the re-wrapped result always carries an empty signature list. It now warns with the discarded count and the correct order of operations (simulate first, then sign).

### Why
This is the concrete pain reported in #2549 (the author's follow-up comment): in a multisig flow, collected signatures vanish with no indication. The signatures are genuinely unusable after simulation — it rewrites the fee and Soroban transaction data, which invalidates them — so preserving them would be wrong; the missing piece was telling the user. This PR references #2549 rather than closing it: the issue also asks for repeated `--sign-with-key` and broader multisig UX, which are larger design decisions.

### Testing
- New `signature_count` helper in `tx/xdr.rs` with a unit test covering signed and unsigned envelopes; `cargo test -p soroban-cli --lib tx::xdr::`: 7 passed.
- `cargo clippy` and `cargo fmt --check` clean.