### PR TITLE
Find example wasm when target lives at workspace root

### DIFF
--- a/.github/workflows/test-with-openzeppelin-contracts.yml
+++ b/.github/workflows/test-with-openzeppelin-contracts.yml
@@ -83,7 +83,8 @@ jobs:
       - name: Find wasm
         id: find-wasm
         run: |
-          wasm=$(find . -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
+          root=$(dirname "$(cargo locate-project --workspace --message-format plain --manifest-path ${{ matrix.dir }}/Cargo.toml)")
+          wasm=$(find "$root/target" -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
           echo "wasm=$wasm" | tee -a $GITHUB_OUTPUT
       - name: Set artifact name
         id: artifact-name

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -91,7 +91,8 @@ jobs:
       - name: Find wasm
         id: find-wasm
         run: |
-          wasm=$(find . -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
+          root=$(dirname "$(cargo locate-project --workspace --message-format plain --manifest-path ${{ matrix.dir }}/Cargo.toml)")
+          wasm=$(find "$root/target" -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
           echo "wasm=$wasm" | tee -a $GITHUB_OUTPUT
       - name: Set artifact name
         id: artifact-name

--- a/.github/workflows/test-with-soroban-examples.yml
+++ b/.github/workflows/test-with-soroban-examples.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Find wasm
         id: find-wasm
         run: |
-          wasm=$(find ${{ matrix.dir }}/target -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
+          wasm=$(find . -name '*.wasm' -path '*/wasm32v1-none/release/*' -not -path '*/deps/*' | head -1)
           echo "wasm=$wasm" | tee -a $GITHUB_OUTPUT
       - name: Set artifact name
         id: artifact-name


### PR DESCRIPTION
### What

Fix the `Find wasm` step in the "Test with soroban-examples" workflow so it locates the built `.wasm` when an example is a Cargo workspace, searching the whole checkout instead of only `${matrix.dir}/target`.

### Why

The `soroban-examples` repo recently added the `groth16_verifier` example (containing `bn254_verifier` and `bls12_381_verifier`), which is a Cargo workspace with its contracts as members. For workspaces, build output goes to the workspace-root `target/`, not `${matrix.dir}/target`, so the step failed with `No such file or directory` and broke CI on every open PR and on `main`. Searching from the checkout root matches the pattern already used in `test-with-openzeppelin-contracts.yml`.

### Known limitations

N/A