### PR TITLE
Add `stellar token mint` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1923,6 +1923,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 - `decimals` — Read the token's decimals (SEP-41 metadata)
 - `approve` — Approve an allowance for a spender to transfer on your behalf
 - `allowance` — Read the allowance a spender has on an owner's behalf
+- `mint` — Mint new tokens to an account or contract (SAC admin)
 
 ## `stellar token transfer`
 
@@ -2154,6 +2155,46 @@ Read the allowance a spender has on an owner's behalf
 - `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
 - `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 - `-n`, `--network <NETWORK>` — Name of network to use from config
+
+## `stellar token mint`
+
+Mint new tokens to an account or contract (SAC admin)
+
+**Usage:** `stellar token mint [OPTIONS] --id <ID> --admin <ADMIN> --to <TO> --amount <AMOUNT>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to mint: a contract id or alias, `native`, or a classic asset as `CODE:ISSUER`
+- `--admin <ADMIN>` — The token's administrator. Signs and authorizes the mint, so it must be an identity or secret key you control (the asset issuer for a Stellar Asset Contract)
+- `--to <TO>` — Account or contract to mint the tokens to. Accepts a `G…`/`M…` account, a `C…` contract address, or an alias
+- `--amount <AMOUNT>` — Amount to mint, in the token's smallest unit (stroops for a Stellar Asset Contract)
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+
+###### **Signing Options:**
+
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--auto-sign` — Sign without prompting for approval. Only applies to signatures that require user approval, like non-root Soroban auth entries
 
 ## `stellar tx`
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/mint.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mint.rs
@@ -1,0 +1,91 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{
+    token::{add_trustline, deploy_sac, sac_balance, sac_id},
+    util::{new_account, test_address},
+};
+
+#[tokio::test]
+async fn mint_credits_recipient_and_returns_receipt() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // The SAC admin is the asset issuer. Minting a classic asset to an account
+    // requires the recipient to hold a trustline.
+    add_trustline(sandbox, "test", &asset);
+    deploy_sac(sandbox, &asset, "issuer");
+
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "mint", "--id", &asset, "--admin", "issuer", "--to", &test, "--amount", "7500000",
+            "--output", "json",
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let receipt: Value = serde_json::from_str(&stdout).unwrap();
+    assert!(
+        receipt["tx_hash"].as_str().is_some(),
+        "expected a tx hash, got: {receipt}"
+    );
+
+    // The minted balance is now readable on-chain.
+    let sac = sac_id(sandbox, &asset);
+    assert_eq!(
+        sac_balance(sandbox, &sac, &test),
+        7_500_000,
+        "expected the minted balance on-chain"
+    );
+}
+
+#[tokio::test]
+async fn mint_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed → structured deploy-pointer error with a typed discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "mint", "--id", &asset, "--admin", "issuer", "--to", &test, "--amount", "1",
+            "--output", "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn mint_rejects_negative_amount_before_any_rpc() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+
+    // A negative mint is rejected at the CLI layer, before any network call.
+    // `=` form so clap reads `-1` as the value, not an unknown flag.
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "mint",
+            "--id",
+            "native",
+            "--admin",
+            "test",
+            "--to",
+            &test,
+            "--amount=-1",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("must not be negative"));
+}

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -2,6 +2,7 @@ pub mod allowance;
 pub mod approve;
 pub mod balance;
 pub mod decimals;
+pub mod mint;
 pub mod name;
 pub mod renamed;
 pub mod symbol;

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -149,6 +149,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Token(token::Cmd::Decimals(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Approve(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Allowance(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::Mint(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/mint.rs
+++ b/cmd/soroban-cli/src/commands/token/mint.rs
@@ -1,0 +1,211 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{
+        self, locator, network, sign_with, token::UnresolvedToken, UnresolvedMuxedAccount,
+        UnresolvedScAddress,
+    },
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to mint: a contract id or alias, `native`, or a classic asset
+    /// as `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// The token's administrator. Signs and authorizes the mint, so it must be
+    /// an identity or secret key you control (the asset issuer for a Stellar
+    /// Asset Contract).
+    #[arg(long)]
+    pub admin: UnresolvedMuxedAccount,
+
+    /// Account or contract to mint the tokens to. Accepts a `G…`/`M…` account, a
+    /// `C…` contract address, or an alias.
+    #[arg(long)]
+    pub to: UnresolvedScAddress,
+
+    /// Amount to mint, in the token's smallest unit (stroops for a Stellar Asset
+    /// Contract).
+    #[arg(long, value_parser = parse_nonneg_i128)]
+    pub amount: i128,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+
+    #[command(flatten)]
+    pub sign_with: sign_with::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    ScAddress(#[from] config::sc_address::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    #[error(
+        "muxed (M…) source accounts are not yet supported for `token mint`; \
+         use the underlying G… account as `--admin` instead"
+    )]
+    MuxedSourceNotSupported,
+}
+
+/// Parse `--amount` as a non-negative `i128`. A negative mint amount is always
+/// invalid, so reject it at the clap layer instead of letting it reach the
+/// contract and fail as an opaque `HostError` deep in simulation.
+fn parse_nonneg_i128(value: &str) -> Result<i128, String> {
+    let amount: i128 = value
+        .parse()
+        .map_err(|_| format!("invalid amount: {value}"))?;
+    if amount < 0 {
+        return Err(format!("amount must not be negative: {value}"));
+    }
+    Ok(amount)
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::ScAddress(_) => "invalid_address",
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+            Error::MuxedSourceNotSupported => "unsupported",
+        }
+    }
+}
+
+/// The machine-readable receipt of a token mint.
+#[derive(Debug, serde::Serialize)]
+struct Receipt {
+    /// Hex-encoded hash of the submitted transaction.
+    tx_hash: Option<String>,
+    /// The decoded contract return value (`null` for the SAC `mint`, which
+    /// returns nothing).
+    result: serde_json::Value,
+}
+
+impl Cmd {
+    /// Assemble a full [`config::Args`] for the underlying invocation, using
+    /// `--admin` as the source account that signs and authorizes the mint. Fees
+    /// are left unset so the pipeline applies its default inclusion fee — this
+    /// command intentionally exposes no fee or sequence knobs.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: self.admin.clone(),
+            locator: self.locator.clone(),
+            sign_with: self.sign_with.clone(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // In JSON mode the underlying invoke pipeline's human-readable status
+        // logging (which writes to stderr) would still fire; run it quietly so
+        // machine consumers get clean output without needing `--quiet`.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+
+        // The admin only authorizes the mint; it is not itself a `mint` argument.
+        // The invoke pipeline can't source a transaction from a muxed account yet
+        // (see #2645), so reject a muxed admin up front with a clear message.
+        let source_account = config.source_account()?;
+        if matches!(source_account, crate::xdr::MuxedAccount::MuxedEd25519(_)) {
+            return Err(Error::MuxedSourceNotSupported);
+        }
+        // `--to` may be an account (`G…`/`M…`), a contract (`C…`), or an alias;
+        // resolve it to an `ScAddress` and hand the strkey to the `mint` arg,
+        // which accepts any of these destinations.
+        let to = self
+            .to
+            .clone()
+            .resolve(&config.locator, &network.network_passphrase, None)?
+            .to_string();
+        let amount = self.amount.to_string();
+
+        // SAC `mint(to, amount)` — supply the values in that order and let the
+        // contract's parameters be matched by position. A mint always intends to
+        // submit, so force `Send::Yes`: a token whose `mint` records no
+        // writes/events/auth can't be classified read-only and silently exit 0
+        // without ever crediting the recipient.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "mint",
+            vec![to, amount],
+            invoke::Send::Yes,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        // `mint` always writes, so the invocation is submitted rather than
+        // resolved as a build-only transaction; a missing receipt would mean
+        // `--build-only`, which this command never sets.
+        let Some(receipt) = receipt else {
+            return Ok(());
+        };
+
+        let result = if receipt.output.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_str(&receipt.output)
+                .unwrap_or(serde_json::Value::String(receipt.output.clone()))
+        };
+
+        // The pipeline already logs submission status and the explorer link to
+        // stderr; echo the hash to stdout so readable output is scriptable too.
+        if !output.is_json() {
+            if let Some(tx_hash) = &receipt.tx_hash {
+                println!("{tx_hash}");
+            }
+        }
+
+        output.json_value(&Receipt {
+            tx_hash: receipt.tx_hash,
+            result,
+        })?;
+
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -3,6 +3,7 @@ pub mod approve;
 pub mod args;
 pub mod balance;
 pub mod decimals;
+pub mod mint;
 pub mod name;
 pub mod symbol;
 pub mod transfer;
@@ -31,6 +32,9 @@ pub enum Cmd {
 
     /// Read the allowance a spender has on an owner's behalf
     Allowance(allowance::Cmd),
+
+    /// Mint new tokens to an account or contract (SAC admin)
+    Mint(mint::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -49,6 +53,8 @@ pub enum Error {
     Approve(#[from] approve::Error),
     #[error(transparent)]
     Allowance(#[from] allowance::Error),
+    #[error(transparent)]
+    Mint(#[from] mint::Error),
 }
 
 impl Error {
@@ -63,6 +69,7 @@ impl Error {
             Error::Decimals(e) => e.error_type(),
             Error::Approve(e) => e.error_type(),
             Error::Allowance(e) => e.error_type(),
+            Error::Mint(e) => e.error_type(),
         }
     }
 }
@@ -77,6 +84,7 @@ impl Cmd {
             Cmd::Decimals(cmd) => cmd.run(global_args).await?,
             Cmd::Approve(cmd) => cmd.run(global_args).await?,
             Cmd::Allowance(cmd) => cmd.run(global_args).await?,
+            Cmd::Mint(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
### What

Adds `stellar token mint`, a SAC-admin write subcommand that mints new tokens. `--admin` signs and authorizes the mint (the asset issuer for a Stellar Asset Contract), `--to` is the recipient, and `--amount` is the quantity in smallest units. Returns a JSON receipt with the tx hash.

### Why

Part of #2620 (typed SEP-41 + SAC client), first of the SAC-admin commands. A thin wrapper over `contract invoke` reusing `args::invoke_by_position` and `args::not_deployed_error`. Unlike `transfer`/`approve`, the admin only authorizes — it is not a `mint` argument — so only `[to, amount]` are passed positionally.

### Known limitations

Muxed (`M…`) source accounts are rejected with a clear error (same constraint as `transfer`, see #2645).