### PR TITLE
Add `stellar token set-admin` subcommand

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -1925,6 +1925,7 @@ Interact with SEP-41 tokens and Stellar Asset Contracts
 - `allowance` — Read the allowance a spender has on an owner's behalf
 - `mint` — Mint new tokens to an account or contract (SAC admin)
 - `clawback` — Claw back tokens from an account or contract (SAC admin)
+- `set-admin` — Transfer administration of the token to a new admin (SAC admin)
 
 ## `stellar token transfer`
 
@@ -2213,6 +2214,45 @@ Claw back tokens from an account or contract (SAC admin)
 - `--admin <ADMIN>` — The token's administrator. Signs and authorizes the clawback, so it must be an identity or secret key you control (the asset issuer for a Stellar Asset Contract)
 - `--from <FROM>` — Account or contract to claw the tokens back from. Accepts a `G…`/`M…` account, a `C…` contract address, or an alias
 - `--amount <AMOUNT>` — Amount to claw back, in the token's smallest unit (stroops for a Stellar Asset Contract)
+- `--output <OUTPUT>` — Format of the output
+
+  Default value: `text`
+
+  Possible values:
+  - `text`: Human-readable text
+  - `json`: Compact, single-line JSON output
+  - `json-formatted`: Formatted (multiline) JSON output
+
+###### **RPC Options:**
+
+- `--rpc-url <RPC_URL>` — RPC server endpoint
+- `--rpc-header <RPC_HEADERS>` — RPC Header(s) to include in requests to the RPC provider, example: "X-API-Key: abc123". Multiple headers can be added by passing the option multiple times
+- `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+- `-n`, `--network <NETWORK>` — Name of network to use from config
+
+###### **Signing Options:**
+
+- `--sign-with-key <SIGN_WITH_KEY>` — Sign with a local key or key saved in OS secure storage. Can be an identity (--sign-with-key alice), a secret key (--sign-with-key SC36…), or a seed phrase (--sign-with-key "kite urban…"). If using seed phrase, `--hd-path` defaults to the `0` path
+- `--hd-path <HD_PATH>` — If using a seed phrase to sign, sets which hierarchical deterministic path to use, e.g. `m/44'/148'/{hd_path}`. Example: `--hd-path 1`. Default: `0`
+- `--sign-with-lab` — Sign with https://lab.stellar.org
+- `--sign-with-ledger` — Sign with a ledger wallet
+- `--auto-sign` — Sign without prompting for approval. Only applies to signatures that require user approval, like non-root Soroban auth entries
+
+## `stellar token set-admin`
+
+Transfer administration of the token to a new admin (SAC admin)
+
+**Usage:** `stellar token set-admin [OPTIONS] --id <ID> --admin <ADMIN> --new-admin <NEW_ADMIN>`
+
+###### **Global Options:**
+
+- `--config-dir <CONFIG_DIR>` — Location of config directory. By default, it uses `$XDG_CONFIG_HOME/stellar` if set, falling back to `~/.config/stellar` otherwise. Contains configuration files, aliases, and other persistent settings
+
+###### **Options:**
+
+- `--id <ID>` — The token to re-administer: a contract id or alias, or a classic asset as `CODE:ISSUER`
+- `--admin <ADMIN>` — The token's current administrator. Signs and authorizes the change, so it must be an identity or secret key you control (the asset issuer for a Stellar Asset Contract)
+- `--new-admin <NEW_ADMIN>` — The new administrator to hand control to. Accepts a `G…`/`M…` account, a `C…` contract address, or an alias
 - `--output <OUTPUT>` — Format of the output
 
   Default value: `text`

--- a/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/mod.rs
@@ -6,6 +6,7 @@ pub mod decimals;
 pub mod mint;
 pub mod name;
 pub mod renamed;
+pub mod set_admin;
 pub mod symbol;
 pub mod transfer;
 

--- a/cmd/crates/soroban-test/tests/it/integration/token/set_admin.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/token/set_admin.rs
@@ -1,0 +1,115 @@
+use serde_json::Value;
+use soroban_test::{AssertExt, TestEnv};
+
+use crate::integration::{
+    token::{add_trustline, deploy_sac, sac_balance, sac_id},
+    util::{new_account, test_address},
+};
+
+#[tokio::test]
+async fn set_admin_transfers_control_and_returns_receipt() {
+    let sandbox = &TestEnv::new();
+    let test = test_address(sandbox);
+    let issuer = new_account(sandbox, "issuer");
+    let new_admin = new_account(sandbox, "newadmin");
+    let asset = format!("USDC:{issuer}");
+
+    add_trustline(sandbox, "test", &asset);
+    deploy_sac(sandbox, &asset, "issuer");
+
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "set-admin",
+            "--id",
+            &asset,
+            "--admin",
+            "issuer",
+            "--new-admin",
+            &new_admin,
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout_as_str();
+    let receipt: Value = serde_json::from_str(&stdout).unwrap();
+    assert!(
+        receipt["tx_hash"].as_str().is_some(),
+        "expected a tx hash, got: {receipt}"
+    );
+
+    // Control has transferred: the new admin can now mint, proving the change
+    // took effect.
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "mint", "--id", &asset, "--admin", "newadmin", "--to", &test, "--amount", "9000000",
+        ])
+        .assert()
+        .success();
+    let sac = sac_id(sandbox, &asset);
+    assert_eq!(
+        sac_balance(sandbox, &sac, &test),
+        9_000_000,
+        "the new admin should be able to mint"
+    );
+}
+
+#[tokio::test]
+async fn set_admin_fails_when_sac_not_deployed() {
+    let sandbox = &TestEnv::new();
+    let issuer = new_account(sandbox, "issuer");
+    let new_admin = new_account(sandbox, "newadmin");
+    let asset = format!("USDC:{issuer}");
+
+    // No SAC deployed → structured deploy-pointer error with a typed discriminator.
+    let stdout = sandbox
+        .new_assert_cmd("token")
+        .args([
+            "set-admin",
+            "--id",
+            &asset,
+            "--admin",
+            "issuer",
+            "--new-admin",
+            &new_admin,
+            "--output",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .stdout_as_str();
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        value["error"]["type"], "sac_not_deployed",
+        "expected a typed error, got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn set_admin_rejects_muxed_source_with_clear_error() {
+    let sandbox = &TestEnv::new();
+    let new_admin = new_account(sandbox, "newadmin");
+
+    // Muxed (M…) source accounts aren't supported by the invoke pipeline yet
+    // (see #2645). Until then the command must reject them up front with a clear
+    // message rather than a raw strkey decode error deep in the pipeline.
+    let muxed = "MA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAAAAAAAAAPCICBKU";
+    sandbox
+        .new_assert_cmd("token")
+        .args([
+            "set-admin",
+            "--id",
+            "native",
+            "--admin",
+            muxed,
+            "--new-admin",
+            &new_admin,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "muxed (M…) source accounts are not yet supported",
+        ));
+}

--- a/cmd/soroban-cli/src/cli.rs
+++ b/cmd/soroban-cli/src/cli.rs
@@ -151,6 +151,7 @@ fn json_error_format(cmd: &commands::Cmd) -> Option<crate::output::Format> {
         commands::Cmd::Token(token::Cmd::Allowance(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Mint(cmd)) => cmd.output.into(),
         commands::Cmd::Token(token::Cmd::Clawback(cmd)) => cmd.output.into(),
+        commands::Cmd::Token(token::Cmd::SetAdmin(cmd)) => cmd.output.into(),
         _ => return None,
     };
 

--- a/cmd/soroban-cli/src/commands/token/mod.rs
+++ b/cmd/soroban-cli/src/commands/token/mod.rs
@@ -6,6 +6,7 @@ pub mod clawback;
 pub mod decimals;
 pub mod mint;
 pub mod name;
+pub mod set_admin;
 pub mod symbol;
 pub mod transfer;
 
@@ -39,6 +40,9 @@ pub enum Cmd {
 
     /// Claw back tokens from an account or contract (SAC admin)
     Clawback(clawback::Cmd),
+
+    /// Transfer administration of the token to a new admin (SAC admin)
+    SetAdmin(set_admin::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -61,6 +65,8 @@ pub enum Error {
     Mint(#[from] mint::Error),
     #[error(transparent)]
     Clawback(#[from] clawback::Error),
+    #[error(transparent)]
+    SetAdmin(#[from] set_admin::Error),
 }
 
 impl Error {
@@ -77,6 +83,7 @@ impl Error {
             Error::Allowance(e) => e.error_type(),
             Error::Mint(e) => e.error_type(),
             Error::Clawback(e) => e.error_type(),
+            Error::SetAdmin(e) => e.error_type(),
         }
     }
 }
@@ -93,6 +100,7 @@ impl Cmd {
             Cmd::Allowance(cmd) => cmd.run(global_args).await?,
             Cmd::Mint(cmd) => cmd.run(global_args).await?,
             Cmd::Clawback(cmd) => cmd.run(global_args).await?,
+            Cmd::SetAdmin(cmd) => cmd.run(global_args).await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/token/set_admin.rs
+++ b/cmd/soroban-cli/src/commands/token/set_admin.rs
@@ -1,0 +1,193 @@
+use clap::Parser;
+
+use crate::{
+    commands::{
+        contract::invoke,
+        global,
+        token::args::{self, OutputFormat},
+    },
+    config::{
+        self, locator, network, sign_with, token::UnresolvedToken, UnresolvedMuxedAccount,
+        UnresolvedScAddress,
+    },
+    output::Output,
+};
+
+#[derive(Debug, Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// The token to re-administer: a contract id or alias, or a classic asset as
+    /// `CODE:ISSUER`.
+    #[arg(long = "id")]
+    pub id: UnresolvedToken,
+
+    /// The token's current administrator. Signs and authorizes the change, so it
+    /// must be an identity or secret key you control (the asset issuer for a
+    /// Stellar Asset Contract).
+    #[arg(long)]
+    pub admin: UnresolvedMuxedAccount,
+
+    /// The new administrator to hand control to. Accepts a `G…`/`M…` account, a
+    /// `C…` contract address, or an alias.
+    #[arg(long = "new-admin")]
+    pub new_admin: UnresolvedScAddress,
+
+    /// Format of the output.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+
+    #[command(flatten)]
+    pub network: network::Args,
+
+    #[command(flatten)]
+    pub locator: locator::Args,
+
+    #[command(flatten)]
+    pub sign_with: sign_with::Args,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Config(#[from] config::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Args(#[from] args::Error),
+    #[error(transparent)]
+    Token(#[from] config::token::Error),
+    #[error(transparent)]
+    ScAddress(#[from] config::sc_address::Error),
+    #[error(transparent)]
+    Invoke(#[from] invoke::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    #[error(
+        "muxed (M…) source accounts are not yet supported for `token set-admin`; \
+         use the underlying G… account as `--admin` instead"
+    )]
+    MuxedSourceNotSupported,
+}
+
+impl Error {
+    /// Machine-readable discriminator for the JSON error envelope's `type` field.
+    #[must_use]
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Network(_) => "network",
+            Error::Args(e) => e.error_type(),
+            Error::Token(e) => e.error_type(),
+            Error::ScAddress(_) => "invalid_address",
+            Error::Invoke(_) => "invoke",
+            Error::Serde(_) => "internal",
+            Error::MuxedSourceNotSupported => "unsupported",
+        }
+    }
+}
+
+/// The machine-readable receipt of a set-admin change.
+#[derive(Debug, serde::Serialize)]
+struct Receipt {
+    /// Hex-encoded hash of the submitted transaction.
+    tx_hash: Option<String>,
+    /// The decoded contract return value (`null` for the SAC `set_admin`, which
+    /// returns nothing).
+    result: serde_json::Value,
+}
+
+impl Cmd {
+    /// Assemble a full [`config::Args`] for the underlying invocation, using
+    /// `--admin` as the source account that signs and authorizes the change.
+    /// Fees are left unset so the pipeline applies its default inclusion fee —
+    /// this command intentionally exposes no fee or sequence knobs.
+    fn config(&self) -> config::Args {
+        config::Args {
+            network: self.network.clone(),
+            source_account: self.admin.clone(),
+            locator: self.locator.clone(),
+            sign_with: self.sign_with.clone(),
+            fee: None,
+            inclusion_fee: None,
+        }
+    }
+
+    pub async fn run(&self, global_args: &global::Args) -> Result<(), Error> {
+        let output = Output::new(self.output.into(), global_args.quiet);
+        // In JSON mode the underlying invoke pipeline's human-readable status
+        // logging (which writes to stderr) would still fire; run it quietly so
+        // machine consumers get clean output without needing `--quiet`.
+        let quiet = global_args.quiet || output.is_json();
+        let config = self.config();
+        let network = config.get_network()?;
+
+        let token = self
+            .id
+            .resolve(&config.locator, &network.network_passphrase)?;
+
+        // The admin only authorizes the change; it is not itself a `set_admin`
+        // argument. The invoke pipeline can't source a transaction from a muxed
+        // account yet (see #2645), so reject a muxed admin up front with a clear
+        // message.
+        let source_account = config.source_account()?;
+        if matches!(source_account, crate::xdr::MuxedAccount::MuxedEd25519(_)) {
+            return Err(Error::MuxedSourceNotSupported);
+        }
+        // `--new-admin` may be an account (`G…`/`M…`), a contract (`C…`), or an
+        // alias; resolve it to an `ScAddress` and hand the strkey to the
+        // `set_admin` arg, which accepts any of these administrators.
+        let new_admin = self
+            .new_admin
+            .clone()
+            .resolve(&config.locator, &network.network_passphrase, None)?
+            .to_string();
+
+        // SAC `set_admin(new_admin)` — supply the value and let the contract's
+        // parameter be matched by position. A set-admin always intends to
+        // submit, so force `Send::Yes`: a token whose `set_admin` records no
+        // writes/events/auth can't be classified read-only and silently exit 0
+        // without ever changing the administrator.
+        let receipt = args::invoke_by_position(
+            &config,
+            quiet,
+            global_args.no_cache,
+            &token,
+            "set_admin",
+            vec![new_admin],
+            invoke::Send::Yes,
+        )
+        .await
+        .map_err(|e| args::not_deployed_error(&token, &e).map_or(Error::Invoke(e), Error::Args))?
+        .into_result();
+
+        // `set_admin` always writes, so the invocation is submitted rather than
+        // resolved as a build-only transaction; a missing receipt would mean
+        // `--build-only`, which this command never sets.
+        let Some(receipt) = receipt else {
+            return Ok(());
+        };
+
+        let result = if receipt.output.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_str(&receipt.output)
+                .unwrap_or(serde_json::Value::String(receipt.output.clone()))
+        };
+
+        // The pipeline already logs submission status and the explorer link to
+        // stderr; echo the hash to stdout so readable output is scriptable too.
+        if !output.is_json() {
+            if let Some(tx_hash) = &receipt.tx_hash {
+                println!("{tx_hash}");
+            }
+        }
+
+        output.json_value(&Receipt {
+            tx_hash: receipt.tx_hash,
+            result,
+        })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### What

Adds `stellar token set-admin`, a SAC-admin write subcommand that transfers administration of a token. `--admin` (the current admin) signs and authorizes the change, and `--new-admin` is the successor. Returns a JSON receipt with the tx hash.

### Why

Part of #2620 (typed SEP-41 + SAC client), a SAC-admin command alongside `mint`/`clawback`. A thin wrapper over `contract invoke` reusing `args::invoke_by_position` and `args::not_deployed_error`; like the other admin commands, the admin only authorizes and is not a `set_admin` argument, so only `[new_admin]` is passed positionally. The happy-path test verifies control transferred behaviorally — after `set-admin`, the new admin can `mint`.

### Known limitations

Muxed (`M…`) source accounts are rejected with a clear error (same constraint as `transfer`, see #2645).