### PR TITLE
Remove dead code and stale comments in CLI tests

### DIFF
--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -674,7 +674,6 @@ impl Spec {
             ),
             (ScVal::Vec(Some(vec_)), ScSpecEntry::UdtUnionV0(union)) => {
                 let v = vec_.to_vec();
-                // let val = &v[0];
                 let (first, rest) = match v.split_at(1) {
                     ([first], []) => (first, None),
                     ([first], rest) => (first, Some(rest)),

--- a/cmd/crates/soroban-test/tests/it/message.rs
+++ b/cmd/crates/soroban-test/tests/it/message.rs
@@ -73,17 +73,6 @@ async fn sep_53_sign_message_and_verify_stdin() {
     let secret_key = "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW";
     let public_key = "GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L";
 
-    // sandbox
-    //     .new_assert_cmd("keys")
-    //     .args(["add", alias_secret, "--secret-key", secret_key])
-    //     .assert()
-    //     .success();
-    // sandbox
-    //     .new_assert_cmd("keys")
-    //     .args(["add", alias_public, "--public-key", public_key])
-    //     .assert()
-    //     .success();
-
     let output = sandbox
         .new_assert_cmd("message")
         .write_stdin(message)

--- a/cmd/crates/soroban-test/tests/it/util.rs
+++ b/cmd/crates/soroban-test/tests/it/util.rs
@@ -59,5 +59,3 @@ pub async fn invoke_custom(
 }
 
 pub const DEFAULT_CONTRACT_ID: &str = "CDR6QKTWZQYW6YUJ7UP7XXZRLWQPFRV6SWBLQS4ZQOSAF4BOUD77OO5Z";
-#[allow(dead_code)]
-pub const LOCAL_NETWORK_PASSPHRASE: &str = "Local Sandbox Stellar Network ; September 2022";


### PR DESCRIPTION
### What

Remove a few small leftovers of dead code in the CLI test crates.

### Why

`soroban-test/tests/it/util.rs` had an unused `LOCAL_NETWORK_PASSPHRASE` const already marked `#[allow(dead_code)]` (real usages import the one from `soroban_test` instead), `message.rs` had a commented-out block referencing undefined variables that wouldn't even compile if uncommented, and `soroban-spec-tools/src/lib.rs` had a single stray commented-out line.

### Known limitations

N/A