### PR TITLE
Add contract bindings subcommand for kmp

### DIFF
--- a/FULL_HELP_DOCS.md
+++ b/FULL_HELP_DOCS.md
@@ -278,6 +278,7 @@ Generate code client bindings for a contract
 - `flutter` — Generate Flutter bindings
 - `swift` — Generate Swift bindings
 - `php` — Generate PHP bindings
+- `kmp` — Generate Kotlin Multiplatform bindings
 
 ## `stellar contract bindings rust`
 
@@ -343,6 +344,12 @@ Generate Swift bindings
 Generate PHP bindings
 
 **Usage:** `stellar contract bindings php`
+
+## `stellar contract bindings kmp`
+
+Generate Kotlin Multiplatform bindings
+
+**Usage:** `stellar contract bindings kmp`
 
 ## `stellar contract build`
 

--- a/cmd/soroban-cli/src/commands/contract/bindings.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings.rs
@@ -1,5 +1,6 @@
 pub mod flutter;
 pub mod java;
+pub mod kmp;
 pub mod php;
 pub mod python;
 pub mod rust;
@@ -28,6 +29,9 @@ pub enum Cmd {
 
     /// Generate PHP bindings
     Php(php::Cmd),
+
+    /// Generate Kotlin Multiplatform bindings
+    Kmp(kmp::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -52,6 +56,9 @@ pub enum Error {
 
     #[error(transparent)]
     Php(#[from] php::Error),
+
+    #[error(transparent)]
+    Kmp(#[from] kmp::Error),
 }
 
 impl Cmd {
@@ -64,6 +71,7 @@ impl Cmd {
             Cmd::Flutter(flutter) => flutter.run()?,
             Cmd::Swift(swift) => swift.run()?,
             Cmd::Php(php) => php.run()?,
+            Cmd::Kmp(kmp) => kmp.run()?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/bindings/kmp.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/kmp.rs
@@ -1,0 +1,19 @@
+use std::fmt::Debug;
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("kmp binding generation is not implemented in the stellar-cli, but is available via the tool located here: https://github.com/lightsail-network/stellar-contract-bindings")]
+    NotImplemented,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        Err(Error::NotImplemented)
+    }
+}


### PR DESCRIPTION
### What

Adds the `stellar contract bindings kmp` subcommand. Like the `python`, `java`, `flutter`, `swift` and `php` subcommands, it displays a link to the [`stellar-contract-bindings`](https://github.com/lightsail-network/stellar-contract-bindings) tool.

### Why

`stellar-contract-bindings` 0.6.0b0 generates Kotlin Multiplatform bindings for the [KMP Stellar SDK](https://github.com/Soneso/kmp-stellar-sdk).

### Known limitations

The bindings are not generated by the cli. The cli only displays the link to the `stellar-contract-bindings` tool, like the other subcommands above.