### PR TITLE
Add `stellar token symbol` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -2040,8 +2040,8 @@ Read the token's symbol (SEP-41 metadata)
 
   Possible values:
   - `text`: Human-readable text
-  - `json`: Compact, single-line JSON receipt
-  - `json-formatted`: Formatted (multiline) JSON receipt
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
 
 ###### **RPC Options:**
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1919,6 +1919,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 - `transfer` — Transfer tokens from one account to another
 - `balance` — Read the token balance of an account or contract
 - `name` — Read the token's name (SEP-41 metadata)
+- `symbol` — Read the token's symbol (SEP-41 metadata)
 
 ## `stellar token transfer`
 
@@ -2012,6 +2013,35 @@ Read the token's name (SEP-41 metadata)
   - `text`: Human-readable text
   - `json`: Compact, single-line JSON output
   - `json-formatted`: Formatted (multiline) JSON output
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+
+## `stellar token symbol`
+
+Read the token's symbol (SEP-41 metadata)
+
+**Usage:** `stellar token symbol [OPTIONS] --id <ID>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON receipt
+  - `json-formatted`: Formatted (multiline) JSON receipt
 
 ###### **RPC Options:**
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,6 +1,7 @@
 pub mod balance;
 pub mod name;
 pub mod renamed;
+pub mod symbol;
 pub mod transfer;
 
 use soroban_test::{AssertExt, TestEnv};

--- a/cmd/crates/soroban-test/tests/it/integration/token/symbol.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/symbol.rs
@@ -1,0 +1,60 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{token::deploy_sac, util::new_account};
+
+/// Run `stellar token symbol --id <id> --output json` and return the parsed value.
+fn symbol_json(sandbox: &TestEnv, id: &str) -> Value {
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(["symbol", "--id", id, "--output", "json"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    serde_json::from_str(&stdout).unwrap()
+}
+
+#[tokio::test]
+async fn symbol_returns_native_metadata() {
+    let sandbox = &TestEnv::new();
+    deploy_sac(sandbox, "native", "test");
+
+    let value = symbol_json(sandbox, "native");
+    assert_eq!(value["symbol"], "native", "native SAC symbol, got: {value}");
+}
+
+#[tokio::test]
+async fn symbol_returns_issued_asset_metadata() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+    deploy_sac(sandbox, &asset, "issuer");
+
+    // A SAC's `symbol()` metadata for an issued asset is its asset code.
+    let value = symbol_json(sandbox, &asset);
+    assert_eq!(
+        value["symbol"], "USDC",
+        "issued-asset SAC symbol, got: {value}"
+    );
+}
+
+#[tokio::test]
+async fn symbol_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed for this asset → structured deploy-pointer error, and in
+    // JSON mode the error carries a machine-readable `type` discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(["symbol", "--id", &asset, "--output", "json"])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -145,6 +145,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Token(token::Cmd::Transfer(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Balance(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Name(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Symbol(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -1,6 +1,7 @@
 pub mod args;
 pub mod balance;
 pub mod name;
+pub mod symbol;
 pub mod transfer;
 
 use crate::commands::global;
@@ -15,6 +16,9 @@ pub enum Cmd {
 
     /// Read the token's name (SEP-41 metadata)
     Name(name::Cmd),
+
+    /// Read the token's symbol (SEP-41 metadata)
+    Symbol(symbol::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -25,6 +29,8 @@ pub enum Error {
     Balance(#[from] balance::Error),
     #[error(transparent)]
     Name(#[from] name::Error),
+    #[error(transparent)]
+    Symbol(#[from] symbol::Error),
 }
 
 impl Error {
@@ -35,6 +41,7 @@ impl Error {
             Error::Transfer(e) => e.error_type(),
             Error::Balance(e) => e.error_type(),
             Error::Name(e) => e.error_type(),
+            Error::Symbol(e) => e.error_type(),
         }
     }
 }
@@ -45,6 +52,7 @@ impl Cmd {
             Cmd::Transfer(cmd) => cmd.run(global_args).await?,
             Cmd::Balance(cmd) => cmd.run(global_args).await?,
             Cmd::Name(cmd) => cmd.run(global_args).await?,
+            Cmd::Symbol(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/token/symbol.rs
+++ b/cmd/soroban-cli/src/commands/token/symbol.rs
@@ -107,12 +107,22 @@ impl Cmd {
         .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
         .into_result();
 
-        // The decoded `symbol` comes back JSON-encoded as a quoted string; strip
-        // the surrounding quotes to recover the plain metadata value.
-        let out = receipt.map(|r| r.output).unwrap_or_default();
-        let symbol = out.trim().trim_matches('"').to_string();
+        // The invoke pipeline renders the `String` return value as JSON, so
+        // decode it back through serde rather than trimming quotes by hand —
+        // that recovers a symbol containing quotes, backslashes, or control
+        // characters intact instead of leaking the escape sequences. `symbol()`
+        // always returns a value on a successful read, so a missing receipt
+        // (build-only, which reads never set) decodes as an empty symbol.
+        let symbol = match receipt {
+            Some(r) => serde_json::from_str::<String>(r.output.trim())?,
+            None => String::new(),
+        };
 
-        output.readable(|_| println!("{symbol}"));
+        // The symbol is contract-controlled data, so escape any ANSI/control
+        // sequences before writing it to the terminal — matching how other
+        // contract-derived output is rendered (see `log::auth`/`log::event`).
+        // JSON output keeps the exact value: serde re-escapes it safely.
+        output.readable(|_| println!("{}", soroban_spec_tools::sanitize(&symbol)));
         output.json_value(&SymbolResult { symbol })?;
 
         Ok(())

--- a/cmd/soroban-cli/src/commands/token/symbol.rs
+++ b/cmd/soroban-cli/src/commands/token/symbol.rs
@@ -1,0 +1,120 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{self, locator, network, sign_with, token::UnresolvedToken},
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to query: a contract id or alias, `native`, or a classic asset
+    /// as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+        }
+    }
+}
+
+/// The machine-readable result of a `symbol` query.
+#[derive(Debug, serde::Serialize)]
+struct SymbolResult {
+    /// The token's SEP-41 `symbol` metadata.
+    symbol: String,
+}
+
+impl Cmd {
+    /// A read-only config: `symbol` is resolved by simulation, so no source
+    /// account, signing options, or fees are needed.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: config::UnresolvedMuxedAccount::default(),
+            locator: self.locator.clone(),
+            sign_with: sign_with::Args::default(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // Read-only calls still log through the invoke pipeline's Print; keep it
+        // quiet in JSON mode so stdout stays pure JSON.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+
+        // SEP-41 `symbol()` takes no arguments and returns a `String`.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "symbol",
+            vec![],
+            invoke::Send::No,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        // The decoded `symbol` comes back JSON-encoded as a quoted string; strip
+        // the surrounding quotes to recover the plain metadata value.
+        let out = receipt.map(|r| r.output).unwrap_or_default();
+        let symbol = out.trim().trim_matches('"').to_string();
+
+        output.readable(|_| println!("{symbol}"));
+        output.json_value(&SymbolResult { symbol })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### What

Adds `stellar token symbol`, a read-only subcommand returning a token's SEP-41 `symbol()` metadata. Resolves a token by `--id` (contract id, alias, `native`, or `CODE:ISSUER`) and prints the symbol as text or JSON.

### Why

Part of #2620 (typed SEP-41 + SAC client), following `name`. Stacked on the `token-name` branch; a thin wrapper over `contract invoke` reusing `args::invoke_by_position` and `args::not_deployed_error`.

### Known limitations

N/A