### PR TITLE
Add `stellar token approve` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1921,6 +1921,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 - `name` — Read the token's name (SEP-41 metadata)
 - `symbol` — Read the token's symbol (SEP-41 metadata)
 - `decimals` — Read the token's decimals (SEP-41 metadata)
+- `approve` — Approve an allowance for a spender to transfer on your behalf
 
 ## `stellar token transfer`
 
@@ -2079,6 +2080,47 @@ Read the token's decimals (SEP-41 metadata)
 - `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
 - `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 - `-n`, `--network <NETWORK>` — Name of network to use from config
+
+## `stellar token approve`
+
+Approve an allowance for a spender to transfer on your behalf
+
+**Usage:** `stellar token approve [OPTIONS] --id <ID> --from <FROM> --spender <SPENDER> --amount <AMOUNT> --expiration-ledger <EXPIRATION_LEDGER>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to approve an allowance on: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
+- `--from <FROM>` — Account granting the allowance. Signs and authorizes the approval, so it must be an identity or secret key you control
+- `--spender <SPENDER>` — Account or contract allowed to spend on `--from`'s behalf. Accepts a `G…`/`M…` account, a `C…` contract address, or an alias
+- `--amount <AMOUNT>` — Allowance to grant, in the token's smallest unit (stroops for a Stellar Asset Contract). Replaces any existing allowance
+- `--expiration-ledger <EXPIRATION_LEDGER>` — Ledger sequence after which the allowance expires. Must be at or beyond the current ledger when the amount is positive
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+
+###### **Signing Options:**
+
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--auto-sign` — Sign without prompting for approval. Only applies to signatures that require user approval, like non-root Soroban auth entries
 
 ## `stellar tx`
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/approve.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/approve.rs
@@ -114,6 +114,37 @@ async fn approve_fails_when_sac_not_deployed() {
 }
 
 #[tokio::test]
+async fn approve_rejects_muxed_source_with_clear_error() {
+    let sandbox = &TestEnv::new();
+    let spender = new_account(sandbox, "spender");
+
+    // Muxed (M…) source accounts aren't supported by the invoke pipeline yet
+    // (see #2645). Until then the command must reject them up front with a clear
+    // message rather than a raw strkey decode error deep in the pipeline.
+    let muxed = "MA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAAAAAAAAAPCICBKU";
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "approve",
+            "--id",
+            "native",
+            "--from",
+            muxed,
+            "--spender",
+            &spender,
+            "--amount",
+            "1",
+            "--expiration-ledger",
+            "9999999",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "muxed (M…) source accounts are not yet supported",
+        ));
+}
+
+#[tokio::test]
 async fn approve_rejects_negative_amount_before_any_rpc() {
     let sandbox = &TestEnv::new();
     let spender = new_account(sandbox, "spender");

--- a/cmd/crates/soroban-test/tests/it/integration/token/approve.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/approve.rs
@@ -1,0 +1,140 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{
+    token::{deploy_sac, sac_id},
+    util::{new_account, test_address},
+};
+
+/// Read the on-chain allowance `from` granted `spender` through the token's SAC.
+fn sac_allowance(sandbox: &TestEnv, contract_id: &str, from: &str, spender: &str) -> i128 {
+    let stdout = sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--id",
+            contract_id,
+            "--source-account",
+            "test",
+            "--",
+            "allowance",
+            "--from",
+            from,
+            "--spender",
+            spender,
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+    stdout.trim().trim_matches('"').parse().unwrap()
+}
+
+#[tokio::test]
+async fn approve_sets_allowance_and_returns_receipt() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let spender = new_account(sandbox, "spender");
+    let asset = format!("USDC:{issuer}");
+    deploy_sac(sandbox, &asset, "issuer");
+
+    // `expiration_ledger` must be at or beyond the current ledger for a positive
+    // allowance; read the live sequence and leave a comfortable buffer.
+    let seq = sandbox.client().get_latest_ledger().await.unwrap().sequence;
+    let expiration = (seq + 1000).to_string();
+
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "approve",
+            "--id",
+            &asset,
+            "--from",
+            "test",
+            "--spender",
+            &spender,
+            "--amount",
+            "5000000",
+            "--expiration-ledger",
+            &expiration,
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let receipt: Value = serde_json::from_str(&stdout).unwrap();
+    assert!(
+        receipt["tx_hash"].as_str().is_some(),
+        "expected a tx hash, got: {receipt}"
+    );
+
+    // The allowance is now readable on-chain.
+    let sac = sac_id(sandbox, &asset);
+    assert_eq!(
+        sac_allowance(sandbox, &sac, &test, &spender),
+        5_000_000,
+        "expected the approved allowance on-chain"
+    );
+}
+
+#[tokio::test]
+async fn approve_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let spender = new_account(sandbox, "spender");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed → structured deploy-pointer error with a typed discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "approve",
+            "--id",
+            &asset,
+            "--from",
+            "test",
+            "--spender",
+            &spender,
+            "--amount",
+            "1",
+            "--expiration-ledger",
+            "9999999",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn approve_rejects_negative_amount_before_any_rpc() {
+    let sandbox = &TestEnv::new();
+    let spender = new_account(sandbox, "spender");
+
+    // A negative allowance is rejected at the CLI layer, before any network call.
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "approve",
+            "--id",
+            "native",
+            "--from",
+            "test",
+            "--spender",
+            &spender,
+            // `=` form so clap reads `-1` as the value, not an unknown flag.
+            "--amount=-1",
+            "--expiration-ledger",
+            "9999999",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("must not be negative"));
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,3 +1,4 @@
+pub mod approve;
 pub mod balance;
 pub mod decimals;
 pub mod name;

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -147,6 +147,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Token(token::Cmd::Name(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Symbol(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Decimals(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Approve(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/approve.rs
+++ b/cmd/soroban-cli/src/commands/token/approve.rs
@@ -1,0 +1,223 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{
+        self, locator, network, sign_with, token::UnresolvedToken, UnresolvedMuxedAccount,
+        UnresolvedScAddress,
+    },
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to approve an allowance on: a contract id or alias, `native`,
+    /// or a classic asset as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// Account granting the allowance. Signs and authorizes the approval, so it
+    /// must be an identity or secret key you control.
+    #[arg(long)]
+    pub from: UnresolvedMuxedAccount,
+
+    /// Account or contract allowed to spend on `--from`'s behalf. Accepts a
+    /// `G…`/`M…` account, a `C…` contract address, or an alias.
+    #[arg(long)]
+    pub spender: UnresolvedScAddress,
+
+    /// Allowance to grant, in the token's smallest unit (stroops for a Stellar
+    /// Asset Contract). Replaces any existing allowance.
+    #[arg(long, value_parser = parse_nonneg_i128)]
+    pub amount: i128,
+
+    /// Ledger sequence after which the allowance expires. Must be at or beyond
+    /// the current ledger when the amount is positive.
+    #[arg(long = "expiration-ledger")]
+    pub expiration_ledger: u32,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+
+    #[command(flatten)]
+    pub sign_with: sign_with::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    ScAddress(#[from] config::sc_address::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    #[error(
+        "muxed (M…) source accounts are not yet supported for `token approve`; \
+         use the underlying G… account as `--from` instead"
+    )]
+    MuxedSourceNotSupported,
+}
+
+/// Parse `--amount` as a non-negative `i128`. A negative allowance is always
+/// invalid, so reject it at the clap layer instead of letting it reach the
+/// contract and fail as an opaque `HostError` deep in simulation.
+fn parse_nonneg_i128(value: &str) -> Result<i128, String> {
+    let amount: i128 = value
+        .parse()
+        .map_err(|_| format!("invalid amount: {value}"))?;
+    if amount < 0 {
+        return Err(format!("amount must not be negative: {value}"));
+    }
+    Ok(amount)
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::ScAddress(_) => "invalid_address",
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+            Error::MuxedSourceNotSupported => "unsupported",
+        }
+    }
+}
+
+/// The machine-readable receipt of a token approval.
+#[derive(Debug, serde::Serialize)]
+struct Receipt {
+    /// Hex-encoded hash of the submitted transaction.
+    tx_hash: Option<String>,
+    /// The decoded contract return value (`null` for SEP-41 `approve`, which
+    /// returns nothing).
+    result: serde_json::Value,
+}
+
+impl Cmd {
+    /// Assemble a full [`config::Args`] for the underlying invocation, using
+    /// `--from` as the source account that signs and authorizes the approval.
+    /// Fees are left unset so the pipeline applies its default inclusion fee —
+    /// this command intentionally exposes no fee or sequence knobs.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: self.from.clone(),
+            locator: self.locator.clone(),
+            sign_with: self.sign_with.clone(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // In JSON mode the underlying invoke pipeline's human-readable status
+        // logging (which writes to stderr) would still fire; run it quietly so
+        // machine consumers get clean output without needing `--quiet`.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+
+        // SEP-41 `approve(from, spender, amount, expiration_ledger)`: `from` is
+        // the source account (which also signs and authorizes), `spender` is the
+        // delegate being granted the allowance.
+        //
+        // The invoke pipeline can't source a transaction from a muxed account
+        // yet (see #2645), and a muxed strkey in the `from` arg is rejected
+        // mid-simulation with an opaque host error; reject it up front with a
+        // clear message instead.
+        let source_account = config.source_account()?;
+        if matches!(source_account, crate::xdr::MuxedAccount::MuxedEd25519(_)) {
+            return Err(Error::MuxedSourceNotSupported);
+        }
+        let from = source_account.to_string();
+        // `--spender` may be an account (`G…`/`M…`), a contract (`C…`), or an
+        // alias; resolve it to an `ScAddress` and hand the strkey to the
+        // `approve` arg, which accepts any of these delegates.
+        let spender = self
+            .spender
+            .clone()
+            .resolve(&config.locator, &network.network_passphrase, None)?
+            .to_string();
+        let amount = self.amount.to_string();
+        let expiration_ledger = self.expiration_ledger.to_string();
+
+        // SEP-41 `approve(from, spender, amount, expiration_ledger)` — supply the
+        // values in that order and let the contract's parameters be matched by
+        // position, so a token that names them anything still works. An approval
+        // always intends to submit, so force `Send::Yes`: a token whose `approve`
+        // records no writes/events/auth can't be classified read-only and
+        // silently exit 0 without ever setting the allowance.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "approve",
+            vec![from, spender, amount, expiration_ledger],
+            invoke::Send::Yes,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        // `approve` always writes, so the invocation is submitted rather than
+        // resolved as a build-only transaction; a missing receipt would mean
+        // `--build-only`, which this command never sets.
+        let Some(receipt) = receipt else {
+            return Ok(());
+        };
+
+        let result = if receipt.output.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_str(&receipt.output)
+                .unwrap_or(serde_json::Value::String(receipt.output.clone()))
+        };
+
+        // The pipeline already logs submission status and the explorer link to
+        // stderr; echo the hash to stdout so readable output is scriptable too.
+        if !output.is_json() {
+            if let Some(tx_hash) = &receipt.tx_hash {
+                println!("{tx_hash}");
+            }
+        }
+
+        output.json_value(&Receipt {
+            tx_hash: receipt.tx_hash,
+            result,
+        })?;
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -1,3 +1,4 @@
+pub mod approve;
 pub mod args;
 pub mod balance;
 pub mod decimals;
@@ -23,6 +24,9 @@ pub enum Cmd {
 
     /// Read the token's decimals (SEP-41 metadata)
     Decimals(decimals::Cmd),
+
+    /// Approve an allowance for a spender to transfer on your behalf
+    Approve(approve::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -37,6 +41,8 @@ pub enum Error {
     Symbol(#[from] symbol::Error),
     #[error(transparent)]
     Decimals(#[from] decimals::Error),
+    #[error(transparent)]
+    Approve(#[from] approve::Error),
 }
 
 impl Error {
@@ -49,6 +55,7 @@ impl Error {
             Error::Name(e) => e.error_type(),
             Error::Symbol(e) => e.error_type(),
             Error::Decimals(e) => e.error_type(),
+            Error::Approve(e) => e.error_type(),
         }
     }
 }
@@ -61,6 +68,7 @@ impl Cmd {
             Cmd::Name(cmd) => cmd.run(global_args).await?,
             Cmd::Symbol(cmd) => cmd.run(global_args).await?,
             Cmd::Decimals(cmd) => cmd.run(global_args).await?,
+            Cmd::Approve(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
### What

Adds `stellar token approve`, a write subcommand that sets a SEP-41 allowance. `--from` grants and authorizes the allowance, `--spender` is the delegate, `--amount` is the allowance in smallest units, and `--expiration-ledger` is the ledger after which it expires. Returns a JSON receipt with the tx hash.

### Why

Part of #2620 (typed SEP-41 + SAC client), first of the write commands after the read-metadata group. A thin wrapper over `contract invoke` reusing `args::invoke_by_position` and `args::not_deployed_error`, mirroring `transfer`. Landing `approve` before `allowance` lets the allowance command's tests do a clean approve→read round-trip.

### Known limitations

Muxed (`M…`) source accounts are rejected with a clear error (same constraint as `transfer`, see #2645).