### PR TITLE
Add `stellar token allowance` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1922,6 +1922,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 - `symbol` — Read the token's symbol (SEP-41 metadata)
 - `decimals` — Read the token's decimals (SEP-41 metadata)
 - `approve` — Approve an allowance for a spender to transfer on your behalf
+- `allowance` — Read the allowance a spender has on an owner's behalf
 
 ## `stellar token transfer`
 
@@ -2121,6 +2122,38 @@ Approve an allowance for a spender to transfer on your behalf
 - `--sign-with-lab` — Sign with https://lab.stellar.org
 - `--sign-with-ledger` — Sign with a ledger wallet
 - `--auto-sign` — Sign without prompting for approval. Only applies to signatures that require user approval, like non-root Soroban auth entries
+
+## `stellar token allowance`
+
+Read the allowance a spender has on an owner's behalf
+
+**Usage:** `stellar token allowance [OPTIONS] --id <ID> --from <FROM> --spender <SPENDER>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
+- `--from <FROM>` — Account that granted the allowance (the owner of the funds)
+- `--spender <SPENDER>` — Account or contract allowed to spend on `--from`'s behalf
+- `--decimal` — Format the allowance as a decimal using the token's `decimals`, instead of the raw smallest unit (stroops for a Stellar Asset Contract)
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
 
 ## `stellar tx`
 

--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -2136,7 +2136,7 @@ Read the allowance a spender has on an owner's behalf
 ###### **Options:**
 
 - `--id <ID>` — The token to query: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
-- `--from <FROM>` — Account that granted the allowance (the owner of the funds)
+- `--from <FROM>` — Account or contract that granted the allowance (the owner of the funds)
 - `--spender <SPENDER>` — Account or contract allowed to spend on `--from`'s behalf
 - `--decimal` — Format the allowance as a decimal using the token's `decimals`, instead of the raw smallest unit (stroops for a Stellar Asset Contract)
 - `--output <OUTPUT>` — Format of the output

--- a/cmd/crates/soroban-test/tests/it/integration/token/allowance.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/allowance.rs
@@ -1,0 +1,125 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{
+    token::deploy_sac,
+    util::{new_account, test_address},
+};
+
+/// Run `stellar token allowance ... --output json` and return the parsed value.
+fn allowance_json(sandbox: &TestEnv, id: &str, from: &str, spender: &str, decimal: bool) -> Value {
+    let mut args = vec![
+        "allowance",
+        "--id",
+        id,
+        "--from",
+        from,
+        "--spender",
+        spender,
+        "--output",
+        "json",
+    ];
+    if decimal {
+        args.push("--decimal");
+    }
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args(args)
+        .assert()
+        .success()
+        .stdout_as_str();
+    serde_json::from_str(&stdout).unwrap()
+}
+
+/// Grant `spender` an allowance of `amount` on `asset`, authorized by `test`.
+fn approve(sandbox: &TestEnv, asset: &str, spender: &str, amount: i128, expiration: u32) {
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "approve",
+            "--id",
+            asset,
+            "--from",
+            "test",
+            "--spender",
+            spender,
+            "--amount",
+            &amount.to_string(),
+            "--expiration-ledger",
+            &expiration.to_string(),
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn allowance_returns_stroops_and_optional_decimal() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let spender = new_account(sandbox, "spender");
+    let asset = format!("USDC:{issuer}");
+    deploy_sac(sandbox, &asset, "issuer");
+
+    // Approve 1.23 units (12_300_000 stroops at 7 decimals).
+    let seq = sandbox.client().get_latest_ledger().await.unwrap().sequence;
+    approve(sandbox, &asset, &spender, 12_300_000, seq + 1000);
+
+    // Default: raw stroops, as a string.
+    let raw = allowance_json(sandbox, &asset, &test, &spender, false);
+    assert_eq!(raw["allowance"], "12300000", "raw allowance, got: {raw}");
+    assert!(
+        raw.get("decimals").is_none(),
+        "no decimals without --decimal"
+    );
+
+    // `--decimal`: decimal-aware value plus the token's decimals.
+    let dec = allowance_json(sandbox, &asset, &test, &spender, true);
+    assert_eq!(dec["allowance"], "1.23", "decimal allowance, got: {dec}");
+    assert_eq!(dec["decimals"], 7, "decimals, got: {dec}");
+}
+
+#[tokio::test]
+async fn allowance_zero_when_never_approved() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let spender = new_account(sandbox, "spender");
+    let asset = format!("USDC:{issuer}");
+    deploy_sac(sandbox, &asset, "issuer");
+
+    // No approval granted → a zero allowance.
+    let raw = allowance_json(sandbox, &asset, &test, &spender, false);
+    assert_eq!(raw["allowance"], "0", "expected zero allowance, got: {raw}");
+}
+
+#[tokio::test]
+async fn allowance_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let spender = new_account(sandbox, "spender");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed → structured deploy-pointer error with a typed discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "allowance",
+            "--id",
+            &asset,
+            "--from",
+            "test",
+            "--spender",
+            &spender,
+            "--output",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -1,3 +1,4 @@
+pub mod allowance;
 pub mod approve;
 pub mod balance;
 pub mod decimals;

--- a/cmd/crates/soroban-test/tests/it/integration/token/renamed.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/renamed.rs
@@ -2,11 +2,34 @@
 //! non-canonical names (`balance(who)`, `transfer(sender, recipient, amt)`).
 //! These prove the command maps values to the contract's parameters by
 //! position, not by name — the old flag-name mapping would fail here.
+use serde_json::Value;
 use soroban_test::{AssertExt, TestEnv, Wasm};
 
 use crate::integration::util::{deploy_contract, new_account, test_address, DeployOptions};
 
 const TOKEN_RENAMED: &Wasm = &Wasm::Custom("test-wasms", "test_token_renamed");
+
+/// Deploy the renamed-arg token and set its `decimals` to `decimal_count`,
+/// returning the contract id. No balance is seeded.
+async fn deploy_with_decimals(sandbox: &TestEnv, decimal_count: u32) -> String {
+    let id = deploy_contract(sandbox, TOKEN_RENAMED, DeployOptions::default()).await;
+    sandbox
+        .new_assert_cmd("contract")
+        .args([
+            "invoke",
+            "--id",
+            &id,
+            "--source-account",
+            "test",
+            "--",
+            "init",
+            "--decimal_count",
+            &decimal_count.to_string(),
+        ])
+        .assert()
+        .success();
+    id
+}
 
 /// Deploy the renamed-arg token, set decimals to 7, and mint `qty` to `test`.
 /// Returns the contract id and `test`'s address.
@@ -80,6 +103,39 @@ async fn transfer_maps_renamed_params_by_position() {
         .success();
 
     assert_eq!(token_balance(sandbox, &id, &recipient), "400");
+}
+
+#[tokio::test]
+async fn balance_decimal_rejects_oversized_decimals() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    // `decimals` is contract-controlled; a hostile value would make `--decimal`
+    // pad the output to that many characters. Anything past the CLI's cap is
+    // rejected up front rather than risking a pathological allocation. 1000 is
+    // over the cap but small enough that, without the guard, formatting would
+    // still succeed — so this test truly catches a regression.
+    let id = deploy_with_decimals(sandbox, 1000).await;
+
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "balance",
+            "--id",
+            &id,
+            "--account",
+            &test,
+            "--decimal",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "decimals_too_large",
+        "expected a typed error, got: {stdout}"
+    );
 }
 
 #[tokio::test]

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -148,6 +148,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Token(token::Cmd::Symbol(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Decimals(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Approve(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Allowance(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/allowance.rs
+++ b/cmd/soroban-cli/src/commands/token/allowance.rs
@@ -1,0 +1,226 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{
+        self, locator, network, sign_with,
+        token::{ResolvedToken, UnresolvedToken},
+        UnresolvedScAddress,
+    },
+    fixed_point::FixedPoint,
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to query: a contract id or alias, `native`, or a classic asset
+    /// as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// Account that granted the allowance (the owner of the funds).
+    #[arg(long)]
+    pub from: UnresolvedScAddress,
+
+    /// Account or contract allowed to spend on `--from`'s behalf.
+    #[arg(long)]
+    pub spender: UnresolvedScAddress,
+
+    /// Format the allowance as a decimal using the token's `decimals`, instead
+    /// of the raw smallest unit (stroops for a Stellar Asset Contract).
+    #[arg(long)]
+    pub decimal: bool,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    ScAddress(#[from] config::sc_address::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    #[error("could not parse {what} from the contract: {value:?}")]
+    ParseResult { what: &'static str, value: String },
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::ScAddress(_) => "invalid_address",
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) | Error::ParseResult { .. } => "internal",
+        }
+    }
+}
+
+/// The machine-readable result of an allowance query.
+#[derive(Debug, serde::Serialize)]
+struct AllowanceResult {
+    /// The allowance, in the requested representation: raw smallest units by
+    /// default, or a decimal string when `--decimal` is set.
+    allowance: String,
+    /// The token's `decimals`, present only when `--decimal` was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    decimals: Option<u32>,
+}
+
+impl Cmd {
+    /// A read-only config: allowance is resolved by simulation, so no source
+    /// account, signing options, or fees are needed.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: config::UnresolvedMuxedAccount::default(),
+            locator: self.locator.clone(),
+            sign_with: sign_with::Args::default(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // Read-only calls still log through the invoke pipeline's Print; keep it
+        // quiet in JSON mode so stdout stays pure JSON.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+        let from = self
+            .from
+            .clone()
+            .resolve(&config.locator, &network.network_passphrase, None)?
+            .to_string();
+        let spender = self
+            .spender
+            .clone()
+            .resolve(&config.locator, &network.network_passphrase, None)?
+            .to_string();
+
+        // SEP-41 `allowance(from, spender) -> i128`.
+        let raw: i128 = self
+            .read_parsed(
+                &config,
+                quiet,
+                global_args.no_cache,
+                &token,
+                "allowance",
+                vec![from, spender],
+            )
+            .await?;
+
+        let (allowance, decimals) = if self.decimal {
+            // Deliberately a second, separate simulation: `decimals` isn't
+            // returned by `allowance`, so `--decimal` costs one extra read-only
+            // RPC round-trip on top of the allowance query.
+            let decimals: u32 = self
+                .read_parsed(
+                    &config,
+                    quiet,
+                    global_args.no_cache,
+                    &token,
+                    "decimals",
+                    vec![],
+                )
+                .await?;
+            (FixedPoint::new(raw, decimals).to_string(), Some(decimals))
+        } else {
+            (raw.to_string(), None)
+        };
+
+        output.readable(|_| println!("{allowance}"));
+        output.json_value(&AllowanceResult {
+            allowance,
+            decimals,
+        })?;
+
+        Ok(())
+    }
+
+    /// Invoke a read-only token function by SEP-41 position and return its
+    /// decoded output string.
+    async fn read(
+        &self,
+        config: &config::Args,
+        quiet: bool,
+        no_cache: bool,
+        token: &ResolvedToken,
+        function: &str,
+        args: Vec<String>,
+    ) -> Result<String, Error> {
+        let receipt = args::invoke_by_position(
+            config,
+            quiet,
+            no_cache,
+            token,
+            function,
+            args,
+            invoke::Send::No,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        Ok(receipt.map(|r| r.output).unwrap_or_default())
+    }
+
+    /// Invoke a read-only token function, then parse its decoded output as `T`.
+    /// `function` also labels the value in a `ParseResult` error if parsing fails.
+    async fn read_parsed<T: std::str::FromStr>(
+        &self,
+        config: &config::Args,
+        quiet: bool,
+        no_cache: bool,
+        token: &ResolvedToken,
+        function: &'static str,
+        args: Vec<String>,
+    ) -> Result<T, Error> {
+        let out = self
+            .read(config, quiet, no_cache, token, function, args)
+            .await?;
+        // A 128-bit allowance comes back JSON-encoded as a quoted string (it
+        // can't fit a JSON number), while `decimals` (u32) comes back bare;
+        // strip any surrounding quotes so both parse straight into `T`.
+        out.trim()
+            .trim_matches('"')
+            .parse()
+            .map_err(|_| Error::ParseResult {
+                what: function,
+                value: out,
+            })
+    }
+}

--- a/cmd/soroban-cli/src/commands/token/allowance.rs
+++ b/cmd/soroban-cli/src/commands/token/allowance.rs
@@ -11,7 +11,6 @@ use crate::{
         token::{ResolvedToken, UnresolvedToken},
         UnresolvedScAddress,
     },
-    fixed_point::FixedPoint,
     output::Output,
 };
 
@@ -23,7 +22,7 @@ pub struct Cmd {
     #[arg(long = "id")]
     pub id: UnresolvedToken,
 
-    /// Account that granted the allowance (the owner of the funds).
+    /// Account or contract that granted the allowance (the owner of the funds).
     #[arg(long)]
     pub from: UnresolvedScAddress,
 
@@ -157,7 +156,7 @@ impl Cmd {
                     vec![],
                 )
                 .await?;
-            (FixedPoint::new(raw, decimals).to_string(), Some(decimals))
+            (args::format_decimal(raw, decimals)?, Some(decimals))
         } else {
             (raw.to_string(), None)
         };

--- a/cmd/soroban-cli/src/commands/token/args.rs
+++ b/cmd/soroban-cli/src/commands/token/args.rs
@@ -38,6 +38,13 @@ pub enum Error {
 
     #[error("contract {0} was not found on this network")]
     ContractNotFound(String),
+
+    #[error(
+        "the token reports {decimals} decimals, which exceeds the maximum {max} \
+         this command can format.\n\
+         Query the raw smallest-unit value without `--decimal`."
+    )]
+    DecimalsTooLarge { decimals: u32, max: u32 },
 }
 
 impl Error {
@@ -47,8 +54,30 @@ impl Error {
         match self {
             Error::SacNotDeployed(_) => "sac_not_deployed",
             Error::ContractNotFound(_) => "contract_not_found",
+            Error::DecimalsTooLarge { .. } => "decimals_too_large",
         }
     }
+}
+
+/// The largest `decimals` the token commands will render in `--decimal` form. A
+/// token amount is an `i128` (at most 39 significant digits), so a larger scale
+/// can't represent a meaningful integer part. The cap also matters for safety:
+/// `decimals` is contract-controlled, and decimal formatting pads the output to
+/// that many fractional characters, so an unbounded value from a hostile token
+/// could otherwise force a multi-gigabyte allocation.
+pub const MAX_DECIMALS: u32 = 38;
+
+/// Render `value` scaled by `decimals` as a decimal string, refusing a scale
+/// beyond [`MAX_DECIMALS`] so a contract-supplied `decimals` can't trigger a
+/// pathological allocation. The raw value stays available without `--decimal`.
+pub fn format_decimal(value: i128, decimals: u32) -> Result<String, Error> {
+    if decimals > MAX_DECIMALS {
+        return Err(Error::DecimalsTooLarge {
+            decimals,
+            max: MAX_DECIMALS,
+        });
+    }
+    Ok(crate::fixed_point::FixedPoint::new(value, decimals).to_string())
 }
 
 /// Invoke a token `function` by SEP-41 canonical position: `args` are supplied
@@ -101,4 +130,23 @@ pub fn not_deployed_error(token: &ResolvedToken, err: &invoke::Error) -> Option<
     } else {
         Error::ContractNotFound(format!("{contract_id}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_decimal_scales_within_bound() {
+        assert_eq!(format_decimal(12_300_000, 7).unwrap(), "1.23");
+        assert_eq!(format_decimal(1, 0).unwrap(), "1");
+        // The boundary itself is allowed.
+        assert!(format_decimal(1, MAX_DECIMALS).is_ok());
+    }
+
+    #[test]
+    fn format_decimal_rejects_scale_beyond_bound() {
+        let err = format_decimal(1, MAX_DECIMALS + 1).unwrap_err();
+        assert_eq!(err.error_type(), "decimals_too_large");
+    }
 }

--- a/cmd/soroban-cli/src/commands/token/balance.rs
+++ b/cmd/soroban-cli/src/commands/token/balance.rs
@@ -11,7 +11,6 @@ use crate::{
         token::{ResolvedToken, UnresolvedToken},
         UnresolvedScAddress,
     },
-    fixed_point::FixedPoint,
     output::Output,
 };
 
@@ -147,7 +146,7 @@ impl Cmd {
                     vec![],
                 )
                 .await?;
-            (FixedPoint::new(raw, decimals).to_string(), Some(decimals))
+            (args::format_decimal(raw, decimals)?, Some(decimals))
         } else {
             (raw.to_string(), None)
         };

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -1,3 +1,4 @@
+pub mod allowance;
 pub mod approve;
 pub mod args;
 pub mod balance;
@@ -27,6 +28,9 @@ pub enum Cmd {
 
     /// Approve an allowance for a spender to transfer on your behalf
     Approve(approve::Cmd),
+
+    /// Read the allowance a spender has on an owner's behalf
+    Allowance(allowance::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -43,6 +47,8 @@ pub enum Error {
     Decimals(#[from] decimals::Error),
     #[error(transparent)]
     Approve(#[from] approve::Error),
+    #[error(transparent)]
+    Allowance(#[from] allowance::Error),
 }
 
 impl Error {
@@ -56,6 +62,7 @@ impl Error {
             Error::Symbol(e) => e.error_type(),
             Error::Decimals(e) => e.error_type(),
             Error::Approve(e) => e.error_type(),
+            Error::Allowance(e) => e.error_type(),
         }
     }
 }
@@ -69,6 +76,7 @@ impl Cmd {
             Cmd::Symbol(cmd) => cmd.run(global_args).await?,
             Cmd::Decimals(cmd) => cmd.run(global_args).await?,
             Cmd::Approve(cmd) => cmd.run(global_args).await?,
+            Cmd::Allowance(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
### What

Adds `stellar token allowance`, a read-only subcommand returning the SEP-41 allowance `--from` granted `--spender`. Prints the raw smallest-unit value by default, or a decimal-aware value with `--decimal` (which reads the token's `decimals`), as text or JSON.

### Why

Part of #2620 (typed SEP-41 + SAC client), completing the read group. Mirrors `balance`, reusing `args::invoke_by_position`, `args::not_deployed_error`, and `FixedPoint`. Stacked on `token-approve`, so its tests seed state with a clean `approve`→`allowance` round-trip.

### Known limitations

N/A