### PR TITLE
Add `stellar token name` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1918,6 +1918,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 
 - `transfer` — Transfer tokens from one account to another
 - `balance` — Read the token balance of an account or contract
+- `name` — Read the token's name (SEP-41 metadata)
 
 ## `stellar token transfer`
 
@@ -1974,6 +1975,35 @@ Read the token balance of an account or contract
 - `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
 - `--account <ACCOUNT>` — Account or contract whose balance to read
 - `--decimal` — Format the balance as a decimal using the token's `decimals`, instead of the raw smallest unit (stroops for a Stellar Asset Contract)
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON receipt
+  - `json-formatted`: Formatted (multiline) JSON receipt
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+
+## `stellar token name`
+
+Read the token's name (SEP-41 metadata)
+
+**Usage:** `stellar token name [OPTIONS] --id <ID>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
 - `--output <OUTPUT>` — Format of the output
 
   Default value: `text`
@@ -4503,6 +4533,11 @@ Generate arbitrary XDR values
   Default value: `single-base64`
 
   Possible values: `single`, `single-base64`, `json`, `json-formatted`, `text`
+
+- `--hint <HINT>` — Keep generating values until the value's JSON representation contains this string. Useful for hinting toward a particular union/enum variant or sub-value. Repeat the flag to require several substrings; all of them must be present in the same value
+- `--hint-attempts <HINT_ATTEMPTS>` — Maximum number of generation attempts when --hint is set before giving up
+
+  Default value: `20000`
 
 ## `stellar xdr xfile`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1942,8 +1942,8 @@ Transfer tokens from one account to another
 
   Possible values:
   - `text`: Human-readable text
-  - `json`: Compact, single-line JSON receipt
-  - `json-formatted`: Formatted (multiline) JSON receipt
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
 
 ###### **RPC Options:**
 
@@ -1981,8 +1981,8 @@ Read the token balance of an account or contract
 
   Possible values:
   - `text`: Human-readable text
-  - `json`: Compact, single-line JSON receipt
-  - `json-formatted`: Formatted (multiline) JSON receipt
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
 
 ###### **RPC Options:**
 
@@ -2010,8 +2010,8 @@ Read the token's name (SEP-41 metadata)
 
   Possible values:
   - `text`: Human-readable text
-  - `json`: Compact, single-line JSON receipt
-  - `json-formatted`: Formatted (multiline) JSON receipt
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
 
 ###### **RPC Options:**
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,4 +1,5 @@
 pub mod balance;
+pub mod name;
 pub mod renamed;
 pub mod transfer;
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/name.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/name.rs
@@ -1,0 +1,57 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{token::deploy_sac, util::new_account};
+
+/// Run `stellar token name --id <id> --output json` and return the parsed value.
+fn name_json(sandbox: &TestEnv, id: &str) -> Value {
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(["name", "--id", id, "--output", "json"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    serde_json::from_str(&stdout).unwrap()
+}
+
+#[tokio::test]
+async fn name_returns_native_metadata() {
+    let sandbox = &TestEnv::new();
+    deploy_sac(sandbox, "native", "test");
+
+    let value = name_json(sandbox, "native");
+    assert_eq!(value["name"], "native", "native SAC name, got: {value}");
+}
+
+#[tokio::test]
+async fn name_returns_issued_asset_metadata() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+    deploy_sac(sandbox, &asset, "issuer");
+
+    // A SAC's `name()` metadata for an issued asset is its `CODE:ISSUER` string.
+    let value = name_json(sandbox, &asset);
+    assert_eq!(value["name"], asset, "issued-asset SAC name, got: {value}");
+}
+
+#[tokio::test]
+async fn name_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed for this asset → structured deploy-pointer error, and in
+    // JSON mode the error carries a machine-readable `type` discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(["name", "--id", &asset, "--output", "json"])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -144,6 +144,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Network(network::Cmd::Settings(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Transfer(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Balance(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Name(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -12,9 +12,9 @@ pub enum OutputFormat {
     /// Human-readable text.
     #[default]
     Text,
-    /// Compact, single-line JSON receipt.
+    /// Compact, single-line JSON output.
     Json,
-    /// Formatted (multiline) JSON receipt.
+    /// Formatted (multiline) JSON output.
     JsonFormatted,
 }
 

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod balance;
+pub mod name;
 pub mod transfer;
 
 use crate::commands::global;
@@ -11,6 +12,9 @@ pub enum Cmd {
 
     /// Read the token balance of an account or contract
     Balance(balance::Cmd),
+
+    /// Read the token's name (SEP-41 metadata)
+    Name(name::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -19,6 +23,8 @@ pub enum Error {
     Transfer(#[from] transfer::Error),
     #[error(transparent)]
     Balance(#[from] balance::Error),
+    #[error(transparent)]
+    Name(#[from] name::Error),
 }
 
 impl Error {
@@ -28,6 +34,7 @@ impl Error {
         match self {
             Error::Transfer(e) => e.error_type(),
             Error::Balance(e) => e.error_type(),
+            Error::Name(e) => e.error_type(),
         }
     }
 }
@@ -37,6 +44,7 @@ impl Cmd {
         match self {
             Cmd::Transfer(cmd) => cmd.run(global_args).await?,
             Cmd::Balance(cmd) => cmd.run(global_args).await?,
+            Cmd::Name(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/token/name.rs
+++ b/cmd/soroban-cli/src/commands/token/name.rs
@@ -107,10 +107,16 @@ impl Cmd {
         .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
         .into_result();
 
-        // The decoded `name` comes back JSON-encoded as a quoted string; strip
-        // the surrounding quotes to recover the plain metadata value.
-        let out = receipt.map(|r| r.output).unwrap_or_default();
-        let name = out.trim().trim_matches('"').to_string();
+        // The invoke pipeline renders the `String` return value as JSON, so
+        // decode it back through serde rather than trimming quotes by hand —
+        // that recovers a name containing quotes, backslashes, or control
+        // characters intact instead of leaking the escape sequences. `name()`
+        // always returns a value on a successful read, so a missing receipt
+        // (build-only, which reads never set) decodes as an empty name.
+        let name = match receipt {
+            Some(r) => serde_json::from_str::<String>(r.output.trim())?,
+            None => String::new(),
+        };
 
         output.readable(|_| println!("{name}"));
         output.json_value(&NameResult { name })?;

--- a/cmd/soroban-cli/src/commands/token/name.rs
+++ b/cmd/soroban-cli/src/commands/token/name.rs
@@ -118,7 +118,11 @@ impl Cmd {
             None => String::new(),
         };
 
-        output.readable(|_| println!("{name}"));
+        // The name is contract-controlled data, so escape any ANSI/control
+        // sequences before writing it to the terminal — matching how other
+        // contract-derived output is rendered (see `log::auth`/`log::event`).
+        // JSON output keeps the exact value: serde re-escapes it safely.
+        output.readable(|_| println!("{}", soroban_spec_tools::sanitize(&name)));
         output.json_value(&NameResult { name })?;
 
         Ok(())

--- a/cmd/soroban-cli/src/commands/token/name.rs
+++ b/cmd/soroban-cli/src/commands/token/name.rs
@@ -1,0 +1,120 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{self, locator, network, sign_with, token::UnresolvedToken},
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to query: a contract id or alias, `native`, or a classic asset
+    /// as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+        }
+    }
+}
+
+/// The machine-readable result of a `name` query.
+#[derive(Debug, serde::Serialize)]
+struct NameResult {
+    /// The token's SEP-41 `name` metadata.
+    name: String,
+}
+
+impl Cmd {
+    /// A read-only config: `name` is resolved by simulation, so no source
+    /// account, signing options, or fees are needed.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: config::UnresolvedMuxedAccount::default(),
+            locator: self.locator.clone(),
+            sign_with: sign_with::Args::default(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // Read-only calls still log through the invoke pipeline's Print; keep it
+        // quiet in JSON mode so stdout stays pure JSON.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+
+        // SEP-41 `name()` takes no arguments and returns a `String`.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "name",
+            vec![],
+            invoke::Send::No,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        // The decoded `name` comes back JSON-encoded as a quoted string; strip
+        // the surrounding quotes to recover the plain metadata value.
+        let out = receipt.map(|r| r.output).unwrap_or_default();
+        let name = out.trim().trim_matches('"').to_string();
+
+        output.readable(|_| println!("{name}"));
+        output.json_value(&NameResult { name })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### What

Adds `stellar token name`, a read-only subcommand returning a token's SEP-41 `name()` metadata. Resolves a token by `--id` (contract id, alias, `native`, or `CODE:ISSUER`) and prints the name as text or JSON.

### Why

Part of #2620 (typed SEP-41 + SAC client), following `transfer` and `balance`. First of the per-command PRs; a thin wrapper over `contract invoke` reusing `args::invoke_by_position` and `args::not_deployed_error`.

### Known limitations

N/A