### PR TITLE
Add support for Protocol 28

### DIFF
--- a/.github/workflows/bindings-ts.yml
+++ b/.github/workflows/bindings-ts.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - uses: stellar/quickstart@main
         with:
-          tag: nightly
-          protocol_version: 27
+          tag: latest
+          protocol_version: 28
       - uses: actions/setup-node@v7
         with:
           node-version: "20.x"

--- a/.github/workflows/ledger-emulator.yml
+++ b/.github/workflows/ledger-emulator.yml
@@ -36,8 +36,8 @@ jobs:
     steps:
       - uses: stellar/quickstart@main
         with:
-          tag: nightly
-          protocol_version: 27
+          tag: latest
+          protocol_version: 28
       - uses: actions/checkout@v7
 
       - uses: stellar/actions/rust-cache@main

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: stellar/quickstart@main
         with:
           tag: latest
-          protocol_version: 27
+          protocol_version: 28
       - uses: actions/checkout@v7
       - uses: stellar/actions/rust-cache@main
       - run: rustup update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,7 +4983,7 @@ checksum = "35a5a225b0cc092f0c818c7e51faf9d63d07da8c3157d6250096ca4b8708cfe3"
 dependencies = [
  "ed25519-dalek",
  "ows-signer",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.18",
  "thiserror 2.0.18",
  "tiny-bip39",
 ]
@@ -5818,8 +5818,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-rpc-client"
-version = "27.0.0"
-source = "git+https://github.com/stellar/rs-stellar-rpc-client#ddea9e5cfe9f71d9643b859ed1883bb32c5fd3d0"
+version = "28.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f06a05befef7b6ddb92d28f09880a801e34fc3ab671c04d0e88ec4de6b1d4d"
 dependencies = [
  "clap",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ dependencies = [
  "embedded-io-async",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -2481,6 +2481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,7 +2783,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -4235,7 +4246,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4273,7 +4284,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5041,6 +5052,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5318,14 +5339,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77bc93d930032c487cb1506b6ed166b2af49db76d52678ec4887ac621ecce01"
+checksum = "86ffd329211a50add3965a8f4a8f70e24fc5c8268c945566ab963029b12dce40"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5428,12 +5449,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b22e9981cdd444f3aa6734bc58d76195bf7eca3ccf1dd432b875af5d02da068"
+checksum = "610bb12ee937a56c2b629f8eb16efb7e47607cba4e79ab0c24132b9a53dd19a0"
 dependencies = [
  "arbitrary",
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "ethnum",
  "num-derive",
  "num-traits",
@@ -5447,9 +5468,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6072f99ca6bf8e8d5b04e05d083dac785e5357d9c0f36a6658f819c2fd7d67"
+checksum = "7d383176b27bb286f718ab0ff5713bd9b01132089151266359bd9b20f38684cf"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -5457,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c06afd7c75ce150ce53e4d77a77645b18e3fb61856a0ddc42bfcecdc39fa3b9"
+checksum = "36d7e5920c200939164cc58038224e2d90d7e2fabbfa505d6e2129d648dce7e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5494,9 +5515,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "27.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647811bdd28a3ec40296987f6635781e5e1141c8f5affbbd53ba12b6295b7bb6"
+checksum = "077600bb175ea54592c1ac5983b8fb34ec9ab7a65f298af11d687b61e9d646a4"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5513,9 +5534,9 @@ version = "27.1.0"
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ea48b5d5e22c0cbaa370f813111016c9f5a8a6632edb0684c72be6531c4d3a"
+checksum = "9e68b020e9838df2affe8488998943b81d183c7ea4990691a863b39c13d3516e"
 dependencies = [
  "serde",
  "serde_json",
@@ -5527,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfa78af0110f0830d3af9db0361b6cdb50507846cedb8725189318134218b80"
+checksum = "864a530b8a1eb07c364f3f4b2f069b737ae87df203fd290baebddb9119f2dfe5"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5551,9 +5572,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db611bd0acfe5fd348ffdcef16c84090c6ab051f3e325b5ac049a73044a7ee6"
+checksum = "d66c2bfe91c8ec2179dcab5284ee99215d9271fed2eb8b9819bcd45001ac861f"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -5571,9 +5592,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8061fe31998fe9fba8fcd7175b3e3ca914a6f6e3bf829fe91fdf7f930b1251d9"
+checksum = "2f20e3c44fa7939fece5c8988efa7c9e062ab5596ae7497035a2bc59ffd48816"
 dependencies = [
  "base64 0.22.1",
  "sha2 0.10.9",
@@ -5584,9 +5605,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2180cddacf3023a439827cb35c0e391ec413b1328173fe7c8c2743fc67b3af9e"
+checksum = "43eb9293928c35e949818f83fe5eacfe0cf45ebb32552304aaea66279b7c8403"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5683,18 +5704,18 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52c6f247f1c3383b9fa8f8ab6bf3c6c7b36e893a2fff585bc819cbc89ec193"
+checksum = "b7053541ed1cf2cbfc78625d2b619c496c0748d20d75aee019b2f68169386f4c"
 dependencies = [
  "soroban-sdk",
 ]
 
 [[package]]
 name = "soroban-token-spec"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7417a2ae69b4a6fc52f986c3d501b3bd442ba976a0991f042f81f7ee593e1b30"
+checksum = "27fe6acb049550f221fcb294c8ca3ede0e89609ea3d480c63b84b8cf4197c416"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5743,9 +5764,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-asset-spec"
-version = "27.0.2"
+version = "28.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9943559865bce30221f21f2bdd45352c91c253ddf1002dba413a7a0ffc23945"
+checksum = "4194d1b54a5337c277a0656c2d4da940439f9eb3f2e17a919bc686a870429250"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5798,8 +5819,7 @@ dependencies = [
 [[package]]
 name = "stellar-rpc-client"
 version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b65ae2e8788c09fba690afa3b589094fd67ff4d7d5ec4502ec4f2d7d870576"
+source = "git+https://github.com/stellar/rs-stellar-rpc-client#ddea9e5cfe9f71d9643b859ed1883bb32c5fd3d0"
 dependencies = [
  "clap",
  "hex",
@@ -5812,7 +5832,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "stellar-strkey 0.0.16",
+ "stellar-strkey 0.0.18",
  "stellar-xdr",
  "termcolor",
  "termcolor_output",
@@ -5839,7 +5859,7 @@ dependencies = [
  "clap",
  "crate-git-revision 0.0.6",
  "data-encoding",
- "heapless",
+ "heapless 0.8.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -5847,22 +5867,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-xdr"
-version = "27.0.0"
+name = "stellar-strkey"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
+dependencies = [
+ "crate-git-revision 0.0.9",
+ "data-encoding",
+ "heapless 0.9.3",
+ "zeroize",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93d09ff8b9f919b084f664003c4c546ac66a76affd5429460dbe29f4b326f8e"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
  "cfg_eval",
  "clap",
- "crate-git-revision 0.0.6",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",
  "rand 0.9.5",
  "schemars 0.8.22",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
@@ -7208,7 +7241,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,35 +44,35 @@ path = "cmd/crates/stellar-ledger"
 
 # Dependencies from the rs-stellar-xdr repo:
 [workspace.dependencies.stellar-xdr]
-version = "27.0.0"
+version = "28.0.0"
 
 # Dependencies from the rs-stellar-env repo:
 [workspace.dependencies.soroban-env-host]
-version = "27.0.1"
+version = "28.0.0-rc.1"
 
 # Dependencies from the rs-soroban-sdk repo:
 [workspace.dependencies.soroban-spec]
-version = "27.0.2"
+version = "28.0.0-rc.1"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "27.0.2"
+version = "28.0.0-rc.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "27.0.2"
+version = "28.0.0-rc.1"
 
 [workspace.dependencies.soroban-token-sdk]
-version = "27.0.2"
+version = "28.0.0-rc.1"
 
 [workspace.dependencies.stellar-asset-spec]
-version = "27.0.2"
+version = "28.0.0-rc.1"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "27.0.2"
+version = "28.0.0-rc.1"
 
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-version = "27.0.0"
+git = "https://github.com/stellar/rs-stellar-rpc-client"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ version = "28.0.0-rc.1"
 # Dependencies from the rs-stellar-rpc-client repo:
 [workspace.dependencies.soroban-rpc]
 package = "stellar-rpc-client"
-git = "https://github.com/stellar/rs-stellar-rpc-client"
+version = "28.0.0-rc.1"
 
 # Dependencies from elsewhere shared by crates:
 [workspace.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build:
 	cargo build
 
 build-test-wasms:
-	cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
+	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
 
 build-test: build-test-wasms build-fixtures install
 

--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -5,14 +5,14 @@ use std::str::FromStr;
 use itertools::Itertools;
 use serde_json::{json, Value};
 use stellar_xdr::{
-    AccountId, BytesM, ContractExecutable, ContractId, Error as XdrError, Hash, Int128Parts,
-    Int256Parts, MuxedEd25519Account, PublicKey, ScAddress, ScBytes, ScContractInstance, ScMap,
-    ScMapEntry, ScNonceKey, ScSpecEntry, ScSpecEventV0, ScSpecFunctionV0, ScSpecTypeDef as ScType,
-    ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeResult, ScSpecTypeTuple, ScSpecTypeUdt,
-    ScSpecTypeVec, ScSpecUdtEnumV0, ScSpecUdtErrorEnumCaseV0, ScSpecUdtErrorEnumV0,
-    ScSpecUdtStructV0, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0, ScSpecUdtUnionCaseVoidV0,
-    ScSpecUdtUnionV0, ScString, ScSymbol, ScVal, ScVec, StringM, UInt128Parts, UInt256Parts,
-    Uint256, VecM,
+    AccountId, BytesM, ContractExecutable, ContractExecutableExternalRef, ContractId,
+    Error as XdrError, Hash, Int128Parts, Int256Parts, MuxedEd25519Account, PublicKey, ScAddress,
+    ScBytes, ScContractInstance, ScMap, ScMapEntry, ScNonceKey, ScSpecEntry, ScSpecEventV0,
+    ScSpecFunctionV0, ScSpecTypeDef as ScType, ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeResult,
+    ScSpecTypeTuple, ScSpecTypeUdt, ScSpecTypeVec, ScSpecUdtEnumV0, ScSpecUdtErrorEnumCaseV0,
+    ScSpecUdtErrorEnumV0, ScSpecUdtStructV0, ScSpecUdtUnionCaseTupleV0, ScSpecUdtUnionCaseV0,
+    ScSpecUdtUnionCaseVoidV0, ScSpecUdtUnionV0, ScString, ScSymbol, ScVal, ScVec, StringM,
+    UInt128Parts, UInt256Parts, Uint256, VecM,
 };
 
 pub mod contract;
@@ -1094,9 +1094,27 @@ pub fn to_json(v: &ScVal) -> Result<Value, Error> {
             executable: ContractExecutable::StellarAsset,
             ..
         }) => json!({"SAC": true}),
+        ScVal::ContractInstance(ScContractInstance {
+            executable:
+                ContractExecutable::ExternalRef(ContractExecutableExternalRef {
+                    executable_owner,
+                    tag,
+                }),
+            ..
+        }) => json!({
+            "executable_owner": sc_address_to_json(executable_owner),
+            "tag": std::str::from_utf8(tag.as_slice())
+                .map_err(|_| Error::InvalidValue(Some(ScType::String)))?
+                .to_string(),
+        }),
         ScVal::LedgerKeyNonce(ScNonceKey { nonce }) => {
             Value::Number(serde_json::Number::from(*nonce))
         }
+        ScVal::ExecutableTag(v) => Value::String(
+            std::str::from_utf8(v.as_slice())
+                .map_err(|_| Error::InvalidValue(Some(ScType::String)))?
+                .to_string(),
+        ),
         ScVal::Error(e) => serde_json::to_value(e)?,
     };
     Ok(val)

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractevent, contractimpl, log, symbol_short, vec, Address, BytesN, Env, String,
-    Symbol, Vec,
+    contract, contractevent, contractimpl, log, symbol_short, vec, Address, BytesN,
+    ContractExecutable, ContractExecutableRef, Env, String, Symbol, Vec,
 };
 
 const COUNTER: Symbol = symbol_short!("COUNTER");
@@ -59,7 +59,34 @@ impl Contract {
     }
 
     pub fn upgrade_contract(env: Env, hash: BytesN<32>) {
-        env.deployer().update_current_contract_wasm(hash);
+        env.deployer()
+            .update_current_contract(ContractExecutable::Wasm(hash));
+    }
+
+    // --- CAP-85: externally managed executables (beacon-proxy pattern) ---
+
+    // Publish (create or update) an executable reference entry owned by this
+    // contract, keyed by `tag`, pointing at an already-uploaded `wasm_hash`.
+    pub fn publish(env: Env, tag: String, wasm_hash: BytesN<32>) {
+        env.executable_refs().set(&tag, &wasm_hash);
+    }
+
+    // Read the Wasm hash the executable reference entry `tag` points at.
+    pub fn get_ref(env: Env, tag: String) -> Option<BytesN<32>> {
+        env.executable_refs().get(&tag)
+    }
+
+    // Deploy a fresh contract whose executable is the reference entry `tag`
+    // owned by this contract.
+    pub fn deploy_ref(env: Env, tag: String) -> Address {
+        let salt = BytesN::from_array(&env, &[0u8; 32]);
+        env.deployer().with_current_contract(salt).deploy_contract(
+            ContractExecutable::ExternalRef(ContractExecutableRef {
+                owner: env.current_contract_address(),
+                tag,
+            }),
+            (),
+        )
     }
 
     #[allow(unused_variables)]

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/token/src/contract.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/token/src/contract.rs
@@ -96,7 +96,7 @@ impl token::Interface for Token {
             from: from.clone(),
             spender: spender.clone(),
             amount,
-            expiration_ledger,
+            live_until_ledger: expiration_ledger,
         }
         .publish(&e);
     }

--- a/cmd/crates/soroban-test/tests/it/integration/bindings.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/bindings.rs
@@ -68,9 +68,12 @@ async fn invoke_test_bindings_context_failure() {
     assert!(index_ts_path.exists(), "src/index.ts file does not exist");
 
     let content = std::fs::read_to_string(&index_ts_path).expect("Failed to read index.ts file");
+    // `__check_auth` is a host-only function and must not be exposed as a client
+    // method. It may still be referenced in doc comments (e.g. on the SDK
+    // `Context` type), so assert on the generated method signature specifically.
     assert!(
-        !content.contains("__check_auth"),
-        "Test failed: `__check_auth` found in src/index.ts"
+        !content.contains("__check_auth: ("),
+        "Test failed: `__check_auth` exposed as a client method in src/index.ts"
     );
 
     // check enum message + doc working properly

--- a/cmd/crates/soroban-test/tests/it/integration/contract/external_ref.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/contract/external_ref.rs
@@ -110,4 +110,13 @@ async fn external_ref_resolves_for_invoke_fetch_and_info() {
         .assert()
         .success()
         .stdout(predicates::str::contains("fn hello"));
+
+    // info hash against the proxy resolves the ExternalRef to the referenced
+    // wasm hash (a distinct code path: fetch_wasm_hash_from_contract).
+    sandbox
+        .new_assert_cmd("contract")
+        .args(["info", "hash", "--id", proxy_id])
+        .assert()
+        .success()
+        .stdout(format!("{wasm_hash}\n"));
 }

--- a/cmd/crates/soroban-test/tests/it/integration/contract/external_ref.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/contract/external_ref.rs
@@ -1,0 +1,113 @@
+use crate::integration::util::{deploy_contract, DeployOptions, HELLO_WORLD};
+
+use soroban_test::{AssertExt, TestEnv};
+
+// Exercises CAP-85 externally managed executables end-to-end:
+//
+// 1. Deploy a "beacon" contract (hello_world exposes the CAP-85 helpers).
+// 2. Publish an executable reference entry `fleet` -> hello_world wasm hash.
+// 3. Deploy a proxy contract whose executable is an `ExternalRef` to `fleet`.
+// 4. Assert the CLI transparently resolves the reference for invoke / fetch /
+//    info against the proxy, whose own contract instance has no direct wasm.
+#[tokio::test]
+async fn external_ref_resolves_for_invoke_fetch_and_info() {
+    let sandbox = &TestEnv::new();
+    let wasm_bytes = HELLO_WORLD.bytes();
+    let wasm_hash = HELLO_WORLD.hash().unwrap().to_string();
+
+    // Deploy the beacon. Deploying also uploads the hello_world wasm, so the
+    // hash the reference entry points at already exists on-ledger.
+    let beacon_id = deploy_contract(
+        sandbox,
+        HELLO_WORLD,
+        DeployOptions {
+            deployer: Some("test".to_string()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Publish the executable reference entry keyed by `fleet`.
+    sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--id",
+            &beacon_id,
+            "--",
+            "publish",
+            "--tag",
+            "fleet",
+            "--wasm_hash",
+            &wasm_hash,
+        ])
+        .assert()
+        .success();
+
+    // get_ref round-trips the published hash.
+    sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--is-view",
+            "--id",
+            &beacon_id,
+            "--",
+            "get_ref",
+            "--tag",
+            "fleet",
+        ])
+        .assert()
+        .success()
+        .stdout(format!("\"{wasm_hash}\"\n"));
+
+    // Deploy a proxy whose executable is an `ExternalRef` to `fleet`.
+    let proxy_out = sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--id",
+            &beacon_id,
+            "--",
+            "deploy_ref",
+            "--tag",
+            "fleet",
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let proxy_id = proxy_out.trim().trim_matches('"');
+
+    // invoke against the proxy: the CLI must resolve the ExternalRef to fetch
+    // the underlying wasm's spec and run its code.
+    sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--is-view",
+            "--id",
+            proxy_id,
+            "--",
+            "hello",
+            "--world=world",
+        ])
+        .assert()
+        .success()
+        .stdout("[\"Hello\",\"world\"]\n");
+
+    // fetch against the proxy returns the referenced wasm bytes.
+    sandbox
+        .new_assert_cmd("contract")
+        .args(["fetch", "--id", proxy_id])
+        .assert()
+        .success()
+        .stdout(predicates::ord::eq(wasm_bytes));
+
+    // info interface against the proxy succeeds (spec resolved via ExternalRef).
+    sandbox
+        .new_assert_cmd("contract")
+        .args(["info", "interface", "--id", proxy_id])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("fn hello"));
+}

--- a/cmd/crates/soroban-test/tests/it/integration/contract/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/contract/mod.rs
@@ -1,2 +1,3 @@
+mod external_ref;
 mod fetch;
 mod info_hash;

--- a/cmd/crates/soroban-test/tests/it/integration/tx/fetch.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/tx/fetch.rs
@@ -366,7 +366,9 @@ async fn tx_fetch_events() {
         .stdout_as_str();
 
     let parsed: GetTransactionEvents = serde_json::from_str(&output).unwrap();
-    assert!(parsed.diagnostic_events.is_empty());
+    // With diagnostic events enabled on the network, the RPC surfaces the full
+    // diagnostic stream (fn_call/fn_return, the contract log, and core_metrics).
+    assert!(!parsed.diagnostic_events.is_empty());
     assert_eq!(parsed.contract_events.len(), 1);
     assert_eq!(parsed.transaction_events.len(), 2);
 }

--- a/cmd/crates/soroban-test/tests/it/log.rs
+++ b/cmd/crates/soroban-test/tests/it/log.rs
@@ -30,7 +30,7 @@ fn test_diagnostic_events_logging() {
     });
 
     let captured_logs = logs.lock().unwrap();
-    assert!(captured_logs.iter().any(|log| log.contains(r#"AAAAAAAAAAAAAAAAAAAAAgAAAAAAAAADAAAADwAAAAdmbl9jYWxsAAAAAA0AAAAgfKvD/pIJPlRnGd3RKaBZSHfoq/nJbJSYxkVTScSbhuYAAAAPAAAABGRlY3IAAAAB {"in_successful_contract_call":false,"event":{"ext":"v0","contract_id":null,"type_":"diagnostic","body":{"v0":{"topics":[{"symbol":"fn_call"},{"bytes":"7cabc3fe92093e546719ddd129a0594877e8abf9c96c9498c6455349c49b86e6"},{"symbol":"decr"}],"data":"void"}}}}"#)));
+    assert!(captured_logs.iter().any(|log| log.contains(r#"AAAAAAAAAAAAAAAAAAAAAgAAAAAAAAADAAAADwAAAAdmbl9jYWxsAAAAAA0AAAAgfKvD/pIJPlRnGd3RKaBZSHfoq/nJbJSYxkVTScSbhuYAAAAPAAAABGRlY3IAAAAB {"in_successful_contract_call":false,"event":{"ext":"v0","contract_id":null,"type":"diagnostic","body":{"v0":{"topics":[{"symbol":"fn_call"},{"bytes":"7cabc3fe92093e546719ddd129a0594877e8abf9c96c9498c6455349c49b86e6"},{"symbol":"decr"}],"data":"void"}}}}"#)));
     assert!(captured_logs
         .iter()
         .any(|log| log.contains("VM call trapped")));

--- a/cmd/soroban-cli/src/config/data.rs
+++ b/cmd/soroban-cli/src/config/data.rs
@@ -197,6 +197,7 @@ impl TryFrom<GetTransactionResponse> for Action {
                 result_xdr: res.result.as_ref().map(to_xdr).transpose()?,
                 result_meta_xdr: res.result_meta.as_ref().map(to_xdr).transpose()?,
                 events: None,
+                diagnostic_events_xdr: None,
             },
         })
     }

--- a/cmd/soroban-cli/src/config/network.rs
+++ b/cmd/soroban-cli/src/config/network.rs
@@ -445,10 +445,7 @@ mod tests {
         let invalid_header = format!("{INVALID_HEADER_NAME}: Bearer 1234");
         let result = parse_http_header(&invalid_header);
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            format!("invalid HTTP header name")
-        );
+        assert_eq!(result.unwrap_err().to_string(), "invalid HTTP header name");
     }
 
     #[tokio::test]
@@ -458,7 +455,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("failed to parse header value")
+            "failed to parse header value"
         );
     }
 
@@ -516,7 +513,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("invalid HTTP header: must be in the form 'key:value'")
+            "invalid HTTP header: must be in the form 'key:value'"
         );
     }
 
@@ -532,7 +529,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("invalid HTTP header: must be in the form 'key:value'")
+            "invalid HTTP header: must be in the form 'key:value'"
         );
     }
 
@@ -548,7 +545,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("Invalid URL Bring Your Own: http://localhost:8000")
+            "Invalid URL Bring Your Own: http://localhost:8000"
         );
     }
 

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -57,34 +57,36 @@ pub async fn get_remote_contract_spec(
         return Err(Error::MissingResult);
     };
 
-    // Get the contract spec entries based on the executable type
+    // Get the contract spec entries based on the executable type. Both a
+    // direct Wasm executable and a CAP-85 externally managed executable
+    // resolve to a Wasm hash whose spec is fetched (and cached) the same way.
     Ok(match executable {
         ContractExecutable::StellarAsset => {
             soroban_spec::read::parse_raw(stellar_asset_spec::xdr())?
         }
-        // Both a direct Wasm executable and a CAP-85 externally managed
-        // executable resolve to a Wasm hash whose spec is fetched (and cached)
-        // the same way.
-        ContractExecutable::Wasm(_) | ContractExecutable::ExternalRef(_) => {
-            let hash = match executable {
-                ContractExecutable::Wasm(hash) => hash,
-                ContractExecutable::ExternalRef(external_ref) => {
-                    resolve_external_ref_wasm_hash(&client, &external_ref).await?
-                }
-                ContractExecutable::StellarAsset => unreachable!(),
-            };
-            let hash_str = hash.to_string();
-            if let Ok(entries) = data::read_spec(&hash_str) {
-                entries
-            } else {
-                let raw_wasm = get_remote_wasm_from_hash(&client, &hash).await?;
-                let res = contract_spec::Spec::new(&raw_wasm)?;
-                let res = res.spec;
-                if global_args.is_none_or(|a| !a.no_cache) {
-                    data::write_spec(&hash_str, &res)?;
-                }
-                res
-            }
+        ContractExecutable::Wasm(hash) => {
+            get_spec_for_wasm_hash(&client, &hash, global_args).await?
+        }
+        ContractExecutable::ExternalRef(external_ref) => {
+            let hash = resolve_external_ref_wasm_hash(&client, &external_ref).await?;
+            get_spec_for_wasm_hash(&client, &hash, global_args).await?
         }
     })
+}
+
+async fn get_spec_for_wasm_hash(
+    client: &rpc::Client,
+    hash: &xdr::Hash,
+    global_args: Option<&global::Args>,
+) -> Result<Vec<ScSpecEntry>, Error> {
+    let hash_str = hash.to_string();
+    if let Ok(entries) = data::read_spec(&hash_str) {
+        return Ok(entries);
+    }
+    let raw_wasm = get_remote_wasm_from_hash(client, hash).await?;
+    let res = contract_spec::Spec::new(&raw_wasm)?.spec;
+    if global_args.is_none_or(|a| !a.no_cache) {
+        data::write_spec(&hash_str, &res)?;
+    }
+    Ok(res)
 }

--- a/cmd/soroban-cli/src/get_spec.rs
+++ b/cmd/soroban-cli/src/get_spec.rs
@@ -8,7 +8,7 @@ pub use soroban_spec_tools::contract as contract_spec;
 use crate::commands::global;
 use crate::config::{self, data, locator, network};
 use crate::rpc;
-use crate::utils::rpc::get_remote_wasm_from_hash;
+use crate::utils::rpc::{get_remote_wasm_from_hash, resolve_external_ref_wasm_hash};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -59,7 +59,20 @@ pub async fn get_remote_contract_spec(
 
     // Get the contract spec entries based on the executable type
     Ok(match executable {
-        ContractExecutable::Wasm(hash) => {
+        ContractExecutable::StellarAsset => {
+            soroban_spec::read::parse_raw(stellar_asset_spec::xdr())?
+        }
+        // Both a direct Wasm executable and a CAP-85 externally managed
+        // executable resolve to a Wasm hash whose spec is fetched (and cached)
+        // the same way.
+        ContractExecutable::Wasm(_) | ContractExecutable::ExternalRef(_) => {
+            let hash = match executable {
+                ContractExecutable::Wasm(hash) => hash,
+                ContractExecutable::ExternalRef(external_ref) => {
+                    resolve_external_ref_wasm_hash(&client, &external_ref).await?
+                }
+                ContractExecutable::StellarAsset => unreachable!(),
+            };
             let hash_str = hash.to_string();
             if let Ok(entries) = data::read_spec(&hash_str) {
                 entries
@@ -72,9 +85,6 @@ pub async fn get_remote_contract_spec(
                 }
                 res
             }
-        }
-        ContractExecutable::StellarAsset => {
-            soroban_spec::read::parse_raw(stellar_asset_spec::xdr())?
         }
     })
 }

--- a/cmd/soroban-cli/src/log/auth.rs
+++ b/cmd/soroban-cli/src/log/auth.rs
@@ -127,6 +127,14 @@ fn format_create_contract(
         ContractExecutable::StellarAsset => {
             let _ = writeln!(result, "{prefix}    Executable: StellarAsset");
         }
+        ContractExecutable::ExternalRef(external_ref) => {
+            let _ = writeln!(
+                result,
+                "{prefix}    Executable: ExternalRef (owner: {}, tag: {})",
+                format_address(&external_ref.executable_owner),
+                String::from_utf8_lossy(external_ref.tag.as_slice()),
+            );
+        }
     }
     if let Some(args) = constructor_args {
         if !args.is_empty() {

--- a/cmd/soroban-cli/src/log/auth.rs
+++ b/cmd/soroban-cli/src/log/auth.rs
@@ -132,7 +132,7 @@ fn format_create_contract(
                 result,
                 "{prefix}    Executable: ExternalRef (owner: {}, tag: {})",
                 format_address(&external_ref.executable_owner),
-                String::from_utf8_lossy(external_ref.tag.as_slice()),
+                sanitize(&String::from_utf8_lossy(external_ref.tag.as_slice())),
             );
         }
     }

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -392,7 +392,13 @@ pub mod rpc {
         let Some(entry) = entries.first() else {
             return Err(Error::NotFound(
                 "Executable Reference Entry".to_string(),
-                external_ref.executable_owner.to_string(),
+                format!(
+                    "owner {}, tag {}",
+                    external_ref.executable_owner,
+                    soroban_spec_tools::sanitize(&String::from_utf8_lossy(
+                        external_ref.tag.as_slice()
+                    )),
+                ),
             ));
         };
         match LedgerEntryData::from_xdr_base64(&entry.xdr, Limits::depth(XDR_DEPTH_LIMIT))? {

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -367,7 +367,50 @@ pub mod rpc {
     use super::XDR_DEPTH_LIMIT;
     use crate::xdr;
     use soroban_rpc::{Client, Error};
-    use stellar_xdr::{Hash, LedgerEntryData, LedgerKey, Limits, ReadXdr};
+    use stellar_xdr::{
+        ContractDataDurability, ContractExecutableExternalRef, Hash, LedgerEntryData, LedgerKey,
+        LedgerKeyContractData, Limits, ReadXdr, ScVal,
+    };
+
+    /// Resolve a CAP-85 externally managed executable to the Wasm hash it
+    /// currently points at.
+    ///
+    /// The executable reference entry is a persistent `ContractData` entry
+    /// owned by `external_ref.executable_owner`, keyed by
+    /// `ScVal::ExecutableTag(tag)`, whose value is the 32-byte Wasm hash.
+    pub async fn resolve_external_ref_wasm_hash(
+        client: &Client,
+        external_ref: &ContractExecutableExternalRef,
+    ) -> Result<Hash, Error> {
+        let key = LedgerKey::ContractData(LedgerKeyContractData {
+            contract: external_ref.executable_owner.clone(),
+            key: ScVal::ExecutableTag(external_ref.tag.clone()),
+            durability: ContractDataDurability::Persistent,
+        });
+        let response = client.get_ledger_entries(&[key]).await?;
+        let entries = response.entries.unwrap_or_default();
+        let Some(entry) = entries.first() else {
+            return Err(Error::NotFound(
+                "Executable Reference Entry".to_string(),
+                external_ref.executable_owner.to_string(),
+            ));
+        };
+        match LedgerEntryData::from_xdr_base64(&entry.xdr, Limits::depth(XDR_DEPTH_LIMIT))? {
+            LedgerEntryData::ContractData(xdr::ContractDataEntry {
+                val: ScVal::Bytes(bytes),
+                ..
+            }) => {
+                let hash: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                    Error::NotFound(
+                        "Executable Reference Entry".to_string(),
+                        "value is not a 32-byte Wasm hash".to_string(),
+                    )
+                })?;
+                Ok(Hash(hash))
+            }
+            data => Err(Error::UnexpectedContractCodeDataType(data)),
+        }
+    }
 
     pub async fn get_remote_wasm_from_hash(client: &Client, hash: &Hash) -> Result<Vec<u8>, Error> {
         let code_key = LedgerKey::ContractCode(xdr::LedgerKeyContractCode { hash: hash.clone() });

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -12,7 +12,10 @@ use crate::{
         locator,
         network::{Error as NetworkError, Network},
     },
-    utils::{self, rpc::get_remote_wasm_from_hash},
+    utils::{
+        self,
+        rpc::{get_remote_wasm_from_hash, resolve_external_ref_wasm_hash},
+    },
     wasm::Error::{ContractIsStellarAsset, UnexpectedContractToken},
 };
 
@@ -133,6 +136,10 @@ pub async fn fetch_from_contract(
         return match &contract.executable {
             ContractExecutable::Wasm(hash) => Ok(get_remote_wasm_from_hash(&client, hash).await?),
             ContractExecutable::StellarAsset => Err(ContractIsStellarAsset),
+            ContractExecutable::ExternalRef(external_ref) => {
+                let hash = resolve_external_ref_wasm_hash(&client, external_ref).await?;
+                Ok(get_remote_wasm_from_hash(&client, &hash).await?)
+            }
         };
     }
     Err(UnexpectedContractToken(Box::new(data_entry)))
@@ -158,6 +165,9 @@ pub async fn fetch_wasm_hash_from_contract(
         return match &contract.executable {
             ContractExecutable::Wasm(hash) => Ok(hash.clone()),
             ContractExecutable::StellarAsset => Err(ContractIsStellarAsset),
+            ContractExecutable::ExternalRef(external_ref) => {
+                Ok(resolve_external_ref_wasm_hash(&client, external_ref).await?)
+            }
         };
     }
     Err(UnexpectedContractToken(Box::new(data_entry)))


### PR DESCRIPTION
### What

Upgrades the soroban dependencies to Protocol 28 (`28.0.0-rc.1`) and adds first-class CAP-85 support: the CLI now resolves an externally managed executable (`ExternalRef`) to its wasm hash, so `invoke`, `fetch`, and `info interface` work against beacon-proxied contracts. Includes an end-to-end integration test.

### Why

Protocol 28 introduces new XDR types and SDK changes the CLI must handle to keep building, and without ExternalRef resolution beacon-proxied contracts can't be used through the CLI.

### Known limitations

Delegated auth signers (`AddressWithDelegates`) remain unsupported and the `useUpgradedAuth` flag isn't plumbed through yet (#2701).