### PR TITLE
Follow SEP-41 argument names in token commands regardless of contract naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6207,6 +6207,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_token_renamed"
+version = "28.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "test_udt"
 version = "28.0.0"
 dependencies = [

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/token_renamed/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/token_renamed/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test_token_renamed"
+version = "28.0.0"
+description = "A SEP-41-shaped token whose parameters use non-canonical names"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/token_renamed/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/token_renamed/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+//! A minimal SEP-41-shaped token whose function *parameters* deliberately use
+//! non-canonical names — `balance(who)`, `transfer(sender, recipient, amt)`,
+//! `decimals()` — instead of SEP-41's `id`/`from`/`to`/`amount`. It exists so
+//! integration tests can prove `stellar token` maps values to the contract's
+//! parameters by position, not by name.
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol};
+
+const BALANCES: Symbol = symbol_short!("BAL");
+const DECIMALS: Symbol = symbol_short!("DEC");
+
+#[contract]
+pub struct Token;
+
+#[contractimpl]
+impl Token {
+    /// Set the token's decimals. Not part of SEP-41; test setup only.
+    pub fn init(env: Env, decimal_count: u32) {
+        env.storage().instance().set(&DECIMALS, &decimal_count);
+    }
+
+    /// Seed a balance. Not part of SEP-41; test setup only.
+    pub fn mint(env: Env, dest: Address, qty: i128) {
+        let mut balances = Self::balances(&env);
+        let current = balances.get(dest.clone()).unwrap_or(0);
+        balances.set(dest, current + qty);
+        env.storage().instance().set(&BALANCES, &balances);
+    }
+
+    /// SEP-41 `balance(id) -> i128`, with the parameter renamed to `who`.
+    pub fn balance(env: Env, who: Address) -> i128 {
+        Self::balances(&env).get(who).unwrap_or(0)
+    }
+
+    /// SEP-41 `decimals() -> u32`.
+    pub fn decimals(env: Env) -> u32 {
+        env.storage().instance().get(&DECIMALS).unwrap_or(0)
+    }
+
+    /// SEP-41 `transfer(from, to, amount)`, with the parameters renamed to
+    /// `sender`/`recipient`/`amt`. `sender` authorizes the move.
+    pub fn transfer(env: Env, sender: Address, recipient: Address, amt: i128) {
+        sender.require_auth();
+        let mut balances = Self::balances(&env);
+        let from_bal = balances.get(sender.clone()).unwrap_or(0);
+        balances.set(sender, from_bal - amt);
+        let to_bal = balances.get(recipient.clone()).unwrap_or(0);
+        balances.set(recipient, to_bal + amt);
+        env.storage().instance().set(&BALANCES, &balances);
+    }
+
+    fn balances(env: &Env) -> Map<Address, i128> {
+        env.storage()
+            .instance()
+            .get(&BALANCES)
+            .unwrap_or_else(|| Map::new(env))
+    }
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,4 +1,5 @@
 pub mod balance;
+pub mod renamed;
 pub mod transfer;
 
 use soroban_test::{AssertExt, TestEnv};

--- a/cmd/crates/soroban-test/tests/it/integration/token/renamed.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/renamed.rs
@@ -1,0 +1,105 @@
+//! `stellar token` against a SEP-41-shaped contract whose parameters use
+//! non-canonical names (`balance(who)`, `transfer(sender, recipient, amt)`).
+//! These prove the command maps values to the contract's parameters by
+//! position, not by name — the old flag-name mapping would fail here.
+use soroban_test::{AssertExt, TestEnv, Wasm};
+
+use crate::integration::util::{deploy_contract, new_account, test_address, DeployOptions};
+
+const TOKEN_RENAMED: &Wasm = &Wasm::Custom("test-wasms", "test_token_renamed");
+
+/// Deploy the renamed-arg token, set decimals to 7, and mint `qty` to `test`.
+/// Returns the contract id and `test`'s address.
+async fn deploy_and_seed(sandbox: &TestEnv, qty: i128) -> (String, String) {
+    let id = deploy_contract(sandbox, TOKEN_RENAMED, DeployOptions::default()).await;
+    let test = test_address(sandbox);
+
+    sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--id",
+            &id,
+            "--source-account",
+            "test",
+            "--",
+            "init",
+            "--decimal_count",
+            "7",
+        ])
+        .assert()
+        .success();
+
+    sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--id",
+            &id,
+            "--source-account",
+            "test",
+            "--",
+            "mint",
+            "--dest",
+            &test,
+            "--qty",
+            &qty.to_string(),
+        ])
+        .assert()
+        .success();
+
+    (id, test)
+}
+
+/// Read a balance through the `stellar token balance` command under test.
+fn token_balance(sandbox: &TestEnv, id: &str, account: &str) -> String {
+    sandbox
+        .new_assert_cmd("token")
+        .args(["balance", "--id", id, "--account", account])
+        .assert()
+        .success()
+        .stdout_as_str()
+        .trim()
+        .to_string()
+}
+
+#[tokio::test]
+async fn transfer_maps_renamed_params_by_position() {
+    let sandbox = &TestEnv::new();
+    let (id, _test) = deploy_and_seed(sandbox, 1_000_000).await;
+    let recipient = new_account(sandbox, "recipient");
+
+    // The contract's `transfer` params are sender/recipient/amt, not
+    // from/to/amount — this only works if values map by position.
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "transfer", "--id", &id, "--to", &recipient, "--amount", "400", "--from", "test",
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(token_balance(sandbox, &id, &recipient), "400");
+}
+
+#[tokio::test]
+async fn balance_reads_renamed_param_and_applies_decimals() {
+    let sandbox = &TestEnv::new();
+    let (id, test) = deploy_and_seed(sandbox, 1_000_000).await;
+
+    // `balance`'s param is `who`, not `id`.
+    assert_eq!(token_balance(sandbox, &id, &test), "1000000");
+
+    // `--decimal` runs a second `decimals()` call (no args) and scales the raw
+    // amount: 1_000_000 with 7 decimals renders as 0.1.
+    let decimal = sandbox
+        .new_assert_cmd("token")
+        .args(["balance", "--id", &id, "--account", &test, "--decimal"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    assert!(
+        decimal.trim().starts_with("0.1"),
+        "expected a decimal balance starting with 0.1, got: {decimal:?}"
+    );
+}

--- a/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
+++ b/cmd/soroban-cli/src/commands/contract/arg_parsing.rs
@@ -63,6 +63,12 @@ pub enum Error {
     },
     #[error("argument count ({current}) surpasses maximum allowed count ({maximum})\n\nSuggestions:\n- Reduce the number of arguments\n- Consider using file-based arguments for complex data\n- Check if some arguments can be combined")]
     MaxNumberOfArgumentsReached { current: usize, maximum: usize },
+    #[error("function '{function}' expects {expected} argument(s), but {actual} were provided")]
+    ArgumentArityMismatch {
+        function: String,
+        expected: usize,
+        actual: usize,
+    },
     #[error("Unsupported address type '{address}'\n\nSupported formats:\n- Account addresses: G... (starts with G)\n- Contract addresses: C... (starts with C)\n- Muxed accounts: M... (starts with M)\n- Identity names: alice, bob, etc.\n\nReceived: '{address}'")]
     UnsupportedScAddress { address: String },
     #[error("Duplicate map key '{key}' after alias resolution\n\nMultiple input keys resolved to the same address — likely an alias passed alongside its strkey, or two aliases pointing to the same identity.")]
@@ -100,6 +106,47 @@ pub fn build_host_function_parameters(
     config: &config::Args,
 ) -> Result<HostFunctionParameters, Error> {
     build_host_function_parameters_with_filter(contract_id, slop, spec_entries, config, true)
+}
+
+/// Build invocation parameters by mapping `ordered_values` to the contract
+/// function's parameters **by position**, using each parameter's declared type
+/// only for parsing — never its name.
+///
+/// This is what lets `stellar token` proxy SEP-41 calls (`transfer`, `balance`,
+/// …) regardless of what the deployed contract names its parameters: SEP-41
+/// fixes the function name and argument order, so callers supply values in
+/// canonical order and this maps them onto whatever the contract's parameters
+/// happen to be called.
+pub fn build_host_function_parameters_by_position(
+    contract_id: &stellar_strkey::Contract,
+    function_name: &str,
+    ordered_values: &[String],
+    spec_entries: &[ScSpecEntry],
+    config: &config::Args,
+) -> Result<HostFunctionParameters, Error> {
+    let spec = Spec(Some(spec_entries.to_vec()));
+    let func = get_function_spec(&spec, function_name)?;
+
+    // Positional mapping requires the arity to match exactly: every parameter
+    // gets a value and no value is left over. A contract whose function deviates
+    // from the SEP-41 signature fails loudly here rather than producing a
+    // malformed `InvokeContractArgs`.
+    if ordered_values.len() != func.inputs.len() {
+        return Err(Error::ArgumentArityMismatch {
+            function: function_name.to_string(),
+            expected: func.inputs.len(),
+            actual: ordered_values.len(),
+        });
+    }
+
+    let mut parsed_args = Vec::with_capacity(func.inputs.len());
+    let mut signers = Vec::<Signer>::new();
+    for (input, value) in func.inputs.iter().zip(ordered_values.iter()) {
+        parse_positional_value(input, value, &spec, config, &mut signers, &mut parsed_args)?;
+    }
+
+    let invoke_args = build_invoke_contract_args(contract_id, function_name, parsed_args)?;
+    Ok((function_name.to_string(), spec, invoke_args, signers))
 }
 
 pub fn build_constructor_parameters(
@@ -225,28 +272,7 @@ fn parse_single_argument(
             }
         };
 
-        // Collect a signer up front for top-level address args, so the
-        // alias-named identity can also sign the transaction. Alias-to-strkey
-        // resolution itself happens inside parse_argument_with_validation,
-        // which uniformly handles top-level and nested Address positions.
-        if matches!(
-            input.type_,
-            ScSpecTypeDef::Address | ScSpecTypeDef::MuxedAddress
-        ) {
-            let trimmed_s = s.trim_matches('"');
-            if let Some(signer) = resolve_signer(trimmed_s, config) {
-                signers.push(signer);
-            }
-        }
-
-        parsed_args.push(parse_argument_with_validation(
-            &name,
-            &s,
-            &input.type_,
-            spec,
-            config,
-        )?);
-        Ok(())
+        parse_positional_value(input, &s, spec, config, signers, parsed_args)
     } else if matches!(input.type_, ScSpecTypeDef::Option(_)) {
         parsed_args.push(ScVal::Void);
         Ok(())
@@ -266,6 +292,45 @@ fn parse_single_argument(
             expected_type: expected_type_name,
         })
     }
+}
+
+/// Parse a single already-extracted string `value` for `input` and push the
+/// resulting `ScVal`, collecting a signer for top-level `Address`/`MuxedAddress`
+/// positions. Shared by the flag-based path (`parse_single_argument`) and the
+/// by-position path so alias resolution, JSON validation, and signer collection
+/// stay identical across both.
+fn parse_positional_value(
+    input: &stellar_xdr::ScSpecFunctionInputV0,
+    value: &str,
+    spec: &Spec,
+    config: &config::Args,
+    signers: &mut Vec<Signer>,
+    parsed_args: &mut Vec<ScVal>,
+) -> Result<(), Error> {
+    let name = sanitize(&input.name.to_utf8_string_lossy());
+
+    // Collect a signer up front for top-level address args, so the
+    // alias-named identity can also sign the transaction. Alias-to-strkey
+    // resolution itself happens inside parse_argument_with_validation,
+    // which uniformly handles top-level and nested Address positions.
+    if matches!(
+        input.type_,
+        ScSpecTypeDef::Address | ScSpecTypeDef::MuxedAddress
+    ) {
+        let trimmed = value.trim_matches('"');
+        if let Some(signer) = resolve_signer(trimmed, config) {
+            signers.push(signer);
+        }
+    }
+
+    parsed_args.push(parse_argument_with_validation(
+        &name,
+        value,
+        &input.type_,
+        spec,
+        config,
+    )?);
+    Ok(())
 }
 
 fn parse_file_argument(
@@ -1499,6 +1564,152 @@ mod tests {
             matches!(err, Error::Config(_) | Error::ScAddress(_)),
             "expected alias-resolution error, got {err:?}"
         );
+    }
+
+    // A second valid account strkey, distinct from TEST_G_ADDRESS, so positional
+    // ordering can be checked with two different addresses.
+    const TEST_G_ADDRESS_2: &str = "GAF4UUODFGAAMYRTF5QKUZCCZPXF3S4PRU5NS2BBRVJGX4WLRVI4ZI4Z";
+
+    fn function_spec(name: &str, inputs: &[(&str, ScSpecTypeDef)]) -> Vec<ScSpecEntry> {
+        use stellar_xdr::{ScSpecFunctionInputV0, ScSpecFunctionV0, ScSymbol};
+        let inputs_xdr: Vec<ScSpecFunctionInputV0> = inputs
+            .iter()
+            .map(|(n, t)| ScSpecFunctionInputV0 {
+                doc: "".try_into().unwrap(),
+                name: (*n).try_into().unwrap(),
+                type_: t.clone(),
+            })
+            .collect();
+        vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+            doc: "".try_into().unwrap(),
+            name: ScSymbol(name.try_into().unwrap()),
+            inputs: inputs_xdr.try_into().unwrap(),
+            outputs: vec![].try_into().unwrap(),
+        })]
+    }
+
+    // The whole point of the by-position path: the contract may name SEP-41
+    // `transfer`'s params anything, yet the values map to positions by index and
+    // are parsed against each position's declared type.
+    #[test]
+    fn by_position_maps_values_to_renamed_params_in_order() {
+        let spec_entries = function_spec(
+            "transfer",
+            &[
+                ("sender", ScSpecTypeDef::Address),
+                ("recipient", ScSpecTypeDef::Address),
+                ("amt", ScSpecTypeDef::I128),
+            ],
+        );
+        let contract_id = stellar_strkey::Contract([0u8; 32]);
+        let config = crate::config::Args::default();
+        let values = vec![
+            TEST_G_ADDRESS.to_string(),
+            TEST_G_ADDRESS_2.to_string(),
+            "1000".to_string(),
+        ];
+
+        let (function, _spec, invoke_args, _signers) = build_host_function_parameters_by_position(
+            &contract_id,
+            "transfer",
+            &values,
+            &spec_entries,
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(function, "transfer");
+        assert_eq!(invoke_args.args.len(), 3);
+        // Position 0/1 are addresses, position 2 is the i128 amount — proving the
+        // values landed at the right index under each position's type.
+        let expect_addr = |v: &str| {
+            let sc: UnresolvedScAddress = v.parse().unwrap();
+            let UnresolvedScAddress::Resolved(addr) = sc else {
+                panic!("expected resolved address");
+            };
+            ScVal::Address(addr)
+        };
+        assert_eq!(invoke_args.args[0], expect_addr(TEST_G_ADDRESS));
+        assert_eq!(invoke_args.args[1], expect_addr(TEST_G_ADDRESS_2));
+        assert_eq!(
+            invoke_args.args[2],
+            ScVal::I128(xdr::Int128Parts { hi: 0, lo: 1000 })
+        );
+    }
+
+    // Distinct type per position: if mapping were anything but positional, the
+    // U32 slot would receive an address string and fail to parse.
+    #[test]
+    fn by_position_maps_distinct_types_by_index() {
+        let spec_entries = function_spec(
+            "f",
+            &[
+                ("a", ScSpecTypeDef::U32),
+                ("b", ScSpecTypeDef::Address),
+                ("c", ScSpecTypeDef::I128),
+            ],
+        );
+        let contract_id = stellar_strkey::Contract([0u8; 32]);
+        let config = crate::config::Args::default();
+        let values = vec![
+            "7".to_string(),
+            TEST_G_ADDRESS.to_string(),
+            "42".to_string(),
+        ];
+
+        let (_function, _spec, invoke_args, _signers) = build_host_function_parameters_by_position(
+            &contract_id,
+            "f",
+            &values,
+            &spec_entries,
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(invoke_args.args[0], ScVal::U32(7));
+        assert!(matches!(invoke_args.args[1], ScVal::Address(_)));
+        assert_eq!(
+            invoke_args.args[2],
+            ScVal::I128(xdr::Int128Parts { hi: 0, lo: 42 })
+        );
+    }
+
+    #[test]
+    fn by_position_rejects_arity_mismatch() {
+        let spec_entries = function_spec(
+            "transfer",
+            &[
+                ("sender", ScSpecTypeDef::Address),
+                ("recipient", ScSpecTypeDef::Address),
+                ("amt", ScSpecTypeDef::I128),
+            ],
+        );
+        let contract_id = stellar_strkey::Contract([0u8; 32]);
+        let config = crate::config::Args::default();
+        // Only two values for a three-parameter function.
+        let values = vec![TEST_G_ADDRESS.to_string(), "1000".to_string()];
+
+        let result = build_host_function_parameters_by_position(
+            &contract_id,
+            "transfer",
+            &values,
+            &spec_entries,
+            &config,
+        );
+
+        match result {
+            Err(Error::ArgumentArityMismatch {
+                function,
+                expected,
+                actual,
+            }) => {
+                assert_eq!(function, "transfer");
+                assert_eq!(expected, 3);
+                assert_eq!(actual, 2);
+            }
+            Err(e) => panic!("expected arity mismatch, got {e:?}"),
+            Ok(_) => panic!("expected arity mismatch, got Ok"),
+        }
     }
 
     /// Mirrors `stellar contract invoke`: Spec::from_wasm -> build_clap_command -> render_long_help.

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -21,7 +21,10 @@ use crate::utils::XDR_DEPTH_LIMIT;
 use crate::{
     assembled::simulate_and_assemble_transaction,
     commands::{
-        contract::arg_parsing::{build_host_function_parameters, output_to_string},
+        contract::arg_parsing::{
+            build_host_function_parameters, build_host_function_parameters_by_position,
+            output_to_string,
+        },
         global,
         tx::fetch::fee,
         txn_result::{TxnEnvelopeResult, TxnResult},
@@ -61,6 +64,13 @@ pub struct Cmd {
     #[arg(last = true, id = "CONTRACT_FN_AND_ARGS")]
     pub slop: Vec<OsString>,
 
+    /// When set, invoke this function with these already-resolved values mapped
+    /// to the contract's parameters by position instead of parsing `slop` by
+    /// name. Used by `stellar token` so a SEP-41 call works regardless of what
+    /// the contract names its parameters.
+    #[arg(skip)]
+    pub invocation: Option<PositionalInvocation>,
+
     #[command(flatten)]
     pub config: config::Args,
 
@@ -77,6 +87,16 @@ pub struct Cmd {
     /// Build the transaction and only write the base64 xdr to stdout
     #[arg(long, help_heading = HEADING_TRANSACTION)]
     pub build_only: bool,
+}
+
+/// A request to invoke a named function with values mapped to the contract's
+/// parameters by position rather than by name.
+#[derive(Debug, Clone)]
+pub struct PositionalInvocation {
+    /// The contract function to call (matched by name).
+    pub function: String,
+    /// Already-resolved argument values in the function's parameter order.
+    pub args: Vec<String>,
 }
 
 impl FromStr for Cmd {
@@ -302,7 +322,17 @@ impl Cmd {
 
         if let Some(spec_entries) = &spec_entries {
             // For testing wasm arg parsing
-            build_host_function_parameters(&contract_id, &self.slop, spec_entries, config)?;
+            if let Some(inv) = &self.invocation {
+                build_host_function_parameters_by_position(
+                    &contract_id,
+                    &inv.function,
+                    &inv.args,
+                    spec_entries,
+                    config,
+                )?;
+            } else {
+                build_host_function_parameters(&contract_id, &self.slop, spec_entries, config)?;
+            }
         }
 
         let client = network.rpc_client()?;
@@ -326,8 +356,17 @@ impl Cmd {
         .await
         .map_err(Error::from)?;
 
-        let params =
-            build_host_function_parameters(&contract_id, &self.slop, &spec_entries, config)?;
+        let params = if let Some(inv) = &self.invocation {
+            build_host_function_parameters_by_position(
+                &contract_id,
+                &inv.function,
+                &inv.args,
+                &spec_entries,
+                config,
+            )?
+        } else {
+            build_host_function_parameters(&contract_id, &self.slop, &spec_entries, config)?
+        };
 
         let (function, spec, host_function_params, signers) = params;
 

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -1,5 +1,9 @@
 use crate::{
-    commands::contract::invoke, config::token::ResolvedToken, get_spec, output::Format, rpc,
+    commands::{contract::invoke, txn_result::TxnResult},
+    config::{self, token::ResolvedToken, UnresolvedContract},
+    get_spec,
+    output::Format,
+    rpc,
 };
 
 /// Output format shared by the `stellar token` subcommands.
@@ -45,6 +49,36 @@ impl Error {
             Error::ContractNotFound(_) => "contract_not_found",
         }
     }
+}
+
+/// Invoke a token `function` by SEP-41 canonical position: `args` are supplied
+/// in the function's parameter order and mapped onto the contract's parameters
+/// by index, so the call works regardless of what the contract names them.
+///
+/// Returns the raw `invoke::Error` so callers keep their own
+/// `not_deployed_error` translation; a `None` result means `--build-only`, which
+/// the token commands never set.
+pub async fn invoke_by_position(
+    config: &config::Args,
+    quiet: bool,
+    no_cache: bool,
+    token: &ResolvedToken,
+    function: &str,
+    args: Vec<String>,
+    send: invoke::Send,
+) -> Result<TxnResult<invoke::InvokeReceipt>, invoke::Error> {
+    let cmd = invoke::Cmd {
+        contract_id: UnresolvedContract::Resolved(token.contract_id),
+        invocation: Some(invoke::PositionalInvocation {
+            function: function.to_string(),
+            args,
+        }),
+        config: config.clone(),
+        send,
+        ..Default::default()
+    };
+
+    cmd.execute_with_receipt(config, quiet, no_cache).await
 }
 
 /// If `err` is a "contract not found" failure raised while fetching the contract

--- a/cmd/soroban-cli/src/commands/token/balance.rs
+++ b/cmd/soroban-cli/src/commands/token/balance.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsString;
-
 use clap::Parser;
 
 use crate::{
@@ -11,7 +9,7 @@ use crate::{
     config::{
         self, locator, network, sign_with,
         token::{ResolvedToken, UnresolvedToken},
-        UnresolvedContract, UnresolvedScAddress,
+        UnresolvedScAddress,
     },
     fixed_point::FixedPoint,
     output::Output,
@@ -130,12 +128,8 @@ impl Cmd {
                 quiet,
                 global_args.no_cache,
                 &token,
-                vec![
-                    OsString::from("balance"),
-                    OsString::from("--id"),
-                    OsString::from(&account),
-                ],
                 "balance",
+                vec![account],
             )
             .await?;
 
@@ -149,8 +143,8 @@ impl Cmd {
                     quiet,
                     global_args.no_cache,
                     &token,
-                    vec![OsString::from("decimals")],
                     "decimals",
+                    vec![],
                 )
                 .await?;
             (FixedPoint::new(raw, decimals).to_string(), Some(decimals))
@@ -164,50 +158,56 @@ impl Cmd {
         Ok(())
     }
 
-    /// Invoke a read-only token function and return its decoded output string.
+    /// Invoke a read-only token function by SEP-41 position and return its
+    /// decoded output string.
     async fn read(
         &self,
         config: &config::Args,
         quiet: bool,
         no_cache: bool,
         token: &ResolvedToken,
-        slop: Vec<OsString>,
+        function: &str,
+        args: Vec<String>,
     ) -> Result<String, Error> {
-        let invoke_cmd = invoke::Cmd {
-            contract_id: UnresolvedContract::Resolved(token.contract_id),
-            slop,
-            config: config.clone(),
-            send: invoke::Send::No,
-            ..Default::default()
-        };
-
-        let receipt = invoke_cmd
-            .execute_with_receipt(config, quiet, no_cache)
-            .await
-            .map_err(|e| args::not_deployed_error(token, &e).map_or(Error::Invoke(e), Error::Args))?
-            .into_result();
+        let receipt = args::invoke_by_position(
+            config,
+            quiet,
+            no_cache,
+            token,
+            function,
+            args,
+            invoke::Send::No,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
 
         Ok(receipt.map(|r| r.output).unwrap_or_default())
     }
 
     /// Invoke a read-only token function, then parse its decoded output as `T`.
-    /// `what` labels the value in a `ParseResult` error if parsing fails.
+    /// `function` also labels the value in a `ParseResult` error if parsing fails.
     async fn read_parsed<T: std::str::FromStr>(
         &self,
         config: &config::Args,
         quiet: bool,
         no_cache: bool,
         token: &ResolvedToken,
-        slop: Vec<OsString>,
-        what: &'static str,
+        function: &'static str,
+        args: Vec<String>,
     ) -> Result<T, Error> {
-        let out = self.read(config, quiet, no_cache, token, slop).await?;
+        let out = self
+            .read(config, quiet, no_cache, token, function, args)
+            .await?;
         // A 128-bit balance comes back JSON-encoded as a quoted string (it can't
         // fit a JSON number), while `decimals` (u32) comes back bare; strip any
         // surrounding quotes so both parse straight into `T`.
         out.trim()
             .trim_matches('"')
             .parse()
-            .map_err(|_| Error::ParseResult { what, value: out })
+            .map_err(|_| Error::ParseResult {
+                what: function,
+                value: out,
+            })
     }
 }

--- a/cmd/soroban-cli/src/commands/token/transfer.rs
+++ b/cmd/soroban-cli/src/commands/token/transfer.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsString;
-
 use clap::Parser;
 
 use crate::{
@@ -9,8 +7,8 @@ use crate::{
         token::args::{self, OutputFormat},
     },
     config::{
-        self, locator, network, sign_with, token::UnresolvedToken, UnresolvedContract,
-        UnresolvedMuxedAccount, UnresolvedScAddress,
+        self, locator, network, sign_with, token::UnresolvedToken, UnresolvedMuxedAccount,
+        UnresolvedScAddress,
     },
     output::Output,
 };
@@ -167,31 +165,24 @@ impl Cmd {
             .to_string();
         let amount = self.amount.to_string();
 
-        let slop: Vec<OsString> = [
-            "transfer", "--from", &from, "--to", &to, "--amount", &amount,
-        ]
-        .into_iter()
-        .map(OsString::from)
-        .collect();
-
-        let invoke_cmd = invoke::Cmd {
-            contract_id: UnresolvedContract::Resolved(token.contract_id),
-            slop,
-            config: config.clone(),
-            // A transfer always intends to submit. Force `Send::Yes` so a token
-            // whose `transfer` records no writes/events/auth can't be classified
-            // read-only and silently exit 0 without ever moving funds.
-            send: invoke::Send::Yes,
-            ..Default::default()
-        };
-
-        let receipt = invoke_cmd
-            .execute_with_receipt(&config, quiet, global_args.no_cache)
-            .await
-            .map_err(|e| {
-                args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args)
-            })?
-            .into_result();
+        // SEP-41 `transfer(from, to, amount)` — supply the values in that order
+        // and let the contract's parameters be matched by position, so a token
+        // that names them anything still works. A transfer always intends to
+        // submit, so force `Send::Yes`: a token whose `transfer` records no
+        // writes/events/auth can't be classified read-only and silently exit 0
+        // without ever moving funds.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "transfer",
+            vec![from, to, amount],
+            invoke::Send::Yes,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
 
         // `transfer` always writes, so the invocation is submitted rather than
         // resolved as a build-only transaction; a missing receipt would mean


### PR DESCRIPTION
### What

`stellar token balance` and `stellar token transfer` now map their arguments to the contract **by position** instead of by the contract's parameter names. Callers supply values in SEP-41's canonical order (`transfer(from, to, amount)`, `balance(id)`, `decimals()`) and the contract's actual parameter names no longer matter.

### Why

The commands used to build an argv like `transfer --from … --to … --amount …` and let the generic invoke parser match those flags to the contract spec's parameter names. That only worked when the deployed contract literally named its parameters `from`/`to`/`amount`/`id`. A SEP-41-compliant contract can name them anything (`sender`, `recipient`, `amt`, `addr`, …), so the commands broke against those contracts. SEP-41 fixes the function names and argument order, not the parameter names — so mapping by position is the correct model. Doing this now keeps the two existing commands correct before more token subcommands (approve, allowance, mint, burn, …) are built on the same pattern.

### Known limitations

Positional mapping requires the contract function's arity to match the SEP-41 signature exactly; a deviating arity fails with a clear error rather than sending a malformed call. Attacker-influenceable spec parameter names are sanitized before appearing in any error message, consistent with the existing invoke path.