### PR TITLE
Shake by the recorded version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,7 +5535,7 @@ version = "28.0.0"
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "base64 0.22.1",
  "stellar-xdr",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec-rust"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-sdk"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "soroban-sdk",
 ]
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5758,7 +5758,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-asset-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e22cfbb87fa9f2e7a2e067713f8be91170265912#e22cfbb87fa9f2e7a2e067713f8be91170265912"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,7 +5535,7 @@ version = "28.0.0"
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "base64 0.22.1",
  "stellar-xdr",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec-rust"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-sdk"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "soroban-sdk",
 ]
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5758,7 +5758,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-asset-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d#3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,7 +5535,7 @@ version = "28.0.0"
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "serde",
  "serde_json",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "darling 0.20.11",
  "heck 0.5.0",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "base64 0.22.1",
  "stellar-xdr",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec-rust"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-sdk"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "soroban-sdk",
 ]
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
@@ -5758,7 +5758,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-asset-spec"
 version = "28.0.0-rc.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=788b536af88a1b0a4d473dc8050b6a44c668e80e#788b536af88a1b0a4d473dc8050b6a44c668e80e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=4d13b7ad1629978227924675a487d719119c085a#4d13b7ad1629978227924675a487d719119c085a"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,12 +130,12 @@ stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "82677e
 # user-defined types in contract specs by their fully qualified path, and the
 # PR stacked on it, which stops marking types for spec shaking and shakes them
 # by reachability instead.
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
-soroban-spec-rust = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
-soroban-token-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
-stellar-asset-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
-soroban-ledger-snapshot = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
+soroban-spec-rust = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
+soroban-token-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
+stellar-asset-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
+soroban-ledger-snapshot = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
 
 [profile.release]
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,12 +130,12 @@ stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "82677e
 # user-defined types in contract specs by their fully qualified path, and the
 # PR stacked on it, which stops marking types for spec shaking and shakes them
 # by reachability instead.
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
-soroban-spec-rust = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
-soroban-token-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
-stellar-asset-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
-soroban-ledger-snapshot = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3064f93bdf9271d4b09c72b94b15c0e5ecd86e7d" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e22cfbb87fa9f2e7a2e067713f8be91170265912" }
+soroban-spec-rust = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e22cfbb87fa9f2e7a2e067713f8be91170265912" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e22cfbb87fa9f2e7a2e067713f8be91170265912" }
+soroban-token-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e22cfbb87fa9f2e7a2e067713f8be91170265912" }
+stellar-asset-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e22cfbb87fa9f2e7a2e067713f8be91170265912" }
+soroban-ledger-snapshot = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "e22cfbb87fa9f2e7a2e067713f8be91170265912" }
 
 [profile.release]
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,13 +127,15 @@ astral-tokio-tar = "0.6.0"
 # to the same rev rs-soroban-sdk#1970 uses so the graph has one stellar-xdr.
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "82677e1dfe49b6b94fc6440d9c58be74d2a33bff" }
 # Pending https://github.com/stellar/rs-soroban-sdk/pull/1970, which names
-# user-defined types in contract specs by their fully qualified path.
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "788b536af88a1b0a4d473dc8050b6a44c668e80e" }
-soroban-spec-rust = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "788b536af88a1b0a4d473dc8050b6a44c668e80e" }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "788b536af88a1b0a4d473dc8050b6a44c668e80e" }
-soroban-token-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "788b536af88a1b0a4d473dc8050b6a44c668e80e" }
-stellar-asset-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "788b536af88a1b0a4d473dc8050b6a44c668e80e" }
-soroban-ledger-snapshot = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "788b536af88a1b0a4d473dc8050b6a44c668e80e" }
+# user-defined types in contract specs by their fully qualified path, and the
+# PR stacked on it, which stops marking types for spec shaking and shakes them
+# by reachability instead.
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
+soroban-spec-rust = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
+soroban-token-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
+stellar-asset-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
+soroban-ledger-snapshot = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "4d13b7ad1629978227924675a487d719119c085a" }
 
 [profile.release]
 overflow-checks = true

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,7 @@ build:
 	cargo build
 
 build-test-wasms:
-	# Announce the same spec shaking support `stellar contract build` announces,
-	# so the test contracts build against any soroban-sdk this repo patches in.
-	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
-	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1 \
-		cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
+	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
 
 build-test: build-test-wasms build-fixtures install
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ build:
 	cargo build
 
 build-test-wasms:
-	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
+	# Announce the same spec shaking support `stellar contract build` announces,
+	# so the test contracts build against any soroban-sdk this repo patches in.
+	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
+	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1 \
+		cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
 
 build-test: build-test-wasms build-fixtures install
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ build-test-wasms:
 	# so the test contracts build against any soroban-sdk this repo patches in.
 	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
 	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1 \
+	SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_FULL_NAMES=1 \
 		cargo build --package 'test_*' --profile test-wasms --target wasm32v1-none
 
 build-test: build-test-wasms build-fixtures install

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -483,7 +483,7 @@ fn filter_and_dedup_spec_removes_duplicates() {
     use soroban_cli::commands::contract::build::filter_and_dedup_spec;
     use soroban_cli::xdr::{
         ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
-        ScSpecTypeUdt, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, VecM,
+        ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, VecM,
     };
 
     let func = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
@@ -492,9 +492,7 @@ fn filter_and_dedup_spec_removes_duplicates() {
         inputs: vec![ScSpecFunctionInputV0 {
             doc: StringM::default(),
             name: "arg0".try_into().unwrap(),
-            type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
-                name: "MyStruct".try_into().unwrap(),
-            }),
+            type_: ScSpecTypeDef::U32,
         }]
         .try_into()
         .unwrap(),
@@ -514,9 +512,11 @@ fn filter_and_dedup_spec_removes_duplicates() {
         .unwrap(),
     });
 
-    // The function names the struct, so the struct passes the filter. Types
-    // carry no markers of their own.
-    let markers = std::collections::HashSet::new();
+    // Build markers for the struct so it passes the version 2 filter
+    let mut markers = std::collections::HashSet::new();
+    markers.insert(soroban_spec::shaking::generate_marker_for_entry(
+        &used_struct,
+    ));
 
     // Input: function appears twice, struct appears three times
     let entries = vec![
@@ -527,7 +527,8 @@ fn filter_and_dedup_spec_removes_duplicates() {
         used_struct.clone(),
     ];
 
-    let result_xdr = filter_and_dedup_spec(entries, &markers).unwrap();
+    let result_xdr =
+        filter_and_dedup_spec(entries, &markers, soroban_spec::shaking::Version::V2).unwrap();
 
     // Parse back the entries from the XDR
     let result_entries: Vec<ScSpecEntry> =
@@ -558,11 +559,11 @@ fn build_with_spec_shaking_has_feature_meta() {
 
     // The fixture builds against a published soroban-sdk, which records
     // version 2. The workspace's `[patch.crates-io]` does not reach a contract
-    // built in a temp dir, so this tracks whatever version that SDK records,
-    // and the shaking above is what confirms a v2 wasm shakes under the
-    // version 3 rules.
+    // built in a temp dir, so this covers the version 2 rules end to end, and
+    // the SDK's own test contract covers version 3.
     assert_eq!(
-        version, 2,
+        version,
+        soroban_spec::shaking::Version::V2,
         "contractmeta should indicate spec shaking version 2"
     );
 }
@@ -741,9 +742,7 @@ fn parent_path() -> String {
 }
 
 fn with_flags(expected: &str) -> String {
-    // Both are set, and `Command` hands its env vars over sorted by name.
-    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
-                           SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1";
+    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1";
 
     let cargo_home = home::cargo_home().unwrap();
     let registry_prefix = cargo_home.join("registry").join("src");

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -483,7 +483,7 @@ fn filter_and_dedup_spec_removes_duplicates() {
     use soroban_cli::commands::contract::build::filter_and_dedup_spec;
     use soroban_cli::xdr::{
         ReadXdr, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef,
-        ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, VecM,
+        ScSpecTypeUdt, ScSpecUdtStructFieldV0, ScSpecUdtStructV0, StringM, VecM,
     };
 
     let func = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
@@ -492,7 +492,9 @@ fn filter_and_dedup_spec_removes_duplicates() {
         inputs: vec![ScSpecFunctionInputV0 {
             doc: StringM::default(),
             name: "arg0".try_into().unwrap(),
-            type_: ScSpecTypeDef::U32,
+            type_: ScSpecTypeDef::Udt(ScSpecTypeUdt {
+                name: "MyStruct".try_into().unwrap(),
+            }),
         }]
         .try_into()
         .unwrap(),
@@ -512,11 +514,9 @@ fn filter_and_dedup_spec_removes_duplicates() {
         .unwrap(),
     });
 
-    // Build markers for the struct so it passes the filter
-    let mut markers = std::collections::HashSet::new();
-    markers.insert(soroban_spec::shaking::generate_marker_for_entry(
-        &used_struct,
-    ));
+    // The function names the struct, so the struct passes the filter. Types
+    // carry no markers of their own.
+    let markers = std::collections::HashSet::new();
 
     // Input: function appears twice, struct appears three times
     let entries = vec![
@@ -556,6 +556,11 @@ fn build_with_spec_shaking_has_feature_meta() {
 
     let version = soroban_spec::shaking::spec_shaking_version_for_meta(&meta);
 
+    // The fixture builds against a published soroban-sdk, which records
+    // version 2. The workspace's `[patch.crates-io]` does not reach a contract
+    // built in a temp dir, so this tracks whatever version that SDK records,
+    // and the shaking above is what confirms a v2 wasm shakes under the
+    // version 3 rules.
     assert_eq!(
         version, 2,
         "contractmeta should indicate spec shaking version 2"
@@ -736,7 +741,9 @@ fn parent_path() -> String {
 }
 
 fn with_flags(expected: &str) -> String {
-    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1";
+    // Both are set, and `Command` hands its env vars over sorted by name.
+    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
+                           SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1";
 
     let cargo_home = home::cargo_home().unwrap();
     let registry_prefix = cargo_home.join("registry").join("src");

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -742,7 +742,8 @@ fn parent_path() -> String {
 }
 
 fn with_flags(expected: &str) -> String {
-    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1";
+    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
+         SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1";
 
     let cargo_home = home::cargo_home().unwrap();
     let registry_prefix = cargo_home.join("registry").join("src");

--- a/cmd/crates/soroban-test/tests/it/build.rs
+++ b/cmd/crates/soroban-test/tests/it/build.rs
@@ -742,7 +742,8 @@ fn parent_path() -> String {
 }
 
 fn with_flags(expected: &str) -> String {
-    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
+    const ENV_VAR: &str = "SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_FULL_NAMES=1 \
+         SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1 \
          SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3=1";
 
     let cargo_home = home::cargo_home().unwrap();

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -342,11 +342,14 @@ impl Cmd {
                 cmd.env("CARGO_BUILD_RUSTFLAGS", rustflags);
             }
 
-            // Set env var to inform the SDK that this CLI supports spec
-            // optimization. The var says only that this CLI shakes; which
-            // rules it shakes a given contract by comes from the version that
-            // contract records in its meta.
+            // Set env vars to inform the SDK that this CLI supports spec
+            // optimization. Each var names a set of shaking rules, and this
+            // CLI announces every set it can apply, because the SDK refuses to
+            // build a contract whose rules the build system has not claimed.
+            // Which rules a given contract is shaken by comes from the version
+            // that contract records in its meta.
             cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2", "1");
+            cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3", "1");
 
             let cmd_str = serialize_command(&cmd);
 

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -342,14 +342,11 @@ impl Cmd {
                 cmd.env("CARGO_BUILD_RUSTFLAGS", rustflags);
             }
 
-            // Set env vars to inform the SDK that this CLI supports spec
-            // optimization. Version 3 is announced because this CLI shakes
-            // types that carry no marker of their own, by following the
-            // references to them. Version 2 is announced alongside it, and
-            // remains true of this CLI, because a contract on an older SDK
-            // looks for that var alone and refuses to build without it.
+            // Set env var to inform the SDK that this CLI supports spec
+            // optimization. The var says only that this CLI shakes; which
+            // rules it shakes a given contract by comes from the version that
+            // contract records in its meta.
             cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2", "1");
-            cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3", "1");
 
             let cmd_str = serialize_command(&cmd);
 
@@ -503,18 +500,17 @@ impl Cmd {
 
     /// Filters unused types and events from the contract spec.
     ///
-    /// This removes:
-    /// - Type definitions that nothing reachable from the contract's functions
-    ///   references, following references through events and other types
-    /// - Events that don't have corresponding markers in the WASM data section
-    ///   (events that are defined but never published)
-    /// - Error types that are neither referenced nor have a marker (errors
-    ///   that are defined but never returned or panicked with)
+    /// The contract records which spec shaking version it was built with, and
+    /// that version says which entries carry a marker and so what a missing
+    /// marker means. Read it and shake by its rules rather than the newest
+    /// known: a version 2 contract marks every used type, so markers alone say
+    /// what is used, while a version 3 contract marks only the events it
+    /// publishes and the errors it panics with, and every other type is
+    /// settled by following the references to it.
     ///
-    /// The SDK embeds markers in the data section for the events and errors it
-    /// uses in ways no spec entry names. These markers survive dead code
-    /// elimination, so we can detect which of those entries are truly needed;
-    /// every other type is settled by walking references.
+    /// A version this CLI does not recognise reads as version 1, and a
+    /// version 1 contract carries no markers at all, so in both cases there is
+    /// nothing to shake by and the spec is left alone.
     fn filter_spec(target_file_path: &PathBuf) -> Result<(), Error> {
         use soroban_spec_tools::contract::Spec;
         use soroban_spec_tools::wasm::replace_custom_section;
@@ -524,20 +520,19 @@ impl Cmd {
         // Parse the spec from the wasm
         let spec = Spec::new(&wasm_bytes)?;
 
-        // Check if the contract meta indicates spec shaking is enabled. A v2
-        // wasm shakes correctly under these rules too: a marker there is only
-        // ever carried by an entry that is used, and the types that carried
-        // one are named by the entries that use them.
-        if soroban_spec::shaking::spec_shaking_version_for_meta(&spec.meta) < 2 {
+        // Read the version the contract was built with, which selects the
+        // rules below. Nothing to shake by at version 1, so leave it alone.
+        let version = soroban_spec::shaking::spec_shaking_version_for_meta(&spec.meta);
+        if version == soroban_spec::shaking::Version::V1 {
             return Ok(());
         }
 
         // Extract markers from the WASM data section
         let markers = soroban_spec::shaking::find_all(&wasm_bytes);
 
-        // Filter spec entries (types, events) based on markers, and
+        // Filter spec entries (types, events) by that version's rules, and
         // deduplicate any exact duplicate entries.
-        let filtered_xdr = filter_and_dedup_spec(spec.spec.clone(), &markers)?;
+        let filtered_xdr = filter_and_dedup_spec(spec.spec.clone(), &markers, version)?;
 
         // Replace the contractspecv0 section with the filtered version
         let new_wasm = replace_custom_section(&wasm_bytes, "contractspecv0", &filtered_xdr)
@@ -933,17 +928,17 @@ fn check_overflow_checks(doc: &toml_edit::DocumentMut, profile: &str) -> Result<
     }
 }
 
-/// Filters spec entries down to those the contract needs and deduplicates
-/// exact duplicates.
+/// Filters spec entries down to those the contract needs, by the rules of the
+/// spec shaking version it was built with, and deduplicates exact duplicates.
 ///
-/// Functions are always kept. Events are kept only if a matching marker
-/// exists, and every other entry is kept if it is reachable by reference from
-/// a kept entry, or, for an error, if a matching marker exists. Exact
-/// duplicate entries (identical XDR) are collapsed to a single occurrence.
+/// Which entries survive is decided by `soroban_spec::shaking::filter` for the
+/// given version. Exact duplicate entries (identical XDR) are then collapsed
+/// to a single occurrence.
 #[allow(clippy::implicit_hasher)]
 pub fn filter_and_dedup_spec(
     entries: Vec<stellar_xdr::ScSpecEntry>,
     markers: &HashSet<soroban_spec::shaking::Marker>,
+    version: soroban_spec::shaking::Version,
 ) -> Result<Vec<u8>, Error> {
     let mut seen = HashSet::new();
     let mut filtered_xdr = Vec::new();
@@ -951,7 +946,7 @@ pub fn filter_and_dedup_spec(
         Cursor::new(&mut filtered_xdr),
         Limits::depth(XDR_DEPTH_LIMIT),
     );
-    for entry in soroban_spec::shaking::filter(entries, markers) {
+    for entry in soroban_spec::shaking::filter(entries, markers, version) {
         let entry_xdr = entry.to_xdr(Limits::depth(XDR_DEPTH_LIMIT))?;
         if seen.insert(entry_xdr) {
             entry.write_xdr(&mut writer)?;

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -342,9 +342,14 @@ impl Cmd {
                 cmd.env("CARGO_BUILD_RUSTFLAGS", rustflags);
             }
 
-            // Set env var to inform the SDK that this CLI supports spec
-            // optimization using markers.
+            // Set env vars to inform the SDK that this CLI supports spec
+            // optimization. Version 3 is announced because this CLI shakes
+            // types that carry no marker of their own, by following the
+            // references to them. Version 2 is announced alongside it, and
+            // remains true of this CLI, because a contract on an older SDK
+            // looks for that var alone and refuses to build without it.
             cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2", "1");
+            cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3", "1");
 
             let cmd_str = serialize_command(&cmd);
 
@@ -499,13 +504,17 @@ impl Cmd {
     /// Filters unused types and events from the contract spec.
     ///
     /// This removes:
-    /// - Type definitions that are not referenced by any function
+    /// - Type definitions that nothing reachable from the contract's functions
+    ///   references, following references through events and other types
     /// - Events that don't have corresponding markers in the WASM data section
     ///   (events that are defined but never published)
+    /// - Error types that are neither referenced nor have a marker (errors
+    ///   that are defined but never returned or panicked with)
     ///
-    /// The SDK embeds markers in the data section for types/events that are
-    /// actually used. These markers survive dead code elimination, so we can
-    /// detect which spec entries are truly needed.
+    /// The SDK embeds markers in the data section for the events and errors it
+    /// uses in ways no spec entry names. These markers survive dead code
+    /// elimination, so we can detect which of those entries are truly needed;
+    /// every other type is settled by walking references.
     fn filter_spec(target_file_path: &PathBuf) -> Result<(), Error> {
         use soroban_spec_tools::contract::Spec;
         use soroban_spec_tools::wasm::replace_custom_section;
@@ -515,8 +524,11 @@ impl Cmd {
         // Parse the spec from the wasm
         let spec = Spec::new(&wasm_bytes)?;
 
-        // Check if the contract meta indicates spec shaking v2 is enabled.
-        if soroban_spec::shaking::spec_shaking_version_for_meta(&spec.meta) != 2 {
+        // Check if the contract meta indicates spec shaking is enabled. A v2
+        // wasm shakes correctly under these rules too: a marker there is only
+        // ever carried by an entry that is used, and the types that carried
+        // one are named by the entries that use them.
+        if soroban_spec::shaking::spec_shaking_version_for_meta(&spec.meta) < 2 {
             return Ok(());
         }
 
@@ -921,11 +933,13 @@ fn check_overflow_checks(doc: &toml_edit::DocumentMut, profile: &str) -> Result<
     }
 }
 
-/// Filters spec entries based on markers and deduplicates exact duplicates.
+/// Filters spec entries down to those the contract needs and deduplicates
+/// exact duplicates.
 ///
-/// Functions are always kept. Other entries (types, events) are kept only if a
-/// matching marker exists. Exact duplicate entries (identical XDR) are collapsed
-/// to a single occurrence.
+/// Functions are always kept. Events are kept only if a matching marker
+/// exists, and every other entry is kept if it is reachable by reference from
+/// a kept entry, or, for an error, if a matching marker exists. Exact
+/// duplicate entries (identical XDR) are collapsed to a single occurrence.
 #[allow(clippy::implicit_hasher)]
 pub fn filter_and_dedup_spec(
     entries: Vec<stellar_xdr::ScSpecEntry>,
@@ -1019,8 +1033,7 @@ mod tests {
 
         // Embed the spec in a minimal (empty) wasm module and write it out.
         let wasm = replace_custom_section(b"\0asm\x01\0\0\0", "contractspecv0", &spec_xdr).unwrap();
-        let path =
-            env::temp_dir().join(format!("reduce_spec_test_{}.wasm", std::process::id()));
+        let path = env::temp_dir().join(format!("reduce_spec_test_{}.wasm", std::process::id()));
         fs::write(&path, &wasm).unwrap();
 
         Cmd::reduce_spec(&Print::new(true), "pkg", &path).unwrap();

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -346,6 +346,11 @@ impl Cmd {
             // optimization using markers.
             cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2", "1");
 
+            // Set env var to inform the SDK that this CLI reduces fully
+            // qualified user-defined type names in the spec down to their
+            // simple names.
+            cmd.env("SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_FULL_NAMES", "1");
+
             let cmd_str = serialize_command(&cmd);
 
             if self.print_commands_only {


### PR DESCRIPTION
> [!NOTE]
> Part of a stack of PRs that must merge in this order.
>
> Discussion is here:
> - stellar/stellar-protocol#2014
>
> A first group of PRs deliver const-encoded contract specs, so that contract specs are produced at compile time instead of at proc-macro execution time. This provides the foundation for the capability to construct the specs from information that is not known at proc-macro execution and only known at compile time, like the fully qualified name of a type:
> 1. stellar/rs-stellar-xdr#580
> 1. stellar/rs-soroban-env#1736
> 1. stellar/rs-soroban-sdk#2061
> 1. stellar/rs-soroban-sdk#2078
> 1. stellar/rs-soroban-sdk#2080
> 1. stellar/rs-soroban-sdk#1965
>
> A second group of PRs deliver fully qualified type names in contract specs. Instead of a type having the name `Context` it will have the name `soroban_sdk::auth::Context`. Qualified type names make it possible to uniquely identify types in the spec, even when they have the same name. This resolves several problems with contract specs the type identify problem (https://github.com/stellar/rs-soroban-sdk/issues/1570), type aliases limitations (https://github.com/stellar/rs-soroban-sdk/issues/1857 https://github.com/stellar/rs-soroban-sdk/issues/1063), and optimise spec shaking data section size (https://github.com/stellar/rs-soroban-sdk/issues/1978):
> 1. stellar/stellar-xdr#312
> 1. stellar/rs-stellar-xdr#543
> 1. stellar/rs-soroban-sdk#1970
> 1. stellar/stellar-cli#2674
>
> A third group of PRs use those qualified names to shake specs by reachability, so that the markers a contract carries shrink to the few entries a spec never names:
> 1. stellar/rs-soroban-sdk#2043
> 1. stellar/stellar-cli#2720 ← this PR

### What

Patch in the soroban-sdk change that shakes specs by reachability (stellar/rs-soroban-sdk#2043), announce `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V3` to the SDK alongside the existing v2 var, and pick the shaking rules from the `rssdk_spec_shaking` version the built wasm records rather than from a single fixed set of rules.

### Why

Each var names a set of shaking rules, and this CLI announces every set it can apply, because the SDK refuses to build a contract whose rules the build system has not claimed. The v3 var is required by that SDK: from that version most types carry no marker, and a build system has to shake them out by following the references to them instead, so one announcing only v2 would shake by markers alone and strip every type. The v2 var stays set because it is still true of this CLI, and a contract built against an older published SDK looks for that var alone and refuses to build without it.

Which rules apply to a given wasm is a property of that contract, not of the CLI — it may have been built long before this version — so the CLI reads the version the contract recorded and passes it to `soroban_spec::shaking::filter`: version 2 keeps an entry only if it carries a marker, version 3 also follows the references from functions, events, and types, and a wasm recording no version at all is left unshaken.

### Known limitations

Contract fixtures built by the tests resolve soroban-sdk from crates.io rather than through the workspace patch, so they cover the version 2 path and the SDK's own end-to-end test contract covers version 3. The `[patch.crates-io]` git revisions are replaced with published versions once stellar/rs-stellar-xdr#566 and the soroban-sdk stack land and release.