### PR TITLE
Add `stellar token decimals` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1920,6 +1920,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 - `balance` — Read the token balance of an account or contract
 - `name` — Read the token's name (SEP-41 metadata)
 - `symbol` — Read the token's symbol (SEP-41 metadata)
+- `decimals` — Read the token's decimals (SEP-41 metadata)
 
 ## `stellar token transfer`
 
@@ -2026,6 +2027,35 @@ Read the token's name (SEP-41 metadata)
 Read the token's symbol (SEP-41 metadata)
 
 **Usage:** `stellar token symbol [OPTIONS] --id <ID>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+
+## `stellar token decimals`
+
+Read the token's decimals (SEP-41 metadata)
+
+**Usage:** `stellar token decimals [OPTIONS] --id <ID>`
 
 ###### **Global Options:**
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/decimals.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/decimals.rs
@@ -1,0 +1,60 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{token::deploy_sac, util::new_account};
+
+/// Run `stellar token decimals --id <id> --output json` and return the parsed value.
+fn decimals_json(sandbox: &TestEnv, id: &str) -> Value {
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(["decimals", "--id", id, "--output", "json"])
+        .assert()
+        .success()
+        .stdout_as_str();
+    serde_json::from_str(&stdout).unwrap()
+}
+
+#[tokio::test]
+async fn decimals_returns_native_metadata() {
+    let sandbox = &TestEnv::new();
+    deploy_sac(sandbox, "native", "test");
+
+    // A Stellar Asset Contract always reports 7 decimals.
+    let value = decimals_json(sandbox, "native");
+    assert_eq!(value["decimals"], 7, "native SAC decimals, got: {value}");
+}
+
+#[tokio::test]
+async fn decimals_returns_issued_asset_metadata() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+    deploy_sac(sandbox, &asset, "issuer");
+
+    let value = decimals_json(sandbox, &asset);
+    assert_eq!(
+        value["decimals"], 7,
+        "issued-asset SAC decimals, got: {value}"
+    );
+}
+
+#[tokio::test]
+async fn decimals_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed for this asset → structured deploy-pointer error, and in
+    // JSON mode the error carries a machine-readable `type` discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(["decimals", "--id", &asset, "--output", "json"])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,4 +1,5 @@
 pub mod balance;
+pub mod decimals;
 pub mod name;
 pub mod renamed;
 pub mod symbol;

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -146,6 +146,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Token(token::Cmd::Balance(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Name(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Symbol(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Decimals(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/decimals.rs
+++ b/cmd/soroban-cli/src/commands/token/decimals.rs
@@ -1,0 +1,123 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{self, locator, network, sign_with, token::UnresolvedToken},
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to query: a contract id or alias, `native`, or a classic asset
+    /// as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+        }
+    }
+}
+
+/// The machine-readable result of a `decimals` query.
+#[derive(Debug, serde::Serialize)]
+struct DecimalsResult {
+    /// The token's SEP-41 `decimals` metadata.
+    decimals: u32,
+}
+
+impl Cmd {
+    /// A read-only config: `decimals` is resolved by simulation, so no source
+    /// account, signing options, or fees are needed.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: config::UnresolvedMuxedAccount::default(),
+            locator: self.locator.clone(),
+            sign_with: sign_with::Args::default(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // Read-only calls still log through the invoke pipeline's Print; keep it
+        // quiet in JSON mode so stdout stays pure JSON.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+
+        // SEP-41 `decimals()` takes no arguments and returns a `u32`.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "decimals",
+            vec![],
+            invoke::Send::No,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        // `decimals()` renders as a bare JSON number; decode it straight into a
+        // `u32`. It always returns a value on a successful read, so a missing
+        // receipt (build-only, which reads never set) decodes as zero.
+        let decimals = match receipt {
+            Some(r) => serde_json::from_str::<u32>(r.output.trim())?,
+            None => 0,
+        };
+
+        output.readable(|_| println!("{decimals}"));
+        output.json_value(&DecimalsResult { decimals })?;
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod balance;
+pub mod decimals;
 pub mod name;
 pub mod symbol;
 pub mod transfer;
@@ -19,6 +20,9 @@ pub enum Cmd {
 
     /// Read the token's symbol (SEP-41 metadata)
     Symbol(symbol::Cmd),
+
+    /// Read the token's decimals (SEP-41 metadata)
+    Decimals(decimals::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -31,6 +35,8 @@ pub enum Error {
     Name(#[from] name::Error),
     #[error(transparent)]
     Symbol(#[from] symbol::Error),
+    #[error(transparent)]
+    Decimals(#[from] decimals::Error),
 }
 
 impl Error {
@@ -42,6 +48,7 @@ impl Error {
             Error::Balance(e) => e.error_type(),
             Error::Name(e) => e.error_type(),
             Error::Symbol(e) => e.error_type(),
+            Error::Decimals(e) => e.error_type(),
         }
     }
 }
@@ -53,6 +60,7 @@ impl Cmd {
             Cmd::Balance(cmd) => cmd.run(global_args).await?,
             Cmd::Name(cmd) => cmd.run(global_args).await?,
             Cmd::Symbol(cmd) => cmd.run(global_args).await?,
+            Cmd::Decimals(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
### What

Adds `stellar token decimals`, a read-only subcommand returning a token's SEP-41 `decimals()` metadata as a `u32`. Resolves a token by `--id` (contract id, alias, `native`, or `CODE:ISSUER`) and prints the value as text or JSON.

### Why

Part of #2620 (typed SEP-41 + SAC client), completing the read-metadata group after `name` and `symbol`. Stacked on the `token-symbol` branch; a thin wrapper over `contract invoke` reusing `args::invoke_by_position` and `args::not_deployed_error`.

### Known limitations

N/A