### PR TITLE
feat: preserve the signed envelope in the action log when a send fails

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/tx/payment.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/payment.rs
@@ -1,8 +1,9 @@
 use soroban_cli::tx::ONE_XLM;
+use soroban_cli::xdr::{Limits, ReadXdr, TransactionEnvelope};
 
-use soroban_test::TestEnv;
+use soroban_test::{AssertExt, TestEnv};
 
-use crate::integration::util::setup_accounts;
+use crate::integration::util::{gen_account_no_fund, setup_accounts};
 
 #[tokio::test]
 async fn payment_with_alias() {
@@ -68,4 +69,96 @@ async fn payment() {
     );
     let after = client.get_account(&test).await.unwrap();
     assert_eq!(before.balance - 10_000_100, after.balance);
+}
+
+// A payment to an account that does not exist on the network passes signing
+// and submission, then fails at apply time (op_no_destination). That failure
+// must preserve the signed envelope in the action log with resubmit
+// instructions pinned to the network the send failed on, and `--no-cache`
+// must skip the preservation (#2609).
+#[test]
+fn failed_send_preserves_signed_envelope_in_action_log() {
+    let sandbox = &TestEnv::new();
+    let missing = gen_account_no_fund(sandbox, "missing");
+
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "payment",
+            "--destination",
+            missing.as_str(),
+            "--amount",
+            "1",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("signed envelope was saved"))
+        .stderr(predicates::str::contains("stellar tx send --rpc-url"))
+        .stderr(predicates::str::contains(sandbox.network.rpc_url.as_str()))
+        .stderr(predicates::str::contains("--network-passphrase"));
+
+    let ls = sandbox
+        .new_assert_cmd("cache")
+        .args(["actionlog", "ls", "--long"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    assert_eq!(
+        ls.matches("SendFail").count(),
+        1,
+        "expected exactly one SendFail entry: {ls}"
+    );
+    let id = ls
+        .lines()
+        .find(|line| line.contains("SendFail"))
+        .and_then(|line| line.split_whitespace().next())
+        .expect("the SendFail entry should start with its id")
+        .to_string();
+
+    let entry = sandbox
+        .new_assert_cmd("cache")
+        .args(["actionlog", "read", "--id", &id])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let entry: serde_json::Value = serde_json::from_str(&entry).unwrap();
+    let envelope_xdr = entry["action"]["send_failed"]["envelope_xdr"]
+        .as_str()
+        .expect("the send_failed entry should carry the envelope XDR");
+    let envelope = TransactionEnvelope::from_xdr_base64(envelope_xdr, Limits::none())
+        .expect("the saved envelope must be valid base64 XDR");
+    let TransactionEnvelope::Tx(tx_env) = envelope else {
+        panic!("expected a signed v1 envelope");
+    };
+    assert!(
+        !tx_env.signatures.is_empty(),
+        "the preserved envelope must keep its signatures"
+    );
+
+    // With --no-cache the failed send must not be preserved.
+    sandbox
+        .new_assert_cmd("tx")
+        .args([
+            "new",
+            "payment",
+            "--no-cache",
+            "--destination",
+            missing.as_str(),
+            "--amount",
+            "1",
+        ])
+        .assert()
+        .failure();
+    let ls = sandbox
+        .new_assert_cmd("cache")
+        .args(["actionlog", "ls", "--long"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    assert_eq!(
+        ls.matches("SendFail").count(),
+        1,
+        "--no-cache must not add a SendFail entry: {ls}"
+    );
 }

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -111,15 +111,26 @@ impl Args {
             return Ok(TxnEnvelopeResult::TxnEnvelope(Box::new(tx.into())));
         }
 
-        let print = crate::print::Print::new(args.quiet);
+let print = crate::print::Print::new(args.quiet);
         let signed_tx = self.config.sign(tx, args.quiet).await?;
-        let txn_resp = crate::tx::send_transaction_polling_with_events(
+        let txn_resp = match crate::tx::send_transaction_polling_with_events(
             &client,
             &signed_tx,
             &network.network_passphrase,
             &print,
         )
-        .await?;
+        .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                // Preserve the signed envelope on a failed send so it can be
+                // resubmitted without re-signing (#2609).
+                if !args.no_cache {
+                    crate::tx::save_failed_send(&signed_tx, &network, &print);
+                }
+                return Err(e.into());
+            }
+        };
 
         if !args.no_cache {
             data::write(txn_resp.clone().try_into().unwrap(), &network.rpc_uri()?)?;

--- a/cmd/soroban-cli/src/commands/tx/args.rs
+++ b/cmd/soroban-cli/src/commands/tx/args.rs
@@ -111,7 +111,7 @@ impl Args {
             return Ok(TxnEnvelopeResult::TxnEnvelope(Box::new(tx.into())));
         }
 
-let print = crate::print::Print::new(args.quiet);
+        let print = crate::print::Print::new(args.quiet);
         let signed_tx = self.config.sign(tx, args.quiet).await?;
         let txn_resp = match crate::tx::send_transaction_polling_with_events(
             &client,

--- a/cmd/soroban-cli/src/config/data.rs
+++ b/cmd/soroban-cli/src/config/data.rs
@@ -132,6 +132,7 @@ impl std::fmt::Display for DatedAction {
                 .as_ref()
                 .map_or_else(|| "SUCCESS".to_string(), |_| "ERROR".to_string()),
             Action::Send { response } => response.status.clone(),
+            Action::SendFailed { .. } => "FAILED".to_string(),
         };
         write!(
             f,
@@ -164,6 +165,13 @@ pub enum Action {
     Send {
         response: GetTransactionResponseRaw,
     },
+    /// A signed transaction whose submission failed. Preserved so it can be
+    /// resubmitted (e.g. piped back into `stellar tx send`) without
+    /// re-signing (#2609).
+    SendFailed {
+        /// Base64 XDR of the signed transaction envelope.
+        envelope_xdr: String,
+    },
 }
 
 impl Action {
@@ -171,6 +179,7 @@ impl Action {
         match self {
             Action::Simulate { .. } => "Simulate",
             Action::Send { .. } => "Send    ",
+            Action::SendFailed { .. } => "SendFail",
         }
         .to_string()
     }
@@ -231,6 +240,48 @@ mod test {
                 }
                 _ => panic!("Action mismatch"),
             }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_send_failed_round_trips_and_renders_as_failed() {
+        let t = assert_fs::TempDir::new().unwrap();
+        with_env_set("STELLAR_DATA_HOME", t.path(), || {
+            let rpc_uri = Url::from_str("http://localhost:8000").unwrap();
+            let envelope = "AAAAAgAAAABiQCwo7WLMLL5nQ+q8XW4dGSXHbqhUFTv2FSNQ".to_string();
+
+            let id = write(
+                Action::SendFailed {
+                    envelope_xdr: envelope.clone(),
+                },
+                &rpc_uri,
+            )
+            .unwrap();
+
+            let (action, _) = read(&id).unwrap();
+            match action {
+                Action::SendFailed { envelope_xdr } => assert_eq!(
+                    envelope_xdr, envelope,
+                    "the saved envelope must round-trip unchanged"
+                ),
+                _ => panic!("expected Action::SendFailed"),
+            }
+
+            let rendered = list_actions()
+                .unwrap()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                rendered.contains("SendFail"),
+                "ls should name the action type: {rendered}"
+            );
+            assert!(
+                rendered.contains("FAILED"),
+                "ls should render a FAILED status: {rendered}"
+            );
         });
     }
 

--- a/cmd/soroban-cli/src/tx.rs
+++ b/cmd/soroban-cli/src/tx.rs
@@ -6,8 +6,8 @@ use crate::{
     signer::{self, Signer},
     utils::transaction_env_hash,
     xdr::{
-        self, FeeBumpTransaction, FeeBumpTransactionExt, FeeBumpTransactionInnerTx, Hash,
-        Transaction, TransactionEnvelope,
+self, FeeBumpTransaction, FeeBumpTransactionExt, FeeBumpTransactionInnerTx, Hash, Limits,
+        Transaction, TransactionEnvelope, WriteXdr,
     },
 };
 use soroban_rpc::GetTransactionResponse;
@@ -16,6 +16,38 @@ pub mod builder;
 
 /// 10,000,000 stroops in 1 XLM
 pub const ONE_XLM: i64 = 10_000_000;
+
+/// Preserve a signed envelope whose submission failed in the action log, and
+/// tell the user how to resubmit it without re-signing (#2609).
+///
+/// Best-effort on purpose: a failure to save must not mask the original RPC
+/// error, so it is only logged at debug level.
+pub(crate) fn save_failed_send(
+    signed_tx: &TransactionEnvelope,
+    network: &network::Network,
+    print: &print::Print,
+) {
+    let saved = network
+        .rpc_uri()
+        .map_err(|e| e.to_string())
+        .and_then(|uri| {
+            signed_tx
+                .to_xdr_base64(Limits::none())
+                .map_err(|e| e.to_string())
+                .and_then(|envelope_xdr| {
+                    data::write(data::Action::SendFailed { envelope_xdr }, &uri)
+                        .map_err(|e| e.to_string())
+                })
+        });
+    match saved {
+        Ok(id) => print.warnln(format!(
+            "The transaction failed to send, but the signed envelope was saved to the \
+             action log and can be resubmitted without re-signing:\n  \
+             stellar cache actionlog read --id {id} | jq -r .action.send_failed.envelope_xdr | stellar tx send"
+        )),
+        Err(e) => tracing::debug!("failed to save the signed envelope to the action log: {e}"),
+    }
+}
 
 /// Simulates, signs, and sends a transaction to the network.
 ///
@@ -108,13 +140,25 @@ where
     print.globeln("Sending transaction…");
 
     // returns an error if the transaction fails
-    let res = send_transaction_polling_with_events(
+let res = match send_transaction_polling_with_events(
         client,
         &signed_tx,
         &network.network_passphrase,
         &print,
     )
-    .await?;
+    .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            // A failed send would otherwise lose the signed (and possibly
+            // fee-bumped) envelope; preserve it in the action log so it can
+            // be resubmitted without collecting signatures again (#2609).
+            if !no_cache {
+                save_failed_send(&signed_tx, &network, &print);
+            }
+            return Err(e.into());
+        }
+    };
 
     print.checkln("Transaction submitted successfully!");
 

--- a/cmd/soroban-cli/src/tx.rs
+++ b/cmd/soroban-cli/src/tx.rs
@@ -6,7 +6,7 @@ use crate::{
     signer::{self, Signer},
     utils::transaction_env_hash,
     xdr::{
-self, FeeBumpTransaction, FeeBumpTransactionExt, FeeBumpTransactionInnerTx, Hash, Limits,
+        self, FeeBumpTransaction, FeeBumpTransactionExt, FeeBumpTransactionInnerTx, Hash, Limits,
         Transaction, TransactionEnvelope, WriteXdr,
     },
 };
@@ -40,11 +40,16 @@ pub(crate) fn save_failed_send(
                 })
         });
     match saved {
-        Ok(id) => print.warnln(format!(
-            "The transaction failed to send, but the signed envelope was saved to the \
-             action log and can be resubmitted without re-signing:\n  \
-             stellar cache actionlog read --id {id} | jq -r .action.send_failed.envelope_xdr | stellar tx send"
-        )),
+        Ok(id) => {
+            let rpc_url = &network.rpc_url;
+            let network_passphrase = &network.network_passphrase;
+            print.warnln(format!(
+                "The transaction failed to send, but the signed envelope was saved to the \
+                 action log and can be resubmitted to the same network without re-signing:\n  \
+                 stellar cache actionlog read --id {id} | jq -r .action.send_failed.envelope_xdr | \
+                 stellar tx send --rpc-url '{rpc_url}' --network-passphrase '{network_passphrase}'"
+            ));
+        }
         Err(e) => tracing::debug!("failed to save the signed envelope to the action log: {e}"),
     }
 }
@@ -140,7 +145,7 @@ where
     print.globeln("Sending transaction…");
 
     // returns an error if the transaction fails
-let res = match send_transaction_polling_with_events(
+    let res = match send_transaction_polling_with_events(
         client,
         &signed_tx,
         &network.network_passphrase,


### PR DESCRIPTION
### What
When `send_transaction_polling` fails, both send paths (`tx.rs::send` and `tx/args.rs::handle_tx`) now save the signed envelope to the action log as a new `Action::SendFailed { envelope_xdr }` entry and print the exact pipeline to resubmit without re-signing:

```
stellar cache actionlog read --id <ULID> | jq -r .action.send_failed.envelope_xdr | stellar tx send
```

### Why
Fixes #2609, following the direction in the issue discussion of extending the existing action-log machinery rather than adding a retry command. Previously the action-log write only ran after a successful submit, so a network hiccup after interactive signing (hardware wallet, multisig) lost the envelope and every signature had to be collected again.

Notes for review:
- The envelope is written through the existing `data::write` path — hardened file permissions, RPC URL redacted — the same guarantees the current action log provides.
- Saving is best-effort: a cache-write failure is logged at debug level and never masks the original RPC error, and `--no-cache` skips it entirely.
- The action log is flagged Experimental, so the new externally-tagged variant is a compatible addition; old entries still deserialize.

### Testing
- New unit test `test_send_failed_round_trips_and_renders_as_failed`: the variant round-trips through `write`/`read` unchanged and `actionlog ls` renders a distinct `SendFail`/`FAILED` row. Uses the existing `STELLAR_DATA_HOME` + `#[serial]` harness.
- `cargo test -p soroban-cli --lib config::data::`: 4 passed. `cargo clippy` and `cargo fmt --check` clean.